### PR TITLE
Enable customized nebula-common repo url and tag

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -13,6 +13,9 @@
 #   NEBULA_OTHER_ROOT              -- Specify the root directory for user build
 #                                  -- Split with ":", exp: DIR:DIR
 #
+#   NEBULA_COMMON_REPO_URL         -- Git URL for the nebula-common repo
+#   NEBULA_COMMON_REPO_TAG         -- Tag/branch of the nebula-common repo
+#
 #   ENABLE_JEMALLOC                -- Link jemalloc into all executables
 #   ENABLE_NATIVE                  -- Build native client
 #   ENABLE_TESTING                 -- Build unit test
@@ -129,15 +132,23 @@ if("${NEBULA_THIRDPARTY_ROOT}" STREQUAL "")
 endif()
 
 # Submodules
+if("${NEBULA_COMMON_REPO_URL}" STREQUAL "")
+    SET(NEBULA_COMMON_REPO_URL "git@github.com:vesoft-inc-private/nebula-common.git")
+endif()
+
+if("${NEBULA_COMMON_REPO_TAG}" STREQUAL "")
+    SET(NEBULA_COMMON_REPO_TAG "HEAD")
+endif()
+
 include(ExternalProject)
 ExternalProject_Add(
     common
     PREFIX modules
     SOURCE_DIR modules/common
-    GIT_REPOSITORY git@github.com:vesoft-inc-private/nebula-common.git
+    GIT_REPOSITORY ${NEBULA_COMMON_REPO_URL}
     GIT_SHALLOW true
     GIT_PROGRESS true
-    GIT_TAG HEAD
+    GIT_TAG ${NEBULA_COMMON_REPO_TAG}
     CMAKE_ARGS
         -DNEBULA_THIRDPARTY_ROOT=${NEBULA_THIRDPARTY_ROOT}
         -DNEBULA_OTHER_ROOT=${NEBULA_OTHER_ROOT}
@@ -401,10 +412,13 @@ nebula_add_subdirectory(src)
 nebula_add_subdirectory(conf)
 nebula_add_subdirectory(resources)
 
+#set(NEBULA_CLEAN_ALL_DEPS clean-interface clean-pch)
+
 add_custom_target(
     clean-build
     COMMAND ${CMAKE_MAKE_PROGRAM} clean
     COMMAND "find" "." "-name" "Testing" "|" "xargs" "rm" "-fr"
+    DEPENDS ${NEBULA_CLEAN_ALL_DEPS}
 )
 
 add_custom_target(
@@ -412,6 +426,7 @@ add_custom_target(
     COMMAND ${CMAKE_MAKE_PROGRAM} clean
     COMMAND "find" "." "-name" "Testing" "|" "xargs" "rm" "-fr"
     COMMAND "rm" "-fr" "modules/*"
+    DEPENDS ${NEBULA_CLEAN_ALL_DEPS}
 )
 
 add_custom_target(


### PR DESCRIPTION
Two cmake macros can be used to customize the nebula-common repo

**NEBULA_COMMON_REPO_URL:** Url of the nebula-common repo. This can be a file system path pointing to the local repository
**NEBULA_COMMON_REPO_TAG:** A tag/branch name of the nebula-common repo. It is **HEAD** by default