### PR TITLE
Use status check macros to unify the error handling process

### DIFF
--- a/src/validator/ASTValidator.cpp
+++ b/src/validator/ASTValidator.cpp
@@ -21,10 +21,7 @@ Status ASTValidator::validate() {
     }
 
     auto validator = Validator::makeValidator(sentences_, qctx_);
-    auto status = validator->validate();
-    if (!status.ok()) {
-        return status;
-    }
+    NG_RETURN_IF_ERROR(validator->validate());
 
     auto root = validator->root();
     if (!root) {

--- a/src/validator/AdminValidator.cpp
+++ b/src/validator/AdminValidator.cpp
@@ -70,16 +70,12 @@ Status CreateSpaceValidator::validateImpl() {
                     spaceDesc_.collationName_));
     } else if (!spaceDesc_.charsetName_.empty()) {
         retStatusOr = charsetInfo->getDefaultCollationbyCharset(spaceDesc_.charsetName_);
-        if (!retStatusOr.ok()) {
-            return retStatusOr.status();
-        }
-        spaceDesc_.collationName_ = std::move(retStatusOr.value());
+        NG_RETURN_IF_ERROR(retStatusOr);
+        spaceDesc_.collationName_ = std::move(retStatusOr).value();
     } else if (!spaceDesc_.collationName_.empty()) {
         retStatusOr = charsetInfo->getCharsetbyCollation(spaceDesc_.collationName_);
-        if (!retStatusOr.ok()) {
-            return retStatusOr.status();
-        }
-        spaceDesc_.charsetName_ = std::move(retStatusOr.value());
+        NG_RETURN_IF_ERROR(retStatusOr);
+        spaceDesc_.charsetName_ = std::move(retStatusOr).value();
     }
 
     if (spaceDesc_.charsetName_.empty() && spaceDesc_.collationName_.empty()) {

--- a/src/validator/AssignmentValidator.cpp
+++ b/src/validator/AssignmentValidator.cpp
@@ -14,10 +14,7 @@ namespace graph {
 Status AssignmentValidator::validateImpl() {
     auto* assignSentence = static_cast<AssignmentSentence*>(sentence_);
     validator_ = makeValidator(assignSentence->sentence(), qctx_);
-    auto status = validator_->validate();
-    if (!status.ok()) {
-        return status;
-    }
+    NG_RETURN_IF_ERROR(validator_->validate());
 
     auto outputs = validator_->outputs();
     var_ = *assignSentence->var();

--- a/src/validator/GetSubgraphValidator.cpp
+++ b/src/validator/GetSubgraphValidator.cpp
@@ -19,33 +19,11 @@ namespace graph {
 Status GetSubgraphValidator::validateImpl() {
     Status status;
     auto* gsSentence = static_cast<GetSubgraphSentence*>(sentence_);
-    do {
-        status = validateStep(gsSentence->step());
-        if (!status.ok()) {
-            break;
-        }
-
-        status = validateFrom(gsSentence->from());
-        if (!status.ok()) {
-            return status;
-        }
-
-        status = validateInBound(gsSentence->in());
-        if (!status.ok()) {
-            return status;
-        }
-
-        status = validateOutBound(gsSentence->out());
-        if (!status.ok()) {
-            return status;
-        }
-
-        status = validateBothInOutBound(gsSentence->both());
-        if (!status.ok()) {
-            return status;
-        }
-    } while (false);
-
+    NG_RETURN_IF_ERROR(validateStep(gsSentence->step()));
+    NG_RETURN_IF_ERROR(validateFrom(gsSentence->from()));
+    NG_RETURN_IF_ERROR(validateInBound(gsSentence->in()));
+    NG_RETURN_IF_ERROR(validateOutBound(gsSentence->out()));
+    NG_RETURN_IF_ERROR(validateBothInOutBound(gsSentence->both()));
     return Status::OK();
 }
 
@@ -111,11 +89,8 @@ Status GetSubgraphValidator::validateOutBound(OutBoundClause* out) {
             }
 
             auto et = qctx_->schemaMng()->toEdgeType(space.id, *e->edge());
-            if (!et.ok()) {
-                return et.status();
-            }
-
-            edgeTypes_.emplace_back(et.value());
+            NG_RETURN_IF_ERROR(et);
+            edgeTypes_.emplace_back(std::move(et).value());
         }
     }
 
@@ -131,11 +106,8 @@ Status GetSubgraphValidator::validateBothInOutBound(BothInOutClause* out) {
             }
 
             auto et = qctx_->schemaMng()->toEdgeType(space.id, *e->edge());
-            if (!et.ok()) {
-                return et.status();
-            }
-
-            auto v = et.value();
+            NG_RETURN_IF_ERROR(et);
+            auto v = std::move(et).value();
             edgeTypes_.emplace_back(v);
             v = -v;
             edgeTypes_.emplace_back(v);


### PR DESCRIPTION
<del>In order to differential same include path between this repo and nebula-common,  add common path prefix explicitly in `#include`. </del> See PR #60 

Unify to check error of status with `UNLIKELY` macro for branch optimizing.

The PR depends on https://github.com/vesoft-inc-private/nebula-common/pull/90