### PR TITLE
Refactor ExecResult construction

### DIFF
--- a/src/context/CMakeLists.txt
+++ b/src/context/CMakeLists.txt
@@ -9,6 +9,7 @@ nebula_add_library(
     ExpressionContextImpl.cpp
     ExecutionContext.cpp
     Iterator.cpp
+    Result.cpp
 )
 
 nebula_add_subdirectory(test)

--- a/src/context/ExecutionContext.cpp
+++ b/src/context/ExecutionContext.cpp
@@ -9,14 +9,13 @@
 namespace nebula {
 namespace graph {
 
-const ExecResult ExecResult::kEmptyResult = ExecResult();
-const std::vector<ExecResult> ExecResult::kEmptyResultList;
-
 void ExecutionContext::setValue(const std::string& name, Value&& val) {
-    setResult(name, ExecResult::buildDefault(std::move(val)));
+    ResultBuilder builder;
+    builder.value(std::move(val)).iter(Iterator::Kind::kDefault);
+    setResult(name, builder.finish());
 }
 
-void ExecutionContext::setResult(const std::string& name, ExecResult&& result) {
+void ExecutionContext::setResult(const std::string& name, Result&& result) {
     auto& hist = valueMap_[name];
     hist.emplace_back(std::move(result));
 }
@@ -57,21 +56,21 @@ Value ExecutionContext::moveValue(const std::string& name) {
     }
 }
 
-const ExecResult& ExecutionContext::getResult(const std::string& name) const {
+const Result& ExecutionContext::getResult(const std::string& name) const {
     auto it = valueMap_.find(name);
     if (it != valueMap_.end()) {
         return it->second.back();
     } else {
-        return ExecResult::kEmptyResult;
+        return Result::kEmptyResult;
     }
 }
 
-const std::vector<ExecResult>& ExecutionContext::getHistory(const std::string& name) const {
+const std::vector<Result>& ExecutionContext::getHistory(const std::string& name) const {
     auto it = valueMap_.find(name);
     if (it != valueMap_.end()) {
         return it->second;
     } else {
-        return ExecResult::kEmptyResultList;
+        return Result::kEmptyResultList;
     }
 }
 }   // namespace graph

--- a/src/context/ExecutionContext.h
+++ b/src/context/ExecutionContext.h
@@ -9,10 +9,11 @@
 
 #include "common/base/Base.h"
 #include "common/datatypes/Value.h"
-#include "context/Iterator.h"
+#include "context/Result.h"
 
 namespace nebula {
 namespace graph {
+
 /***************************************************************************
  *
  * The context for each query request
@@ -26,112 +27,6 @@ namespace graph {
  * planner, the optimizer, and the executor.
  *
  **************************************************************************/
-class StateDesc final {
-public:
-    enum class State : uint8_t {
-        kUnExecuted,
-        kPartialSuccess,
-        kSuccess
-    };
-
-    StateDesc() = default;
-    StateDesc(State state, std::string msg) {
-        state_ = state;
-        msg_ = std::move(msg);
-    }
-
-    const State& state() const {
-        return state_;
-    }
-
-private:
-    State           state_{State::kUnExecuted};
-    std::string     msg_;
-};
-
-
-// An executor will produce a result.
-class ExecResult final {
-public:
-    static const ExecResult kEmptyResult;
-    static const std::vector<ExecResult> kEmptyResultList;
-
-    static ExecResult buildDefault(std::shared_ptr<Value> val) {
-        return ExecResult(val);
-    }
-
-    static ExecResult buildDefault(Value&& val) {
-        return ExecResult(std::make_shared<Value>(std::move(val)));
-    }
-
-    static ExecResult buildGetNeighbors(Value&& val) {
-        StateDesc stateDesc(StateDesc::State::kSuccess, "");
-        return buildGetNeighbors(std::move(val), std::move(stateDesc));
-    }
-
-    static ExecResult buildGetNeighbors(Value&& val, StateDesc&& stateDesc) {
-        ExecResult result(std::make_shared<Value>(std::move(val)), std::move(stateDesc));
-        auto iter = std::make_unique<GetNeighborsIter>(result.valuePtr());
-        result.setIter(std::move(iter));
-        return result;
-    }
-
-    static ExecResult buildSequential(Value&& val, StateDesc&& stateDesc) {
-        ExecResult result(std::make_shared<Value>(std::move(val)), std::move(stateDesc));
-        auto iter = std::make_unique<SequentialIter>(result.valuePtr());
-        result.setIter(std::move(iter));
-        return result;
-    }
-
-    static ExecResult buildSequential(Value&& val) {
-        StateDesc stateDesc(StateDesc::State::kSuccess, "");
-        return buildSequential(std::move(val), std::move(stateDesc));
-    }
-
-    void setIter(std::unique_ptr<Iterator> iter) {
-        iter_ = std::move(iter);
-    }
-
-    std::shared_ptr<Value> valuePtr() const {
-        return value_;
-    }
-
-    const Value& value() const {
-        return *value_;
-    }
-
-    Value&& moveValue() {
-        return std::move(*value_);
-    }
-
-    const StateDesc& state() const {
-        return stateDesc_;
-    }
-
-    std::unique_ptr<Iterator> iter() const {
-        return iter_->copy();
-    }
-
-private:
-    ExecResult()
-        : value_(std::make_shared<Value>()),
-          stateDesc_(StateDesc::State::kUnExecuted, ""),
-          iter_(std::make_unique<DefaultIter>(value_)) {}
-
-    explicit ExecResult(std::shared_ptr<Value> val)
-        : value_(val),
-          stateDesc_(StateDesc::State::kSuccess, ""),
-          iter_(std::make_unique<DefaultIter>(value_)) {}
-
-    ExecResult(std::shared_ptr<Value> val, StateDesc stateDesc)
-        : value_(val), stateDesc_(stateDesc) {}
-
-private:
-    std::shared_ptr<Value>          value_;
-    StateDesc                       stateDesc_;
-    std::unique_ptr<Iterator>       iter_;
-};
-
 class ExecutionContext {
 public:
     ExecutionContext() = default;
@@ -147,17 +42,17 @@ public:
 
     Value moveValue(const std::string& name);
 
-    const ExecResult& getResult(const std::string& name) const;
+    const Result& getResult(const std::string& name) const;
 
     size_t numVersions(const std::string& name) const;
 
     // Return all existing history of the value. The front is the latest value
     // and the back is the oldest value
-    const std::vector<ExecResult>& getHistory(const std::string& name) const;
+    const std::vector<Result>& getHistory(const std::string& name) const;
 
     void setValue(const std::string& name, Value&& val);
 
-    void setResult(const std::string& name, ExecResult&& result);
+    void setResult(const std::string& name, Result&& result);
 
     void deleteValue(const std::string& name);
 
@@ -170,9 +65,9 @@ public:
 
 private:
     // name -> Value with multiple versions
-    std::unordered_map<std::string, std::vector<ExecResult>>     valueMap_;
+    std::unordered_map<std::string, std::vector<Result>>     valueMap_;
 };
+
 }  // namespace graph
 }  // namespace nebula
 #endif  // CONTEXT_EXECUTIONCONTEXT_H_
-

--- a/src/context/Result.cpp
+++ b/src/context/Result.cpp
@@ -1,0 +1,17 @@
+/* Copyright (c) 2020 vesoft inc. All rights reserved.
+ *
+ * This source code is licensed under Apache 2.0 License,
+ * attached with Common Clause Condition 1.0, found in the LICENSES directory.
+ */
+
+#include "context/Result.h"
+
+namespace nebula {
+namespace graph {
+
+const Result Result::kEmptyResult = ResultBuilder().iter(Iterator::Kind::kDefault).finish();
+
+const std::vector<Result> Result::kEmptyResultList;
+
+}   // namespace graph
+}   // namespace nebula

--- a/src/context/Result.h
+++ b/src/context/Result.h
@@ -1,0 +1,127 @@
+/* Copyright (c) 2020 vesoft inc. All rights reserved.
+ *
+ * This source code is licensed under Apache 2.0 License,
+ * attached with Common Clause Condition 1.0, found in the LICENSES directory.
+ */
+
+#ifndef CONTEXT_RESULT_H_
+#define CONTEXT_RESULT_H_
+
+#include <memory>
+#include <vector>
+
+#include "context/Iterator.h"
+
+namespace nebula {
+namespace graph {
+
+class ResultBuilder;
+
+// An executor will produce a result.
+class Result final {
+public:
+    static const Result kEmptyResult;
+    static const std::vector<Result> kEmptyResultList;
+
+    enum class State : uint8_t {
+        kUnExecuted,
+        kPartialSuccess,
+        kSuccess,
+    };
+
+    std::shared_ptr<Value> valuePtr() const {
+        return core_.value;
+    }
+
+    const Value& value() const {
+        return *core_.value;
+    }
+
+    Value&& moveValue() {
+        return std::move(*core_.value);
+    }
+
+    State state() const {
+        return core_.state;
+    }
+
+    std::unique_ptr<Iterator> iter() const {
+        return core_.iter->copy();
+    }
+
+private:
+    friend class ResultBuilder;
+
+    struct Core {
+        State state;
+        std::string msg;
+        std::shared_ptr<Value> value;
+        std::unique_ptr<Iterator> iter;
+    };
+
+    explicit Result(Core&& core) : core_(std::move(core)) {}
+
+    Core core_;
+};
+
+// Default iterator type is sequential.
+class ResultBuilder final {
+public:
+    ResultBuilder() {
+        core_.state = Result::State::kSuccess;
+    }
+
+    Result finish() {
+        if (!core_.iter) iter(Iterator::Kind::kSequential);
+        if (!core_.value && core_.iter) value(core_.iter->valuePtr());
+        return Result(std::move(core_));
+    }
+
+    ResultBuilder& value(Value&& value) {
+        core_.value = std::make_shared<Value>(std::move(value));
+        return *this;
+    }
+
+    ResultBuilder& value(std::shared_ptr<Value> value) {
+        core_.value = value;
+        return *this;
+    }
+
+    ResultBuilder& iter(std::unique_ptr<Iterator> iter) {
+        core_.iter = std::move(iter);
+        return *this;
+    }
+
+    ResultBuilder& iter(Iterator::Kind kind) {
+        DCHECK(kind == Iterator::Kind::kDefault || core_.value)
+            << "Must set value when creating non-default iterator";
+        switch (kind) {
+            case Iterator::Kind::kDefault:
+                return iter(std::make_unique<DefaultIter>(core_.value));
+            case Iterator::Kind::kSequential:
+                return iter(std::make_unique<SequentialIter>(core_.value));
+            case Iterator::Kind::kGetNeighbors:
+                return iter(std::make_unique<GetNeighborsIter>(core_.value));
+            default:
+                LOG(FATAL) << "Invalid Iterator kind" << static_cast<uint8_t>(kind);
+        }
+    }
+
+    ResultBuilder& state(Result::State state) {
+        core_.state = state;
+        return *this;
+    }
+
+    ResultBuilder& msg(std::string&& msg) {
+        core_.msg = std::move(msg);
+        return *this;
+    }
+
+private:
+    Result::Core core_;
+};
+
+}   // namespace graph
+}   // namespace nebula
+
+#endif   // CONTEXT_RESULT_H_

--- a/src/context/test/ExecutionContextTest.cpp
+++ b/src/context/test/ExecutionContextTest.cpp
@@ -49,9 +49,10 @@ TEST(ExecutionContext, HistoryTest) {
     EXPECT_TRUE(it2 == hist2.end());
 }
 
-TEST(ExecutionContextTest, TestExecResult) {
+TEST(ExecutionContextTest, TestResult) {
     DataSet ds;
-    auto expected = ExecResult::buildDefault(Value(ds));
+    auto expected =
+        ResultBuilder().value(Value(std::move(ds))).iter(Iterator::Kind::kDefault).finish();
     ExecutionContext ctx;
     ctx.setResult("ds", std::move(expected));
     auto& result = ctx.getResult("ds");

--- a/src/exec/Executor.cpp
+++ b/src/exec/Executor.cpp
@@ -314,7 +314,7 @@ Status Executor::finish(nebula::Value &&value) {
     return Status::OK();
 }
 
-Status Executor::finish(ExecResult &&result) {
+Status Executor::finish(Result &&result) {
     ectx_->setResult(node()->varName(), std::move(result));
     return Status::OK();
 }

--- a/src/exec/Executor.h
+++ b/src/exec/Executor.h
@@ -92,7 +92,7 @@ protected:
 
     // Store the result of this executor to execution context
     Status finish(nebula::Value &&value);
-    Status finish(ExecResult &&result);
+    Status finish(Result &&result);
 
     // Dump some execution logging messages, only for debugging
     // TODO(yee): Remove it after implementing profile function

--- a/src/exec/query/DedupExecutor.cpp
+++ b/src/exec/query/DedupExecutor.cpp
@@ -23,7 +23,8 @@ folly::Future<Status> DedupExecutor::execute() {
         LOG(INFO) << "Invalid iterator kind: " << static_cast<uint16_t>(iter->kind());
         return Status::Error("Invalid iterator kind, %d", static_cast<uint16_t>(iter->kind()));
     }
-    auto result = ExecResult::buildDefault(iter->valuePtr());
+    ResultBuilder builder;
+    builder.value(iter->valuePtr());
     ExpressionContextImpl ctx(ectx_, iter.get());
     std::unordered_set<const Row *> unique;
     while (iter->valid()) {
@@ -35,8 +36,8 @@ folly::Future<Status> DedupExecutor::execute() {
         }
     }
     iter->reset();
-    result.setIter(std::move(iter));
-    return finish(std::move(result));
+    builder.iter(std::move(iter));
+    return finish(builder.finish());
 }
 
 }   // namespace graph

--- a/src/exec/query/FilterExecutor.cpp
+++ b/src/exec/query/FilterExecutor.cpp
@@ -22,7 +22,8 @@ folly::Future<Status> FilterExecutor::execute() {
         LOG(ERROR) << "Internal Error: iterator is nullptr";
         return Status::Error("Internal Error: iterator is nullptr");
     }
-    auto result = ExecResult::buildDefault(iter->valuePtr());
+    ResultBuilder builder;
+    builder.value(iter->valuePtr());
     ExpressionContextImpl ctx(ectx_, iter.get());
     auto condition = filter->condition();
     while (iter->valid()) {
@@ -39,8 +40,8 @@ folly::Future<Status> FilterExecutor::execute() {
     }
 
     iter->reset();
-    result.setIter(std::move(iter));
-    return finish(std::move(result));
+    builder.iter(std::move(iter));
+    return finish(builder.finish());
 }
 
 }   // namespace graph

--- a/src/exec/query/IntersectExecutor.cpp
+++ b/src/exec/query/IntersectExecutor.cpp
@@ -30,11 +30,13 @@ folly::Future<Status> IntersectExecutor::execute() {
         }
     }
 
+    ResultBuilder builder;
     if (hashSet.empty()) {
         auto value = lIter->valuePtr();
         DataSet ds;
         ds.colNames = value->getDataSet().colNames;
-        return finish(ExecResult::buildSequential(Value(std::move(ds))));
+        builder.value(Value(std::move(ds))).iter(Iterator::Kind::kSequential);
+        return finish(builder.finish());
     }
 
     while (lIter->valid()) {
@@ -46,10 +48,8 @@ folly::Future<Status> IntersectExecutor::execute() {
         }
     }
 
-    auto result = ExecResult::buildDefault(lIter->valuePtr());
-    result.setIter(std::move(lIter));
-
-    return finish(std::move(result));
+    builder.value(lIter->valuePtr()).iter(std::move(lIter));
+    return finish(builder.finish());
 }
 
 }   // namespace graph

--- a/src/exec/query/LimitExecutor.cpp
+++ b/src/exec/query/LimitExecutor.cpp
@@ -15,7 +15,8 @@ folly::Future<Status> LimitExecutor::execute() {
     dumpLog();
     auto* limit = asNode<Limit>(node());
     auto iter = ectx_->getResult(limit->inputVar()).iter();
-    auto result = ExecResult::buildDefault(iter->valuePtr());
+    ResultBuilder builder;
+    builder.value(iter->valuePtr());
     ExpressionContextImpl ctx(ectx_, iter.get());
     auto offset = limit->offset();
     auto count = limit->count();
@@ -29,8 +30,8 @@ folly::Future<Status> LimitExecutor::execute() {
                size <= static_cast<size_t>(offset + count)) {
         iter->eraseRange(0, offset);
     }
-    result.setIter(std::move(iter));
-    return finish(std::move(result));
+    builder.iter(std::move(iter));
+    return finish(builder.finish());
 }
 
 }   // namespace graph

--- a/src/exec/query/MinusExecutor.cpp
+++ b/src/exec/query/MinusExecutor.cpp
@@ -41,10 +41,9 @@ folly::Future<Status> MinusExecutor::execute() {
         }
     }
 
-    auto result = ExecResult::buildDefault(lIter->valuePtr());
-    result.setIter(std::move(lIter));
-
-    return finish(std::move(result));
+    ResultBuilder builder;
+    builder.value(lIter->valuePtr()).iter(std::move(lIter));
+    return finish(builder.finish());
 }
 
 }   // namespace graph

--- a/src/exec/query/ProjectExecutor.cpp
+++ b/src/exec/query/ProjectExecutor.cpp
@@ -32,8 +32,8 @@ folly::Future<Status> ProjectExecutor::execute() {
         }
         ds.rows.emplace_back(std::move(row));
     }
-    return finish(ExecResult::buildSequential(Value(std::move(ds))));
+    return finish(ResultBuilder().value(Value(std::move(ds))).finish());
 }
 
-}  // namespace graph
-}  // namespace nebula
+}   // namespace graph
+}   // namespace nebula

--- a/src/exec/query/SortExecutor.cpp
+++ b/src/exec/query/SortExecutor.cpp
@@ -56,9 +56,7 @@ folly::Future<Status> SortExecutor::execute() {
         };
         std::sort(seqIter->begin(), seqIter->end(), comparator);
     }
-    auto result = ExecResult::buildDefault(iter->valuePtr());
-    result.setIter(std::move(iter));
-    return finish(std::move(result));
+    return finish(ResultBuilder().value(iter->valuePtr()).iter(std::move(iter)).finish());
 }
 
 }   // namespace graph

--- a/src/exec/query/UnionExecutor.cpp
+++ b/src/exec/query/UnionExecutor.cpp
@@ -16,10 +16,9 @@ folly::Future<Status> UnionExecutor::execute() {
     NG_RETURN_IF_ERROR(checkInputDataSets());
     auto left = getLeftInputDataIter();
     auto right = getRightInputDataIter();
-    auto result = ExecResult::buildDefault(left->valuePtr());
+    auto value = left->valuePtr();
     auto iter = std::make_unique<SequentialIter>(std::move(left), std::move(right));
-    result.setIter(std::move(iter));
-    return finish(std::move(result));
+    return finish(ResultBuilder().value(value).iter(std::move(iter)).finish());
 }
 
 }   // namespace graph

--- a/src/exec/query/test/DataCollectTest.cpp
+++ b/src/exec/query/test/DataCollectTest.cpp
@@ -89,8 +89,9 @@ protected:
             datasets.values.emplace_back(std::move(ds1));
             datasets.values.emplace_back(std::move(ds2));
 
-            qctx_->ectx()->setResult("input_datasets",
-                        ExecResult::buildGetNeighbors(Value(std::move(datasets))));
+            ResultBuilder builder;
+            builder.value(Value(std::move(datasets))).iter(Iterator::Kind::kGetNeighbors);
+            qctx_->ectx()->setResult("input_datasets", builder.finish());
         }
         {
             DataSet ds;
@@ -102,7 +103,7 @@ protected:
                 ds.rows.emplace_back(std::move(row));
             }
             qctx_->ectx()->setResult("input_sequential",
-                        ExecResult::buildSequential(Value(std::move(ds))));
+                                     ResultBuilder().value(Value(std::move(ds))).finish());
         }
         {
             DataSet ds;
@@ -112,7 +113,10 @@ protected:
                             "_edge:+edge1:prop1:prop2:_dst:_rank",
                             "_expr"};
             qctx_->ectx()->setResult("empty_get_neighbors",
-                        ExecResult::buildGetNeighbors(Value(std::move(ds))));
+                                     ResultBuilder()
+                                         .value(Value(std::move(ds)))
+                                         .iter(Iterator::Kind::kGetNeighbors)
+                                         .finish());
         }
     }
 
@@ -145,7 +149,7 @@ TEST_F(DataCollectTest, CollectSubgraph) {
     expected.rows.emplace_back(std::move(row));
 
     EXPECT_EQ(result.value().getDataSet(), expected);
-    EXPECT_EQ(result.state().state(), StateDesc::State::kSuccess);
+    EXPECT_EQ(result.state(), Result::State::kSuccess);
 }
 
 TEST_F(DataCollectTest, RowBasedMove) {
@@ -165,7 +169,7 @@ TEST_F(DataCollectTest, RowBasedMove) {
     auto& result = qctx_->ectx()->getResult(dc->varName());
 
     EXPECT_EQ(result.value().getDataSet(), expected);
-    EXPECT_EQ(result.state().state(), StateDesc::State::kSuccess);
+    EXPECT_EQ(result.state(), Result::State::kSuccess);
 }
 
 TEST_F(DataCollectTest, EmptyResult) {
@@ -187,7 +191,7 @@ TEST_F(DataCollectTest, EmptyResult) {
     row.values.emplace_back(Value(List()));
     expected.rows.emplace_back(std::move(row));
     EXPECT_EQ(result.value().getDataSet(), expected);
-    EXPECT_EQ(result.state().state(), StateDesc::State::kSuccess);
+    EXPECT_EQ(result.state(), Result::State::kSuccess);
 }
 }  // namespace graph
 }  // namespace nebula

--- a/src/exec/query/test/DedupTest.cpp
+++ b/src/exec/query/test/DedupTest.cpp
@@ -37,7 +37,7 @@ public:
             return;                                                            \
         }                                                                      \
         auto& dedupResult = qctx_->ectx()->getResult(dedupNode->varName());    \
-        EXPECT_EQ(dedupResult.state().state(), StateDesc::State::kSuccess);    \
+        EXPECT_EQ(dedupResult.state(), Result::State::kSuccess);               \
                                                                                \
         dedupNode->setInputVar(outputName);                                    \
         auto* project =                                                        \
@@ -51,7 +51,7 @@ public:
         auto& proSesult = qctx_->ectx()->getResult(project->varName());        \
                                                                                \
         EXPECT_EQ(proSesult.value().getDataSet(), expected);                   \
-        EXPECT_EQ(proSesult.state().state(), StateDesc::State::kSuccess);      \
+        EXPECT_EQ(proSesult.state(), Result::State::kSuccess);                 \
     } while (false)
 
 TEST_F(DedupTest, TestSequential) {

--- a/src/exec/query/test/FilterTest.cpp
+++ b/src/exec/query/test/FilterTest.cpp
@@ -33,7 +33,7 @@ public:
             std::make_unique<FilterExecutor>(filterNode, qctx_.get());         \
         EXPECT_TRUE(filterExec->execute().get().ok());                         \
         auto& filterResult = qctx_->ectx()->getResult(filterNode->varName());  \
-        EXPECT_EQ(filterResult.state().state(), StateDesc::State::kSuccess);   \
+        EXPECT_EQ(filterResult.state(), Result::State::kSuccess);              \
                                                                                \
         filterNode->setInputVar(outputName);                                   \
         auto* project =                                                        \
@@ -46,7 +46,7 @@ public:
         auto& proSesult = qctx_->ectx()->getResult(project->varName());        \
                                                                                \
         EXPECT_EQ(proSesult.value().getDataSet(), expected);                   \
-        EXPECT_EQ(proSesult.state().state(), StateDesc::State::kSuccess);      \
+        EXPECT_EQ(proSesult.state(), Result::State::kSuccess);                 \
     } while (false)
 
 TEST_F(FilterTest, TestGetNeighbors_src_dst) {

--- a/src/exec/query/test/GetNeighborsTest.cpp
+++ b/src/exec/query/test/GetNeighborsTest.cpp
@@ -25,7 +25,9 @@ protected:
                 row.values.emplace_back(i + 1);
                 ds.rows.emplace_back(std::move(row));
             }
-            qctx_->ectx()->setResult("input_gn", ExecResult::buildSequential(Value(std::move(ds))));
+            ResultBuilder builder;
+            builder.value(Value(std::move(ds)));
+            qctx_->ectx()->setResult("input_gn", builder.finish());
         }
     }
 

--- a/src/exec/query/test/LimitTest.cpp
+++ b/src/exec/query/test/LimitTest.cpp
@@ -26,7 +26,7 @@ class LimitTest : public QueryTestBase {
         auto limitExec = std::make_unique<LimitExecutor>(limitNode, qctx_.get());     \
         EXPECT_TRUE(limitExec->execute().get().ok());                                 \
         auto& limitResult = qctx_->ectx()->getResult(limitNode->varName());           \
-        EXPECT_EQ(limitResult.state().state(), StateDesc::State::kSuccess);           \
+        EXPECT_EQ(limitResult.state(), Result::State::kSuccess);                      \
         auto yieldSentence = getYieldSentence(                                        \
                 "YIELD study._dst AS name, study.start_year AS start");               \
         auto* project = Project::make(plan, nullptr, yieldSentence->yieldColumns());  \
@@ -36,7 +36,7 @@ class LimitTest : public QueryTestBase {
         EXPECT_TRUE(proExe->execute().get().ok());                                    \
         auto& proResult = qctx_->ectx()->getResult(project->varName());               \
         EXPECT_EQ(proResult.value().getDataSet(), expected);                          \
-        EXPECT_EQ(proResult.state().state(), StateDesc::State::kSuccess);             \
+        EXPECT_EQ(proResult.state(), Result::State::kSuccess);                        \
     } while (false)
 
 

--- a/src/exec/query/test/ProjectTest.cpp
+++ b/src/exec/query/test/ProjectTest.cpp
@@ -27,14 +27,16 @@ protected:
                 row.values.emplace_back(i + 1);
                 ds.rows.emplace_back(std::move(row));
             }
-            qctx_->ectx()->setResult("input_project",
-                        ExecResult::buildSequential(Value(std::move(ds))));
+            ResultBuilder builder;
+            builder.value(Value(std::move(ds)));
+            qctx_->ectx()->setResult("input_project", builder.finish());
         }
         {
             DataSet ds;
             ds.colNames = {"vid", "col2"};
-            qctx_->ectx()->setResult("empty",
-                        ExecResult::buildSequential(Value(std::move(ds))));
+            ResultBuilder builder;
+            builder.value(Value(std::move(ds)));
+            qctx_->ectx()->setResult("empty", builder.finish());
         }
     }
 
@@ -67,7 +69,7 @@ TEST_F(ProjectTest, Project1Col) {
         expected.rows.emplace_back(std::move(row));
     }
     EXPECT_EQ(result.value().getDataSet(), expected);
-    EXPECT_EQ(result.state().state(), StateDesc::State::kSuccess);
+    EXPECT_EQ(result.state(), Result::State::kSuccess);
 }
 
 TEST_F(ProjectTest, Project2Col) {
@@ -94,7 +96,7 @@ TEST_F(ProjectTest, Project2Col) {
         expected.rows.emplace_back(std::move(row));
     }
     EXPECT_EQ(result.value().getDataSet(), expected);
-    EXPECT_EQ(result.state().state(), StateDesc::State::kSuccess);
+    EXPECT_EQ(result.state(), Result::State::kSuccess);
 }
 
 TEST_F(ProjectTest, EmptyInput) {
@@ -114,7 +116,7 @@ TEST_F(ProjectTest, EmptyInput) {
     DataSet expected;
     expected.colNames.emplace_back("vid");
     EXPECT_EQ(result.value().getDataSet(), expected);
-    EXPECT_EQ(result.state().state(), StateDesc::State::kSuccess);
+    EXPECT_EQ(result.state(), Result::State::kSuccess);
 }
 
 }  // namespace graph

--- a/src/exec/query/test/SetExecutorTest.cpp
+++ b/src/exec/query/test/SetExecutorTest.cpp
@@ -60,10 +60,12 @@ TEST_F(SetExecutorTest, TestUnionAll) {
         unionNode->setRightVar(right->varName());
 
         auto unionExecutor = Executor::makeExecutor(unionNode, qctx_.get());
+        ResultBuilder lb, rb;
+        lb.value(Value(lds)).iter(Iterator::Kind::kSequential);
+        rb.value(Value(rds)).iter(Iterator::Kind::kSequential);
         // Must save the values after constructing executors
-        qctx_->ectx()->setResult(left->varName(), ExecResult::buildSequential(Value(lds)));
-        qctx_->ectx()->setResult(right->varName(),
-                                 ExecResult::buildSequential(Value(rds)));
+        qctx_->ectx()->setResult(left->varName(), lb.finish());
+        qctx_->ectx()->setResult(right->varName(), rb.finish());
         auto future = unionExecutor->execute();
         EXPECT_TRUE(std::move(future).get().ok());
 
@@ -182,10 +184,11 @@ TEST_F(SetExecutorTest, TestGetNeighobrsIterator) {
     rds.colNames = {"col1", "col2"};
 
     // Must save the values after constructing executors
-    auto lRes = ExecResult::buildGetNeighbors(Value(std::move(lds)));
-    auto rRes = ExecResult::buildSequential(Value(std::move(rds)));
-    qctx_->ectx()->setResult(left->varName(), std::move(lRes));
-    qctx_->ectx()->setResult(right->varName(), std::move(rRes));
+    ResultBuilder lrb, rrb;
+    auto& lRes = lrb.value(Value(std::move(lds))).iter(Iterator::Kind::kGetNeighbors);
+    auto& rRes = rrb.value(Value(std::move(rds)));
+    qctx_->ectx()->setResult(left->varName(), lRes.finish());
+    qctx_->ectx()->setResult(right->varName(), rRes.finish());
     auto future = unionExecutor->execute();
     auto status = std::move(future).get();
 
@@ -255,10 +258,12 @@ TEST_F(SetExecutorTest, TestIntersect) {
         intersect->setLeftVar(left->varName());
         intersect->setRightVar(right->varName());
 
+        ResultBuilder lb, rb;
+        lb.value(Value(lds)).iter(Iterator::Kind::kSequential);
+        rb.value(Value(rds)).iter(Iterator::Kind::kSequential);
         auto executor = Executor::makeExecutor(intersect, qctx_.get());
-        qctx_->ectx()->setResult(left->varName(), ExecResult::buildSequential(Value(lds)));
-        qctx_->ectx()->setResult(right->varName(),
-                                 ExecResult::buildSequential(Value(rds)));
+        qctx_->ectx()->setResult(left->varName(), lb.finish());
+        qctx_->ectx()->setResult(right->varName(), rb.finish());
 
         auto fut = executor->execute();
         auto status = std::move(fut).get();
@@ -360,10 +365,12 @@ TEST_F(SetExecutorTest, TestMinus) {
         minus->setLeftVar(left->varName());
         minus->setRightVar(right->varName());
 
+        ResultBuilder lb, rb;
+        lb.value(Value(lds)).iter(Iterator::Kind::kSequential);
+        rb.value(Value(rds)).iter(Iterator::Kind::kSequential);
         auto executor = Executor::makeExecutor(minus, qctx_.get());
-        qctx_->ectx()->setResult(left->varName(), ExecResult::buildSequential(Value(lds)));
-        qctx_->ectx()->setResult(right->varName(),
-                                 ExecResult::buildSequential(Value(rds)));
+        qctx_->ectx()->setResult(left->varName(), lb.finish());
+        qctx_->ectx()->setResult(right->varName(), rb.finish());
 
         auto fut = executor->execute();
         auto status = std::move(fut).get();

--- a/src/exec/query/test/SortTest.cpp
+++ b/src/exec/query/test/SortTest.cpp
@@ -26,7 +26,7 @@ class SortTest : public QueryTestBase {
         auto sortExec = std::make_unique<SortExecutor>(sortNode, qctx_.get());        \
         EXPECT_TRUE(sortExec->execute().get().ok());                                  \
         auto& sortResult = qctx_->ectx()->getResult(sortNode->varName());             \
-        EXPECT_EQ(sortResult.state().state(), StateDesc::State::kSuccess);            \
+        EXPECT_EQ(sortResult.state(), Result::State::kSuccess);                       \
         std::string sentence;                                                         \
         std::vector<std::string> colNames;                                            \
         if (multi) {                                                                  \
@@ -45,7 +45,7 @@ class SortTest : public QueryTestBase {
         EXPECT_TRUE(proExe->execute().get().ok());                                    \
         auto& proResult = qctx_->ectx()->getResult(project->varName());               \
         EXPECT_EQ(proResult.value().getDataSet(), expected);                          \
-        EXPECT_EQ(proResult.state().state(), StateDesc::State::kSuccess);             \
+        EXPECT_EQ(proResult.state(), Result::State::kSuccess);                        \
     } while (false)
 
 

--- a/src/validator/GetSubgraphValidator.cpp
+++ b/src/validator/GetSubgraphValidator.cpp
@@ -165,7 +165,10 @@ Status GetSubgraphValidator::toPlan() {
         row.values.emplace_back(vid);
         ds.rows.emplace_back(std::move(row));
     }
-    qctx_->ectx()->setResult(vidsToSave, ExecResult::buildSequential(Value(std::move(ds))));
+
+    ResultBuilder builder;
+    builder.value(Value(std::move(ds))).iter(Iterator::Kind::kSequential);
+    qctx_->ectx()->setResult(vidsToSave, builder.finish());
     auto* vids = new VariablePropertyExpression(
                      new std::string(vidsToSave),
                      new std::string(kVid));
@@ -260,4 +263,3 @@ Status GetSubgraphValidator::toPlan() {
 }
 }  // namespace graph
 }  // namespace nebula
-

--- a/src/validator/GoValidator.cpp
+++ b/src/validator/GoValidator.cpp
@@ -390,8 +390,7 @@ std::string GoValidator::buildInput() {
         row.values.emplace_back(vid);
         ds.rows.emplace_back(std::move(row));
     }
-    qctx_->ectx()->setResult(input,
-            ExecResult::buildSequential(Value(std::move(ds))));
+    qctx_->ectx()->setResult(input, ResultBuilder().value(Value(std::move(ds))).finish());
 
     auto* vids = new VariablePropertyExpression(
                     new std::string(input),
@@ -465,4 +464,3 @@ GetNeighbors::EdgeProps GoValidator::buildEdgeProps() {
 }
 }  // namespace graph
 }  // namespace nebula
-


### PR DESCRIPTION
I move the `State` to ExecResult inner enum class to differentiate with Stats of StatesManger