### PR TITLE
This PR fixes the repo dependency issue

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -140,25 +140,21 @@ if("${NEBULA_COMMON_REPO_TAG}" STREQUAL "")
     SET(NEBULA_COMMON_REPO_TAG "HEAD")
 endif()
 
-include(ExternalProject)
-ExternalProject_Add(
+SET(NEBULA_COMMON_PACKAGE "nebula-common")
+
+# Configure the dependent projects
+include(AddDependentProject)
+message(STATUS "")
+message(STATUS ">>>>> Configuring the nebula-common repo <<<<<")
+add_dependent_project(
+    ${NEBULA_HOME}/modules
     common
-    PREFIX modules
-    SOURCE_DIR modules/common
-    GIT_REPOSITORY ${NEBULA_COMMON_REPO_URL}
-    GIT_SHALLOW true
-    GIT_PROGRESS true
-    GIT_TAG ${NEBULA_COMMON_REPO_TAG}
-    CMAKE_ARGS
-        -DNEBULA_THIRDPARTY_ROOT=${NEBULA_THIRDPARTY_ROOT}
-        -DNEBULA_OTHER_ROOT=${NEBULA_OTHER_ROOT}
-        -DENABLE_JEMALLOC=${ENABLE_JEMALLOC}
-        -DENABLE_NATIVE=${ENABLE_NATIVE}
-        -DENABLE_CCACHE=${ENABLE_CCACHE}
-        -DENABLE_TESTING=false
-    INSTALL_COMMAND ""
-    BUILD_IN_SOURCE true
+    ${NEBULA_COMMON_REPO_URL}
+    ${NEBULA_COMMON_REPO_TAG}
 )
+find_package(${NEBULA_COMMON_PACKAGE} REQUIRED)
+message(STATUS ">>>>> The nebula-common repo has been configured successfully <<<<<")
+message(STATUS "")
 
 # third-party
 if(NOT ${NEBULA_THIRDPARTY_ROOT} STREQUAL "")
@@ -319,7 +315,8 @@ macro(nebula_add_library name type)
     endif()
     add_dependencies(
         ${name}
-        parser_target
+        common_project
+#        parser_target
     )
 endmacro()
 
@@ -412,21 +409,22 @@ nebula_add_subdirectory(src)
 nebula_add_subdirectory(conf)
 nebula_add_subdirectory(resources)
 
-#set(NEBULA_CLEAN_ALL_DEPS clean-interface clean-pch)
+add_custom_target(
+    clean-modules
+    COMMAND "rm" "-fr" "modules/*"
+)
 
 add_custom_target(
     clean-build
     COMMAND ${CMAKE_MAKE_PROGRAM} clean
     COMMAND "find" "." "-name" "Testing" "|" "xargs" "rm" "-fr"
-    DEPENDS ${NEBULA_CLEAN_ALL_DEPS}
 )
 
 add_custom_target(
     clean-all
     COMMAND ${CMAKE_MAKE_PROGRAM} clean
     COMMAND "find" "." "-name" "Testing" "|" "xargs" "rm" "-fr"
-    COMMAND "rm" "-fr" "modules/*"
-    DEPENDS ${NEBULA_CLEAN_ALL_DEPS}
+    DEPENDS clean-modules
 )
 
 add_custom_target(

--- a/cmake/AddDependentProject.cmake
+++ b/cmake/AddDependentProject.cmake
@@ -1,0 +1,71 @@
+# Copyright (c) 2020 vesoft inc. All rights reserved.
+#
+# This source code is licensed under Apache 2.0 License,
+# attached with Common Clause Condition 1.0, found in the LICENSES directory.
+#
+
+macro(add_dependent_project base name repo tag)
+
+# Clone or update the repo
+if(EXISTS ${base}/${name}/.git)
+    message(STATUS "Updating from the repo \"" ${repo} "\"")
+    execute_process(
+        COMMAND ${GIT_EXECUTABLE} pull --depth=1
+        WORKING_DIRECTORY ${base}/${name}
+        RESULT_VARIABLE clone_result
+    )
+else()
+    message(STATUS "Cloning from the repo \"" ${repo} "\"")
+    execute_process(
+        COMMAND
+            ${GIT_EXECUTABLE} clone --depth 1 --progress --branch ${tag} ${repo} ${name}
+        WORKING_DIRECTORY ${base}
+        RESULT_VARIABLE clone_result
+    )
+endif()
+
+if(NOT ${clone_result} EQUAL 0)
+    message(
+        FATAL_ERROR
+        "Cannot clone the repo from \""
+        ${repo}
+        "\" (branch \""
+        ${tag}
+        "\"): \""
+        ${clone_result}
+        "\"")
+else()
+    message(STATUS "Updated the repo from \"" ${repo} "\" (branch \"" ${tag} "\")")
+endif()
+
+# Configure the repo
+execute_process(
+    COMMAND
+        ${CMAKE_COMMAND}
+        -DCMAKE_C_COMPILER=${CMAKE_C_COMPILER}
+        -DCMAKE_CXX_COMPILER=${CMAKE_CXX_COMPILER}
+        -DCMAKE_BUILD_TYPE=${CMAKE_BUILD_TYPE}
+        -DNEBULA_THIRDPARTY_ROOT=${NEBULA_THIRDPARTY_ROOT}
+        -DNEBULA_OTHER_ROOT=${NEBULA_OTHER_ROOT}
+        -DENABLE_JEMALLOC=${ENABLE_JEMALLOC}
+        -DENABLE_NATIVE=${ENABLE_NATIVE}
+        -DENABLE_TESTING=false
+        -DENABLE_CCACHE=${ENABLE_CCACHE}
+        -DENABLE_ASAN=${ENABLE_ASAN}
+        -DENABLE_UBSAN=${ENABLE_UBSAN}
+        .
+    WORKING_DIRECTORY ${base}/${name}
+    RESULT_VARIABLE cmake_result
+)
+if(NOT ${cmake_result} EQUAL 0)
+    message(FATAL_ERROR "Failed to configure the dependent project \"" ${name} "\"")
+endif()
+
+# Add a custom target to build the project
+add_custom_target(
+    ${name}_project ALL
+    COMMAND make -j
+    WORKING_DIRECTORY ${base}/${name}
+)
+
+endmacro()

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -2,4 +2,4 @@
 #nebula_add_subdirectory(parser)
 #nebula_add_subdirectory(graph)
 #nebula_add_subdirectory(daemons)
-nebula_add_subdirectory(planner)
+#nebula_add_subdirectory(planner)


### PR DESCRIPTION
The cmake built-in ExternalProject_add() configures and builds the project during the build time, so if the project depends on the targets in the external project, the run of cmake will fail.

This PR creates a macro to pull the external project and to configure (executes cmake) it during the configuration time, so it solves the target dependency issues