### PR TITLE
Let plan node depend on QueryContext rather than ExecutionPlan

### DIFF
--- a/src/context/QueryContext.cpp
+++ b/src/context/QueryContext.cpp
@@ -30,7 +30,7 @@ QueryContext::QueryContext() {
 
 void QueryContext::init() {
     objPool_ = std::make_unique<ObjectPool>();
-    ep_ = std::make_unique<ExecutionPlan>(objPool_.get());
+    ep_ = std::make_unique<ExecutionPlan>();
     vctx_ = std::make_unique<ValidateContext>();
     ectx_ = std::make_unique<ExecutionContext>();
     idGen_ = std::make_unique<IdGenerator>(0);

--- a/src/context/QueryContext.cpp
+++ b/src/context/QueryContext.cpp
@@ -11,6 +11,31 @@
 namespace nebula {
 namespace graph {
 
+QueryContext::QueryContext(RequestContextPtr rctx,
+                           meta::SchemaManager* sm,
+                           storage::GraphStorageClient* storage,
+                           meta::MetaClient* metaClient,
+                           CharsetInfo* charsetInfo)
+    : rctx_(std::move(rctx)),
+      sm_(DCHECK_NOTNULL(sm)),
+      storageClient_(DCHECK_NOTNULL(storage)),
+      metaClient_(DCHECK_NOTNULL(metaClient)),
+      charsetInfo_(DCHECK_NOTNULL(charsetInfo)) {
+    init();
+}
+
+QueryContext::QueryContext() {
+    init();
+}
+
+void QueryContext::init() {
+    objPool_ = std::make_unique<ObjectPool>();
+    ep_ = std::make_unique<ExecutionPlan>(objPool_.get());
+    vctx_ = std::make_unique<ValidateContext>();
+    ectx_ = std::make_unique<ExecutionContext>();
+    idGen_ = std::make_unique<IdGenerator>(0);
+}
+
 void QueryContext::addProfilingData(int64_t planNodeId, cpp2::ProfilingStats&& profilingStats) {
     // return directly if not enable profile
     if (!planDescription_) return;

--- a/src/executor/Executor.cpp
+++ b/src/executor/Executor.cpp
@@ -73,7 +73,7 @@ namespace nebula {
 namespace graph {
 
 // static
-Executor *Executor::makeExecutor(const PlanNode *node, QueryContext *qctx) {
+Executor *Executor::create(const PlanNode *node, QueryContext *qctx) {
     std::unordered_map<int64_t, Executor *> visited;
     return makeExecutor(node, qctx, &visited);
 }

--- a/src/executor/Executor.h
+++ b/src/executor/Executor.h
@@ -18,8 +18,8 @@
 #include "common/cpp/helpers.h"
 #include "common/datatypes/Value.h"
 #include "common/time/Duration.h"
-#include "util/ScopedTimer.h"
 #include "context/ExecutionContext.h"
+#include "util/ScopedTimer.h"
 
 namespace nebula {
 namespace graph {
@@ -30,7 +30,7 @@ class QueryContext;
 class Executor : private cpp::NonCopyable, private cpp::NonMovable {
 public:
     // Create executor according to plan node
-    static Executor *makeExecutor(const PlanNode *node, QueryContext *qctx);
+    static Executor *create(const PlanNode *node, QueryContext *qctx);
 
     virtual ~Executor();
 

--- a/src/executor/admin/ShowBalanceExecutor.cpp
+++ b/src/executor/admin/ShowBalanceExecutor.cpp
@@ -17,7 +17,7 @@ folly::Future<Status> ShowBalanceExecutor::execute() {
 
 folly::Future<Status> ShowBalanceExecutor::showBalance() {
     auto *sbNode = asNode<ShowBalance>(node());
-    return qctx()->getMetaClient()->showBalance(sbNode->id())
+    return qctx()->getMetaClient()->showBalance(sbNode->jobId())
         .via(runner())
         .then([this](StatusOr<std::vector<meta::cpp2::BalanceTask>> resp) {
             SCOPED_TIMER(&execTime_);

--- a/src/executor/logic/test/LogicExecutorsTest.cpp
+++ b/src/executor/logic/test/LogicExecutorsTest.cpp
@@ -18,19 +18,16 @@ namespace nebula {
 namespace graph {
 class LogicExecutorsTest : public testing::Test {
 protected:
-    static void SetUpTestCase() {
+    void SetUp() override {
         qctx_ = std::make_unique<QueryContext>();
     }
 
 protected:
-    static std::unique_ptr<QueryContext> qctx_;
+    std::unique_ptr<QueryContext> qctx_;
 };
 
-std::unique_ptr<QueryContext> LogicExecutorsTest::qctx_;
-
 TEST_F(LogicExecutorsTest, Start) {
-    auto* plan = qctx_->plan();
-    auto* start = StartNode::make(qctx_);
+    auto* start = StartNode::make(qctx_.get());
     auto startExe = std::make_unique<StartExecutor>(start, qctx_.get());
     auto f = startExe->execute();
     auto status = std::move(f).get();
@@ -38,7 +35,6 @@ TEST_F(LogicExecutorsTest, Start) {
 }
 
 TEST_F(LogicExecutorsTest, Loop) {
-    auto* plan = qctx_->plan();
     std::string counter = "counter";
     qctx_->ectx()->setValue(counter, 0);
     // ++counter{0} <= 5
@@ -50,9 +46,9 @@ TEST_F(LogicExecutorsTest, Loop) {
                                 new std::string(counter),
                                 new ConstantExpression(0))),
                 new ConstantExpression(static_cast<int32_t>(5)));
-    auto* loop = Loop::make(qctx_, nullptr, nullptr, condition.get());
+    auto* loop = Loop::make(qctx_.get(), nullptr, nullptr, condition.get());
 
-    auto* start = StartNode::make(qctx_);
+    auto* start = StartNode::make(qctx_.get());
     auto startExe = std::make_unique<StartExecutor>(start, qctx_.get());
     auto loopExe = std::make_unique<LoopExecutor>(loop, qctx_.get(), startExe.get());
     for (size_t i = 0; i < 5; ++i) {
@@ -75,12 +71,11 @@ TEST_F(LogicExecutorsTest, Loop) {
 }
 
 TEST_F(LogicExecutorsTest, Select) {
-    auto* plan = qctx_->plan();
     {
         auto condition = std::make_unique<ConstantExpression>(true);
-        auto* select = Select::make(qctx_, nullptr, nullptr, nullptr, condition.get());
+        auto* select = Select::make(qctx_.get(), nullptr, nullptr, nullptr, condition.get());
 
-        auto* start = StartNode::make(qctx_);
+        auto* start = StartNode::make(qctx_.get());
         auto startExe = std::make_unique<StartExecutor>(start, qctx_.get());
         auto selectExe = std::make_unique<SelectExecutor>(
                 select, qctx_.get(), startExe.get(), startExe.get());
@@ -95,9 +90,9 @@ TEST_F(LogicExecutorsTest, Select) {
     }
     {
         auto condition = std::make_unique<ConstantExpression>(false);
-        auto* select = Select::make(qctx_, nullptr, nullptr, nullptr, condition.get());
+        auto* select = Select::make(qctx_.get(), nullptr, nullptr, nullptr, condition.get());
 
-        auto* start = StartNode::make(qctx_);
+        auto* start = StartNode::make(qctx_.get());
         auto startExe = std::make_unique<StartExecutor>(start, qctx_.get());
         auto selectExe = std::make_unique<SelectExecutor>(
                 select, qctx_.get(), startExe.get(), startExe.get());

--- a/src/executor/logic/test/LogicExecutorsTest.cpp
+++ b/src/executor/logic/test/LogicExecutorsTest.cpp
@@ -30,7 +30,7 @@ std::unique_ptr<QueryContext> LogicExecutorsTest::qctx_;
 
 TEST_F(LogicExecutorsTest, Start) {
     auto* plan = qctx_->plan();
-    auto* start = StartNode::make(plan);
+    auto* start = StartNode::make(qctx_);
     auto startExe = std::make_unique<StartExecutor>(start, qctx_.get());
     auto f = startExe->execute();
     auto status = std::move(f).get();
@@ -50,9 +50,9 @@ TEST_F(LogicExecutorsTest, Loop) {
                                 new std::string(counter),
                                 new ConstantExpression(0))),
                 new ConstantExpression(static_cast<int32_t>(5)));
-    auto* loop = Loop::make(plan, nullptr, nullptr, condition.get());
+    auto* loop = Loop::make(qctx_, nullptr, nullptr, condition.get());
 
-    auto* start = StartNode::make(plan);
+    auto* start = StartNode::make(qctx_);
     auto startExe = std::make_unique<StartExecutor>(start, qctx_.get());
     auto loopExe = std::make_unique<LoopExecutor>(loop, qctx_.get(), startExe.get());
     for (size_t i = 0; i < 5; ++i) {
@@ -78,9 +78,9 @@ TEST_F(LogicExecutorsTest, Select) {
     auto* plan = qctx_->plan();
     {
         auto condition = std::make_unique<ConstantExpression>(true);
-        auto* select = Select::make(plan, nullptr, nullptr, nullptr, condition.get());
+        auto* select = Select::make(qctx_, nullptr, nullptr, nullptr, condition.get());
 
-        auto* start = StartNode::make(plan);
+        auto* start = StartNode::make(qctx_);
         auto startExe = std::make_unique<StartExecutor>(start, qctx_.get());
         auto selectExe = std::make_unique<SelectExecutor>(
                 select, qctx_.get(), startExe.get(), startExe.get());
@@ -95,9 +95,9 @@ TEST_F(LogicExecutorsTest, Select) {
     }
     {
         auto condition = std::make_unique<ConstantExpression>(false);
-        auto* select = Select::make(plan, nullptr, nullptr, nullptr, condition.get());
+        auto* select = Select::make(qctx_, nullptr, nullptr, nullptr, condition.get());
 
-        auto* start = StartNode::make(plan);
+        auto* start = StartNode::make(qctx_);
         auto startExe = std::make_unique<StartExecutor>(start, qctx_.get());
         auto selectExe = std::make_unique<SelectExecutor>(
                 select, qctx_.get(), startExe.get(), startExe.get());

--- a/src/executor/query/test/AggregateTest.cpp
+++ b/src/executor/query/test/AggregateTest.cpp
@@ -89,8 +89,7 @@ struct RowCmp {
         std::make_unique<InputPropertyExpression>(new std::string("col1")); \
     Aggregate::GroupItem item(expr.get(), FUN, DISTINCT);                   \
     groupItems.emplace_back(std::move(item));                               \
-    auto* plan = qctx_->plan();                                             \
-    auto* agg = Aggregate::make(qctx_, nullptr, std::move(groupKeys),        \
+    auto* agg = Aggregate::make(qctx_.get(), nullptr, std::move(groupKeys), \
                                 std::move(groupItems));                     \
     agg->setInputVar(*input_);                                              \
     agg->setColNames(std::vector<std::string>{COL});                        \
@@ -111,8 +110,7 @@ struct RowCmp {
     groupKeys.emplace_back(expr.get());                                     \
     Aggregate::GroupItem item(expr.get(), FUN, DISTINCT);                   \
     groupItems.emplace_back(std::move(item));                               \
-    auto* plan = qctx_->plan();                                             \
-    auto* agg = Aggregate::make(qctx_, nullptr, std::move(groupKeys),        \
+    auto* agg = Aggregate::make(qctx_.get(), nullptr, std::move(groupKeys), \
                                 std::move(groupItems));                     \
     agg->setInputVar(*input_);                                              \
     agg->setColNames(std::vector<std::string>{COL});                        \
@@ -140,8 +138,7 @@ struct RowCmp {
     groupKeys.emplace_back(expr1.get());                                    \
     Aggregate::GroupItem item1(expr1.get(), FUN, DISTINCT);                 \
     groupItems.emplace_back(std::move(item1));                              \
-    auto* plan = qctx_->plan();                                             \
-    auto* agg = Aggregate::make(qctx_, nullptr, std::move(groupKeys),        \
+    auto* agg = Aggregate::make(qctx_.get(), nullptr, std::move(groupKeys), \
                                 std::move(groupItems));                     \
     agg->setInputVar(*input_);                                              \
     agg->setColNames(std::vector<std::string>{"col2", COL});                \
@@ -162,8 +159,7 @@ struct RowCmp {
     auto expr = std::make_unique<ConstantExpression>(1);                    \
     Aggregate::GroupItem item(expr.get(), FUN, DISTINCT);                   \
     groupItems.emplace_back(std::move(item));                               \
-    auto* plan = qctx_->plan();                                             \
-    auto* agg = Aggregate::make(qctx_, nullptr, std::move(groupKeys),        \
+    auto* agg = Aggregate::make(qctx_.get(), nullptr, std::move(groupKeys), \
                                 std::move(groupItems));                     \
     agg->setInputVar(*input_);                                              \
     agg->setColNames(std::vector<std::string>{COL});                        \
@@ -310,8 +306,7 @@ TEST_F(AggregateTest, Collect) {
         groupKeys.emplace_back(expr.get());
         Aggregate::GroupItem item(expr.get(), AggFun::Function::kCollect, false);
         groupItems.emplace_back(std::move(item));
-        auto* plan = qctx_->plan();
-        auto* agg = Aggregate::make(qctx_, nullptr, std::move(groupKeys),
+        auto* agg = Aggregate::make(qctx_.get(), nullptr, std::move(groupKeys),
                                     std::move(groupItems));
         agg->setInputVar(*input_);
         agg->setColNames(std::vector<std::string>{"list"});
@@ -417,8 +412,7 @@ TEST_F(AggregateTest, Collect) {
             std::make_unique<InputPropertyExpression>(new std::string("col1"));
         Aggregate::GroupItem item(expr.get(), AggFun::Function::kCollect, true);
         groupItems.emplace_back(std::move(item));
-        auto* plan = qctx_->plan();
-        auto* agg = Aggregate::make(qctx_, nullptr, std::move(groupKeys),
+        auto* agg = Aggregate::make(qctx_.get(), nullptr, std::move(groupKeys),
                                     std::move(groupItems));
         agg->setInputVar(*input_);
         agg->setColNames(std::vector<std::string>{"list"});
@@ -480,8 +474,7 @@ TEST_F(AggregateTest, Collect) {
         groupKeys.emplace_back(expr.get());
         Aggregate::GroupItem item(expr.get(), AggFun::Function::kCollect, true);
         groupItems.emplace_back(std::move(item));
-        auto* plan = qctx_->plan();
-        auto* agg = Aggregate::make(qctx_, nullptr, std::move(groupKeys),
+        auto* agg = Aggregate::make(qctx_.get(), nullptr, std::move(groupKeys),
                                     std::move(groupItems));
         agg->setInputVar(*input_);
         agg->setColNames(std::vector<std::string>{"list"});

--- a/src/executor/query/test/AggregateTest.cpp
+++ b/src/executor/query/test/AggregateTest.cpp
@@ -90,7 +90,7 @@ struct RowCmp {
     Aggregate::GroupItem item(expr.get(), FUN, DISTINCT);                   \
     groupItems.emplace_back(std::move(item));                               \
     auto* plan = qctx_->plan();                                             \
-    auto* agg = Aggregate::make(plan, nullptr, std::move(groupKeys),        \
+    auto* agg = Aggregate::make(qctx_, nullptr, std::move(groupKeys),        \
                                 std::move(groupItems));                     \
     agg->setInputVar(*input_);                                              \
     agg->setColNames(std::vector<std::string>{COL});                        \
@@ -112,7 +112,7 @@ struct RowCmp {
     Aggregate::GroupItem item(expr.get(), FUN, DISTINCT);                   \
     groupItems.emplace_back(std::move(item));                               \
     auto* plan = qctx_->plan();                                             \
-    auto* agg = Aggregate::make(plan, nullptr, std::move(groupKeys),        \
+    auto* agg = Aggregate::make(qctx_, nullptr, std::move(groupKeys),        \
                                 std::move(groupItems));                     \
     agg->setInputVar(*input_);                                              \
     agg->setColNames(std::vector<std::string>{COL});                        \
@@ -141,7 +141,7 @@ struct RowCmp {
     Aggregate::GroupItem item1(expr1.get(), FUN, DISTINCT);                 \
     groupItems.emplace_back(std::move(item1));                              \
     auto* plan = qctx_->plan();                                             \
-    auto* agg = Aggregate::make(plan, nullptr, std::move(groupKeys),        \
+    auto* agg = Aggregate::make(qctx_, nullptr, std::move(groupKeys),        \
                                 std::move(groupItems));                     \
     agg->setInputVar(*input_);                                              \
     agg->setColNames(std::vector<std::string>{"col2", COL});                \
@@ -163,7 +163,7 @@ struct RowCmp {
     Aggregate::GroupItem item(expr.get(), FUN, DISTINCT);                   \
     groupItems.emplace_back(std::move(item));                               \
     auto* plan = qctx_->plan();                                             \
-    auto* agg = Aggregate::make(plan, nullptr, std::move(groupKeys),        \
+    auto* agg = Aggregate::make(qctx_, nullptr, std::move(groupKeys),        \
                                 std::move(groupItems));                     \
     agg->setInputVar(*input_);                                              \
     agg->setColNames(std::vector<std::string>{COL});                        \
@@ -311,7 +311,7 @@ TEST_F(AggregateTest, Collect) {
         Aggregate::GroupItem item(expr.get(), AggFun::Function::kCollect, false);
         groupItems.emplace_back(std::move(item));
         auto* plan = qctx_->plan();
-        auto* agg = Aggregate::make(plan, nullptr, std::move(groupKeys),
+        auto* agg = Aggregate::make(qctx_, nullptr, std::move(groupKeys),
                                     std::move(groupItems));
         agg->setInputVar(*input_);
         agg->setColNames(std::vector<std::string>{"list"});
@@ -418,7 +418,7 @@ TEST_F(AggregateTest, Collect) {
         Aggregate::GroupItem item(expr.get(), AggFun::Function::kCollect, true);
         groupItems.emplace_back(std::move(item));
         auto* plan = qctx_->plan();
-        auto* agg = Aggregate::make(plan, nullptr, std::move(groupKeys),
+        auto* agg = Aggregate::make(qctx_, nullptr, std::move(groupKeys),
                                     std::move(groupItems));
         agg->setInputVar(*input_);
         agg->setColNames(std::vector<std::string>{"list"});
@@ -481,7 +481,7 @@ TEST_F(AggregateTest, Collect) {
         Aggregate::GroupItem item(expr.get(), AggFun::Function::kCollect, true);
         groupItems.emplace_back(std::move(item));
         auto* plan = qctx_->plan();
-        auto* agg = Aggregate::make(plan, nullptr, std::move(groupKeys),
+        auto* agg = Aggregate::make(qctx_, nullptr, std::move(groupKeys),
                                     std::move(groupItems));
         agg->setInputVar(*input_);
         agg->setColNames(std::vector<std::string>{"list"});

--- a/src/executor/query/test/DataCollectTest.cpp
+++ b/src/executor/query/test/DataCollectTest.cpp
@@ -128,7 +128,7 @@ std::unique_ptr<QueryContext> DataCollectTest::qctx_;
 
 TEST_F(DataCollectTest, CollectSubgraph) {
     auto* plan = qctx_->plan();
-    auto* dc = DataCollect::make(plan, nullptr,
+    auto* dc = DataCollect::make(qctx_, nullptr,
             DataCollect::CollectKind::kSubgraph, {"input_datasets"});
     dc->setColNames(std::vector<std::string>{"_vertices", "_edges"});
 
@@ -180,7 +180,7 @@ TEST_F(DataCollectTest, CollectSubgraph) {
 
 TEST_F(DataCollectTest, RowBasedMove) {
     auto* plan = qctx_->plan();
-    auto* dc = DataCollect::make(plan, nullptr,
+    auto* dc = DataCollect::make(qctx_, nullptr,
             DataCollect::CollectKind::kRowBasedMove, {"input_sequential"});
     dc->setColNames(std::vector<std::string>{"col1", "col2"});
 
@@ -200,7 +200,7 @@ TEST_F(DataCollectTest, RowBasedMove) {
 
 TEST_F(DataCollectTest, EmptyResult) {
     auto* plan = qctx_->plan();
-    auto* dc = DataCollect::make(plan, nullptr,
+    auto* dc = DataCollect::make(qctx_, nullptr,
             DataCollect::CollectKind::kSubgraph, {"empty_get_neighbors"});
     dc->setColNames(std::vector<std::string>{"_vertices", "_edges"});
 

--- a/src/executor/query/test/DataCollectTest.cpp
+++ b/src/executor/query/test/DataCollectTest.cpp
@@ -14,7 +14,7 @@ namespace nebula {
 namespace graph {
 class DataCollectTest : public testing::Test {
 protected:
-    static void SetUpTestCase() {
+    void SetUp() override {
         qctx_ = std::make_unique<QueryContext>();
         {
             DataSet ds1;
@@ -121,14 +121,11 @@ protected:
     }
 
 protected:
-    static std::unique_ptr<QueryContext> qctx_;
+    std::unique_ptr<QueryContext> qctx_;
 };
 
-std::unique_ptr<QueryContext> DataCollectTest::qctx_;
-
 TEST_F(DataCollectTest, CollectSubgraph) {
-    auto* plan = qctx_->plan();
-    auto* dc = DataCollect::make(qctx_, nullptr,
+    auto* dc = DataCollect::make(qctx_.get(), nullptr,
             DataCollect::CollectKind::kSubgraph, {"input_datasets"});
     dc->setColNames(std::vector<std::string>{"_vertices", "_edges"});
 
@@ -179,8 +176,7 @@ TEST_F(DataCollectTest, CollectSubgraph) {
 }
 
 TEST_F(DataCollectTest, RowBasedMove) {
-    auto* plan = qctx_->plan();
-    auto* dc = DataCollect::make(qctx_, nullptr,
+    auto* dc = DataCollect::make(qctx_.get(), nullptr,
             DataCollect::CollectKind::kRowBasedMove, {"input_sequential"});
     dc->setColNames(std::vector<std::string>{"col1", "col2"});
 
@@ -199,8 +195,7 @@ TEST_F(DataCollectTest, RowBasedMove) {
 }
 
 TEST_F(DataCollectTest, EmptyResult) {
-    auto* plan = qctx_->plan();
-    auto* dc = DataCollect::make(qctx_, nullptr,
+    auto* dc = DataCollect::make(qctx_.get(), nullptr,
             DataCollect::CollectKind::kSubgraph, {"empty_get_neighbors"});
     dc->setColNames(std::vector<std::string>{"_vertices", "_edges"});
 

--- a/src/executor/query/test/DataJoinTest.cpp
+++ b/src/executor/query/test/DataJoinTest.cpp
@@ -91,7 +91,7 @@ void DataJoinTest::testJoin(std::string left, std::string right,
 
     auto* plan = qctx_->plan();
     auto* dataJoin =
-        DataJoin::make(plan, nullptr, {left, 0}, {right, 0}, std::move(hashKeys),
+        DataJoin::make(qctx_, nullptr, {left, 0}, {right, 0}, std::move(hashKeys),
                        std::move(probeKeys));
     dataJoin->setColNames(std::vector<std::string>{
         "src", "dst", kVid, "tag_prop", "edge_prop", kDst});
@@ -163,7 +163,7 @@ TEST_F(DataJoinTest, JoinTwice) {
 
         auto* plan = qctx_->plan();
         auto* dataJoin =
-            DataJoin::make(plan, nullptr, {left, 0}, {right, 0}, std::move(hashKeys),
+            DataJoin::make(qctx_, nullptr, {left, 0}, {right, 0}, std::move(hashKeys),
                         std::move(probeKeys));
         dataJoin->setColNames(std::vector<std::string>{
             "src", "dst", kVid, "tag_prop", "edge_prop", kDst});
@@ -186,7 +186,7 @@ TEST_F(DataJoinTest, JoinTwice) {
 
     auto* plan = qctx_->plan();
     auto* dataJoin =
-        DataJoin::make(plan, nullptr, {left, 0}, {right, 0}, std::move(hashKeys),
+        DataJoin::make(qctx_, nullptr, {left, 0}, {right, 0}, std::move(hashKeys),
                     std::move(probeKeys));
     dataJoin->setColNames(std::vector<std::string>{
         "src", "dst", kVid, "tag_prop", "edge_prop", kDst, "col1"});

--- a/src/executor/query/test/DataJoinTest.cpp
+++ b/src/executor/query/test/DataJoinTest.cpp
@@ -15,7 +15,7 @@ namespace nebula {
 namespace graph {
 class DataJoinTest : public QueryTestBase {
 protected:
-    static void SetUpTestCase() {
+    void SetUp() override {
         qctx_ = std::make_unique<QueryContext>();
         {
             DataSet ds;
@@ -71,14 +71,11 @@ protected:
         }
     }
 
-    static void testJoin(std::string left, std::string right,
-                         DataSet& expected, int64_t line);
+    void testJoin(std::string left, std::string right, DataSet& expected, int64_t line);
 
-   protected:
-    static std::unique_ptr<QueryContext> qctx_;
+protected:
+    std::unique_ptr<QueryContext> qctx_;
 };
-
-std::unique_ptr<QueryContext> DataJoinTest::qctx_;
 
 void DataJoinTest::testJoin(std::string left, std::string right,
                             DataSet& expected, int64_t line) {
@@ -89,9 +86,8 @@ void DataJoinTest::testJoin(std::string left, std::string right,
                                      new std::string("_vid"));
     std::vector<Expression*> probeKeys = {&probe};
 
-    auto* plan = qctx_->plan();
     auto* dataJoin =
-        DataJoin::make(qctx_, nullptr, {left, 0}, {right, 0}, std::move(hashKeys),
+        DataJoin::make(qctx_.get(), nullptr, {left, 0}, {right, 0}, std::move(hashKeys),
                        std::move(probeKeys));
     dataJoin->setColNames(std::vector<std::string>{
         "src", "dst", kVid, "tag_prop", "edge_prop", kDst});
@@ -161,9 +157,8 @@ TEST_F(DataJoinTest, JoinTwice) {
                                         new std::string("_vid"));
         std::vector<Expression*> probeKeys = {&probe};
 
-        auto* plan = qctx_->plan();
         auto* dataJoin =
-            DataJoin::make(qctx_, nullptr, {left, 0}, {right, 0}, std::move(hashKeys),
+            DataJoin::make(qctx_.get(), nullptr, {left, 0}, {right, 0}, std::move(hashKeys),
                         std::move(probeKeys));
         dataJoin->setColNames(std::vector<std::string>{
             "src", "dst", kVid, "tag_prop", "edge_prop", kDst});
@@ -184,9 +179,8 @@ TEST_F(DataJoinTest, JoinTwice) {
                                     new std::string("col1"));
     std::vector<Expression*> probeKeys = {&probe};
 
-    auto* plan = qctx_->plan();
     auto* dataJoin =
-        DataJoin::make(qctx_, nullptr, {left, 0}, {right, 0}, std::move(hashKeys),
+        DataJoin::make(qctx_.get(), nullptr, {left, 0}, {right, 0}, std::move(hashKeys),
                     std::move(probeKeys));
     dataJoin->setColNames(std::vector<std::string>{
         "src", "dst", kVid, "tag_prop", "edge_prop", kDst, "col1"});

--- a/src/executor/query/test/DedupTest.cpp
+++ b/src/executor/query/test/DedupTest.cpp
@@ -21,37 +21,34 @@ public:
     }
 };
 
-#define DEDUP_RESUTL_CHECK(inputName, outputName, sentence, expected)          \
-    do {                                                                       \
-        auto* plan = qctx_->plan();                                            \
-        auto yieldSentence = getYieldSentence(sentence);                       \
-        auto* dedupNode = Dedup::make(qctx_, nullptr);                          \
-        dedupNode->setInputVar(inputName);                                     \
-        dedupNode->setOutputVar(outputName);                                   \
-        auto dedupExec =                                                       \
-            std::make_unique<DedupExecutor>(dedupNode, qctx_.get());           \
-        if (!expected.colNames.empty()) {                                      \
-            EXPECT_TRUE(dedupExec->execute().get().ok());                      \
-        } else {                                                               \
-            EXPECT_FALSE(dedupExec->execute().get().ok());                     \
-            return;                                                            \
-        }                                                                      \
-        auto& dedupResult = qctx_->ectx()->getResult(dedupNode->varName());    \
-        EXPECT_EQ(dedupResult.state(), Result::State::kSuccess);               \
-                                                                               \
-        dedupNode->setInputVar(outputName);                                    \
-        auto* project =                                                        \
-            Project::make(qctx_, nullptr, yieldSentence->yieldColumns());       \
-        project->setInputVar(dedupNode->varName());                            \
-        auto colNames = expected.colNames;                                     \
-        project->setColNames(std::move(colNames));                             \
-                                                                               \
-        auto proExe = std::make_unique<ProjectExecutor>(project, qctx_.get()); \
-        EXPECT_TRUE(proExe->execute().get().ok());                             \
-        auto& proSesult = qctx_->ectx()->getResult(project->varName());        \
-                                                                               \
-        EXPECT_EQ(proSesult.value().getDataSet(), expected);                   \
-        EXPECT_EQ(proSesult.state(), Result::State::kSuccess);                 \
+#define DEDUP_RESUTL_CHECK(inputName, outputName, sentence, expected)                              \
+    do {                                                                                           \
+        auto yieldSentence = getYieldSentence(sentence);                                           \
+        auto* dedupNode = Dedup::make(qctx_.get(), nullptr);                                       \
+        dedupNode->setInputVar(inputName);                                                         \
+        dedupNode->setOutputVar(outputName);                                                       \
+        auto dedupExec = std::make_unique<DedupExecutor>(dedupNode, qctx_.get());                  \
+        if (!expected.colNames.empty()) {                                                          \
+            EXPECT_TRUE(dedupExec->execute().get().ok());                                          \
+        } else {                                                                                   \
+            EXPECT_FALSE(dedupExec->execute().get().ok());                                         \
+            return;                                                                                \
+        }                                                                                          \
+        auto& dedupResult = qctx_->ectx()->getResult(dedupNode->varName());                        \
+        EXPECT_EQ(dedupResult.state(), Result::State::kSuccess);                                   \
+                                                                                                   \
+        dedupNode->setInputVar(outputName);                                                        \
+        auto* project = Project::make(qctx_.get(), nullptr, yieldSentence->yieldColumns());        \
+        project->setInputVar(dedupNode->varName());                                                \
+        auto colNames = expected.colNames;                                                         \
+        project->setColNames(std::move(colNames));                                                 \
+                                                                                                   \
+        auto proExe = std::make_unique<ProjectExecutor>(project, qctx_.get());                     \
+        EXPECT_TRUE(proExe->execute().get().ok());                                                 \
+        auto& proSesult = qctx_->ectx()->getResult(project->varName());                            \
+                                                                                                   \
+        EXPECT_EQ(proSesult.value().getDataSet(), expected);                                       \
+        EXPECT_EQ(proSesult.state(), Result::State::kSuccess);                                     \
     } while (false)
 
 TEST_F(DedupTest, TestSequential) {

--- a/src/executor/query/test/DedupTest.cpp
+++ b/src/executor/query/test/DedupTest.cpp
@@ -25,7 +25,7 @@ public:
     do {                                                                       \
         auto* plan = qctx_->plan();                                            \
         auto yieldSentence = getYieldSentence(sentence);                       \
-        auto* dedupNode = Dedup::make(plan, nullptr);                          \
+        auto* dedupNode = Dedup::make(qctx_, nullptr);                          \
         dedupNode->setInputVar(inputName);                                     \
         dedupNode->setOutputVar(outputName);                                   \
         auto dedupExec =                                                       \
@@ -41,7 +41,7 @@ public:
                                                                                \
         dedupNode->setInputVar(outputName);                                    \
         auto* project =                                                        \
-            Project::make(plan, nullptr, yieldSentence->yieldColumns());       \
+            Project::make(qctx_, nullptr, yieldSentence->yieldColumns());       \
         project->setInputVar(dedupNode->varName());                            \
         auto colNames = expected.colNames;                                     \
         project->setColNames(std::move(colNames));                             \

--- a/src/executor/query/test/FilterTest.cpp
+++ b/src/executor/query/test/FilterTest.cpp
@@ -46,7 +46,7 @@ public:
         } else {                                                                                   \
             ExpressionUtils::rewriteLabelAttribute<EdgePropertyExpression>(filter);                \
         }                                                                                          \
-        auto* filterNode = Filter::make(plan, nullptr, yieldSentence->where()->filter());          \
+        auto* filterNode = Filter::make(qctx_, nullptr, yieldSentence->where()->filter());         \
         filterNode->setInputVar(inputName);                                                        \
         filterNode->setOutputVar(outputName);                                                      \
         auto filterExec = std::make_unique<FilterExecutor>(filterNode, qctx_.get());               \
@@ -55,7 +55,7 @@ public:
         EXPECT_EQ(filterResult.state(), Result::State::kSuccess);                                  \
                                                                                                    \
         filterNode->setInputVar(outputName);                                                       \
-        auto* project = Project::make(plan, nullptr, yieldSentence->yieldColumns());               \
+        auto* project = Project::make(qctx_, nullptr, yieldSentence->yieldColumns());              \
         project->setInputVar(filterNode->varName());                                               \
         project->setColNames(std::vector<std::string>{"name"});                                    \
                                                                                                    \

--- a/src/executor/query/test/FilterTest.cpp
+++ b/src/executor/query/test/FilterTest.cpp
@@ -24,7 +24,6 @@ public:
 
 #define FILTER_RESUTL_CHECK(inputName, outputName, sentence, expected)                             \
     do {                                                                                           \
-        auto* plan = qctx_->plan();                                                                \
         auto yieldSentence = getYieldSentence(sentence);                                           \
         auto columns = yieldSentence->columns();                                                   \
         for (auto& col : columns) {                                                                \
@@ -46,7 +45,7 @@ public:
         } else {                                                                                   \
             ExpressionUtils::rewriteLabelAttribute<EdgePropertyExpression>(filter);                \
         }                                                                                          \
-        auto* filterNode = Filter::make(qctx_, nullptr, yieldSentence->where()->filter());         \
+        auto* filterNode = Filter::make(qctx_.get(), nullptr, yieldSentence->where()->filter());   \
         filterNode->setInputVar(inputName);                                                        \
         filterNode->setOutputVar(outputName);                                                      \
         auto filterExec = std::make_unique<FilterExecutor>(filterNode, qctx_.get());               \
@@ -55,7 +54,7 @@ public:
         EXPECT_EQ(filterResult.state(), Result::State::kSuccess);                                  \
                                                                                                    \
         filterNode->setInputVar(outputName);                                                       \
-        auto* project = Project::make(qctx_, nullptr, yieldSentence->yieldColumns());              \
+        auto* project = Project::make(qctx_.get(), nullptr, yieldSentence->yieldColumns());        \
         project->setInputVar(filterNode->varName());                                               \
         project->setColNames(std::vector<std::string>{"name"});                                    \
                                                                                                    \

--- a/src/executor/query/test/GetNeighborsTest.cpp
+++ b/src/executor/query/test/GetNeighborsTest.cpp
@@ -14,7 +14,7 @@ namespace nebula {
 namespace graph {
 class GetNeighborsTest : public testing::Test {
 protected:
-    static void SetUpTestCase() {
+    void SetUp() override {
         qctx_ = std::make_unique<QueryContext>();
         {
             DataSet ds;
@@ -37,18 +37,18 @@ protected:
 
 
 TEST_F(GetNeighborsTest, BuildRequestDataSet) {
-    auto* plan = qctx_->plan();
+    auto* pool = qctx_->objPool();
     std::vector<EdgeType> edgeTypes;
     auto vertexProps = std::make_unique<std::vector<storage::cpp2::VertexProp>>();
     auto edgeProps = std::make_unique<std::vector<storage::cpp2::EdgeProp>>();
     auto statProps = std::make_unique<std::vector<storage::cpp2::StatProp>>();
     auto exprs = std::make_unique<std::vector<storage::cpp2::Expr>>();
-    auto* vids = new InputPropertyExpression(new std::string("id"));
+    auto* vids = pool->add(new InputPropertyExpression(new std::string("id")));
     auto* gn = GetNeighbors::make(
-            qctx_,
+            qctx_.get(),
             nullptr,
             0,
-            plan->saveObject(vids),
+            vids,
             std::move(edgeTypes),
             storage::cpp2::EdgeDirection::BOTH,
             std::move(vertexProps),

--- a/src/executor/query/test/GetNeighborsTest.cpp
+++ b/src/executor/query/test/GetNeighborsTest.cpp
@@ -32,10 +32,9 @@ protected:
     }
 
 protected:
-    static std::unique_ptr<QueryContext> qctx_;
+    std::unique_ptr<QueryContext> qctx_;
 };
 
-std::unique_ptr<QueryContext> GetNeighborsTest::qctx_;
 
 TEST_F(GetNeighborsTest, BuildRequestDataSet) {
     auto* plan = qctx_->plan();
@@ -46,7 +45,7 @@ TEST_F(GetNeighborsTest, BuildRequestDataSet) {
     auto exprs = std::make_unique<std::vector<storage::cpp2::Expr>>();
     auto* vids = new InputPropertyExpression(new std::string("id"));
     auto* gn = GetNeighbors::make(
-            plan,
+            qctx_,
             nullptr,
             0,
             plan->saveObject(vids),

--- a/src/executor/query/test/LimitTest.cpp
+++ b/src/executor/query/test/LimitTest.cpp
@@ -21,7 +21,7 @@ class LimitTest : public QueryTestBase {
 #define LIMIT_RESUTL_CHECK(outputName, offset, count, expected)                           \
     do {                                                                                  \
         auto* plan = qctx_->plan();                                                       \
-        auto* limitNode = Limit::make(plan, nullptr, offset, count);                      \
+        auto* limitNode = Limit::make(qctx_, nullptr, offset, count);                      \
         limitNode->setInputVar("input_neighbor");                                         \
         limitNode->setOutputVar(outputName);                                              \
         auto limitExec = std::make_unique<LimitExecutor>(limitNode, qctx_.get());         \
@@ -41,7 +41,7 @@ class LimitTest : public QueryTestBase {
                     col->expr());                                                         \
             }                                                                             \
         }                                                                                 \
-        auto* project = Project::make(plan, nullptr, yieldSentence->yieldColumns());      \
+        auto* project = Project::make(qctx_, nullptr, yieldSentence->yieldColumns());      \
         project->setInputVar(limitNode->varName());                                       \
         project->setColNames(std::vector<std::string>{"name", "start"});                  \
         auto proExe = std::make_unique<ProjectExecutor>(project, qctx_.get());            \

--- a/src/executor/query/test/LimitTest.cpp
+++ b/src/executor/query/test/LimitTest.cpp
@@ -6,51 +6,50 @@
 
 #include <gtest/gtest.h>
 
-#include "util/ExpressionUtils.h"
 #include "context/QueryContext.h"
-#include "planner/Query.h"
 #include "executor/query/LimitExecutor.h"
 #include "executor/query/ProjectExecutor.h"
 #include "executor/query/test/QueryTestBase.h"
+#include "planner/Logic.h"
+#include "planner/Query.h"
+#include "util/ExpressionUtils.h"
 
 namespace nebula {
 namespace graph {
 class LimitTest : public QueryTestBase {
 };
 
-#define LIMIT_RESUTL_CHECK(outputName, offset, count, expected)                           \
-    do {                                                                                  \
-        auto* plan = qctx_->plan();                                                       \
-        auto* limitNode = Limit::make(qctx_, nullptr, offset, count);                      \
-        limitNode->setInputVar("input_neighbor");                                         \
-        limitNode->setOutputVar(outputName);                                              \
-        auto limitExec = std::make_unique<LimitExecutor>(limitNode, qctx_.get());         \
-        EXPECT_TRUE(limitExec->execute().get().ok());                                     \
-        auto& limitResult = qctx_->ectx()->getResult(limitNode->varName());               \
-        EXPECT_EQ(limitResult.state(), Result::State::kSuccess);                          \
-        auto yieldSentence = getYieldSentence(                                            \
-                "YIELD study._dst AS name, study.start_year AS start");                   \
-        auto columns = yieldSentence->columns();                                          \
-        for (auto& col : columns) {                                                       \
-            if (col->expr()->kind() == Expression::Kind::kLabelAttribute) {               \
-                auto laExpr = static_cast<LabelAttributeExpression*>(col->expr());        \
-                col->setExpr(ExpressionUtils                                              \
-                    ::rewriteLabelAttribute<EdgePropertyExpression>(laExpr));             \
-            } else {                                                                      \
-                ExpressionUtils::rewriteLabelAttribute<EdgePropertyExpression>(           \
-                    col->expr());                                                         \
-            }                                                                             \
-        }                                                                                 \
-        auto* project = Project::make(qctx_, nullptr, yieldSentence->yieldColumns());      \
-        project->setInputVar(limitNode->varName());                                       \
-        project->setColNames(std::vector<std::string>{"name", "start"});                  \
-        auto proExe = std::make_unique<ProjectExecutor>(project, qctx_.get());            \
-        EXPECT_TRUE(proExe->execute().get().ok());                                        \
-        auto& proResult = qctx_->ectx()->getResult(project->varName());                   \
-        EXPECT_EQ(proResult.value().getDataSet(), expected);                              \
-        EXPECT_EQ(proResult.state(), Result::State::kSuccess);                            \
+#define LIMIT_RESUTL_CHECK(outputName, offset, count, expected)                                    \
+    do {                                                                                           \
+        auto start = StartNode::make(qctx_.get());                                                 \
+        auto* limitNode = Limit::make(qctx_.get(), start, offset, count);                          \
+        limitNode->setInputVar("input_neighbor");                                                  \
+        limitNode->setOutputVar(outputName);                                                       \
+        auto limitExec = Executor::create(limitNode, qctx_.get());                                 \
+        EXPECT_TRUE(limitExec->execute().get().ok());                                              \
+        auto& limitResult = qctx_->ectx()->getResult(limitNode->varName());                        \
+        EXPECT_EQ(limitResult.state(), Result::State::kSuccess);                                   \
+        auto yieldSentence =                                                                       \
+            getYieldSentence("YIELD study._dst AS name, study.start_year AS start");               \
+        auto columns = yieldSentence->columns();                                                   \
+        for (auto& col : columns) {                                                                \
+            if (col->expr()->kind() == Expression::Kind::kLabelAttribute) {                        \
+                auto laExpr = static_cast<LabelAttributeExpression*>(col->expr());                 \
+                col->setExpr(                                                                      \
+                    ExpressionUtils::rewriteLabelAttribute<EdgePropertyExpression>(laExpr));       \
+            } else {                                                                               \
+                ExpressionUtils::rewriteLabelAttribute<EdgePropertyExpression>(col->expr());       \
+            }                                                                                      \
+        }                                                                                          \
+        auto* project = Project::make(qctx_.get(), start, yieldSentence->yieldColumns());          \
+        project->setInputVar(limitNode->varName());                                                \
+        project->setColNames(std::vector<std::string>{"name", "start"});                           \
+        auto proExe = Executor::create(project, qctx_.get());                                      \
+        EXPECT_TRUE(proExe->execute().get().ok());                                                 \
+        auto& proResult = qctx_->ectx()->getResult(project->varName());                            \
+        EXPECT_EQ(proResult.value().getDataSet(), expected);                                       \
+        EXPECT_EQ(proResult.state(), Result::State::kSuccess);                                     \
     } while (false)
-
 
 TEST_F(LimitTest, getNeighborInRange1) {
     DataSet expected({"name", "start"});

--- a/src/executor/query/test/ProjectTest.cpp
+++ b/src/executor/query/test/ProjectTest.cpp
@@ -7,16 +7,19 @@
 #include <gtest/gtest.h>
 
 #include "context/QueryContext.h"
-#include "planner/Query.h"
 #include "executor/query/ProjectExecutor.h"
 #include "executor/query/test/QueryTestBase.h"
+#include "planner/Logic.h"
+#include "planner/Query.h"
 
 namespace nebula {
 namespace graph {
+
 class ProjectTest : public QueryTestBase {
 protected:
-    static void SetUpTestCase() {
+    void SetUp() override {
         qctx_ = std::make_unique<QueryContext>();
+        start_ = StartNode::make(qctx_.get());
 
         {
             DataSet ds;
@@ -41,21 +44,19 @@ protected:
     }
 
 protected:
-    static std::unique_ptr<QueryContext> qctx_;
+    std::unique_ptr<QueryContext> qctx_;
+    StartNode* start_;
 };
-
-std::unique_ptr<QueryContext> ProjectTest::qctx_;
 
 TEST_F(ProjectTest, Project1Col) {
     std::string input = "input_project";
     auto yieldColumns = getYieldColumns("YIELD $input_project.vid AS vid");
 
-    auto* plan = qctx_->plan();
-    auto* project = Project::make(qctx_, nullptr, yieldColumns);
+    auto* project = Project::make(qctx_.get(), start_, yieldColumns);
     project->setInputVar(input);
     project->setColNames(std::vector<std::string>{"vid"});
 
-    auto proExe = std::make_unique<ProjectExecutor>(project, qctx_.get());
+    auto proExe = Executor::create(project, qctx_.get());
     auto future = proExe->execute();
     auto status = std::move(future).get();
     EXPECT_TRUE(status.ok());
@@ -76,12 +77,11 @@ TEST_F(ProjectTest, Project2Col) {
     std::string input = "input_project";
     auto yieldColumns = getYieldColumns(
             "YIELD $input_project.vid AS vid, $input_project.col2 AS num");
-    auto* plan = qctx_->plan();
-    auto* project = Project::make(qctx_, nullptr, yieldColumns);
+    auto* project = Project::make(qctx_.get(), start_, yieldColumns);
     project->setInputVar(input);
     project->setColNames(std::vector<std::string>{"vid", "num"});
 
-    auto proExe = std::make_unique<ProjectExecutor>(project, qctx_.get());
+    auto proExe = Executor::create(project, qctx_.get());
     auto future = proExe->execute();
     auto status = std::move(future).get();
     EXPECT_TRUE(status.ok());
@@ -102,12 +102,11 @@ TEST_F(ProjectTest, Project2Col) {
 TEST_F(ProjectTest, EmptyInput) {
     std::string input = "empty";
     auto yieldColumns = getYieldColumns("YIELD $input_project.vid AS vid");
-    auto* plan = qctx_->plan();
-    auto* project = Project::make(qctx_, nullptr, std::move(yieldColumns));
+    auto* project = Project::make(qctx_.get(), start_, std::move(yieldColumns));
     project->setInputVar(input);
     project->setColNames(std::vector<std::string>{"vid"});
 
-    auto proExe = std::make_unique<ProjectExecutor>(project, qctx_.get());
+    auto proExe = Executor::create(project, qctx_.get());
     auto future = proExe->execute();
     auto status = std::move(future).get();
     EXPECT_TRUE(status.ok());

--- a/src/executor/query/test/ProjectTest.cpp
+++ b/src/executor/query/test/ProjectTest.cpp
@@ -51,7 +51,7 @@ TEST_F(ProjectTest, Project1Col) {
     auto yieldColumns = getYieldColumns("YIELD $input_project.vid AS vid");
 
     auto* plan = qctx_->plan();
-    auto* project = Project::make(plan, nullptr, yieldColumns);
+    auto* project = Project::make(qctx_, nullptr, yieldColumns);
     project->setInputVar(input);
     project->setColNames(std::vector<std::string>{"vid"});
 
@@ -77,7 +77,7 @@ TEST_F(ProjectTest, Project2Col) {
     auto yieldColumns = getYieldColumns(
             "YIELD $input_project.vid AS vid, $input_project.col2 AS num");
     auto* plan = qctx_->plan();
-    auto* project = Project::make(plan, nullptr, yieldColumns);
+    auto* project = Project::make(qctx_, nullptr, yieldColumns);
     project->setInputVar(input);
     project->setColNames(std::vector<std::string>{"vid", "num"});
 
@@ -103,7 +103,7 @@ TEST_F(ProjectTest, EmptyInput) {
     std::string input = "empty";
     auto yieldColumns = getYieldColumns("YIELD $input_project.vid AS vid");
     auto* plan = qctx_->plan();
-    auto* project = Project::make(plan, nullptr, std::move(yieldColumns));
+    auto* project = Project::make(qctx_, nullptr, std::move(yieldColumns));
     project->setInputVar(input);
     project->setColNames(std::vector<std::string>{"vid"});
 

--- a/src/executor/query/test/SetExecutorTest.cpp
+++ b/src/executor/query/test/SetExecutorTest.cpp
@@ -25,7 +25,6 @@ class SetExecutorTest : public ::testing::Test {
 public:
     void SetUp() override {
         qctx_ = std::make_unique<QueryContext>();
-        plan_ = qctx_->plan();
     }
 
     static bool diffDataSet(const DataSet& lhs, const DataSet& rhs) {
@@ -49,7 +48,6 @@ public:
 
 protected:
     std::unique_ptr<QueryContext> qctx_;
-    ExecutionPlan* plan_;
 };
 
 TEST_F(SetExecutorTest, TestUnionAll) {
@@ -60,7 +58,7 @@ TEST_F(SetExecutorTest, TestUnionAll) {
         unionNode->setLeftVar(left->varName());
         unionNode->setRightVar(right->varName());
 
-        auto unionExecutor = Executor::makeExecutor(unionNode, qctx_.get());
+        auto unionExecutor = Executor::create(unionNode, qctx_.get());
         ResultBuilder lb, rb;
         lb.value(Value(lds)).iter(Iterator::Kind::kSequential);
         rb.value(Value(rds)).iter(Iterator::Kind::kSequential);
@@ -83,7 +81,9 @@ TEST_F(SetExecutorTest, TestUnionAll) {
             resultDS.emplace_back(std::move(row));
         }
 
-        EXPECT_TRUE(diffDataSet(resultDS, expected));
+        EXPECT_TRUE(diffDataSet(resultDS, expected)) << "\nResult dataset: \n"
+                                                     << resultDS << "Expected dataset: \n"
+                                                     << expected;
     };
 
     std::vector<std::string> colNames = {"col1", "col2"};
@@ -177,7 +177,7 @@ TEST_F(SetExecutorTest, TestGetNeighobrsIterator) {
     unionNode->setLeftVar(left->varName());
     unionNode->setRightVar(right->varName());
 
-    auto unionExecutor = Executor::makeExecutor(unionNode, qctx_.get());
+    auto unionExecutor = Executor::create(unionNode, qctx_.get());
 
     DataSet lds;
     lds.colNames = {"col1"};
@@ -206,7 +206,7 @@ TEST_F(SetExecutorTest, TestUnionDifferentColumns) {
     unionNode->setLeftVar(left->varName());
     unionNode->setRightVar(right->varName());
 
-    auto unionExecutor = Executor::makeExecutor(unionNode, qctx_.get());
+    auto unionExecutor = Executor::create(unionNode, qctx_.get());
 
     DataSet lds;
     lds.colNames = {"col1"};
@@ -232,7 +232,7 @@ TEST_F(SetExecutorTest, TestUnionDifferentValueType) {
     unionNode->setLeftVar(left->varName());
     unionNode->setRightVar(right->varName());
 
-    auto unionExecutor = Executor::makeExecutor(unionNode, qctx_.get());
+    auto unionExecutor = Executor::create(unionNode, qctx_.get());
 
     List lst;
     DataSet rds;
@@ -262,7 +262,7 @@ TEST_F(SetExecutorTest, TestIntersect) {
         ResultBuilder lb, rb;
         lb.value(Value(lds)).iter(Iterator::Kind::kSequential);
         rb.value(Value(rds)).iter(Iterator::Kind::kSequential);
-        auto executor = Executor::makeExecutor(intersect, qctx_.get());
+        auto executor = Executor::create(intersect, qctx_.get());
         qctx_->ectx()->setResult(left->varName(), lb.finish());
         qctx_->ectx()->setResult(right->varName(), rb.finish());
 
@@ -369,7 +369,7 @@ TEST_F(SetExecutorTest, TestMinus) {
         ResultBuilder lb, rb;
         lb.value(Value(lds)).iter(Iterator::Kind::kSequential);
         rb.value(Value(rds)).iter(Iterator::Kind::kSequential);
-        auto executor = Executor::makeExecutor(minus, qctx_.get());
+        auto executor = Executor::create(minus, qctx_.get());
         qctx_->ectx()->setResult(left->varName(), lb.finish());
         qctx_->ectx()->setResult(right->varName(), rb.finish());
 

--- a/src/executor/query/test/SetExecutorTest.cpp
+++ b/src/executor/query/test/SetExecutorTest.cpp
@@ -54,9 +54,9 @@ protected:
 
 TEST_F(SetExecutorTest, TestUnionAll) {
     auto testUnion = [this](const DataSet& lds, const DataSet& rds, const DataSet& expected) {
-        auto left = StartNode::make(plan_);
-        auto right = StartNode::make(plan_);
-        auto unionNode = Union::make(plan_, left, right);
+        auto left = StartNode::make(qctx_.get());
+        auto right = StartNode::make(qctx_.get());
+        auto unionNode = Union::make(qctx_.get(), left, right);
         unionNode->setLeftVar(left->varName());
         unionNode->setRightVar(right->varName());
 
@@ -171,9 +171,9 @@ TEST_F(SetExecutorTest, TestUnionAll) {
 }
 
 TEST_F(SetExecutorTest, TestGetNeighobrsIterator) {
-    auto left = StartNode::make(plan_);
-    auto right = StartNode::make(plan_);
-    auto unionNode = Union::make(plan_, left, right);
+    auto left = StartNode::make(qctx_.get());
+    auto right = StartNode::make(qctx_.get());
+    auto unionNode = Union::make(qctx_.get(), left, right);
     unionNode->setLeftVar(left->varName());
     unionNode->setRightVar(right->varName());
 
@@ -200,9 +200,9 @@ TEST_F(SetExecutorTest, TestGetNeighobrsIterator) {
 }
 
 TEST_F(SetExecutorTest, TestUnionDifferentColumns) {
-    auto left = StartNode::make(plan_);
-    auto right = StartNode::make(plan_);
-    auto unionNode = Union::make(plan_, left, right);
+    auto left = StartNode::make(qctx_.get());
+    auto right = StartNode::make(qctx_.get());
+    auto unionNode = Union::make(qctx_.get(), left, right);
     unionNode->setLeftVar(left->varName());
     unionNode->setRightVar(right->varName());
 
@@ -226,9 +226,9 @@ TEST_F(SetExecutorTest, TestUnionDifferentColumns) {
 }
 
 TEST_F(SetExecutorTest, TestUnionDifferentValueType) {
-    auto left = StartNode::make(plan_);
-    auto right = StartNode::make(plan_);
-    auto unionNode = Union::make(plan_, left, right);
+    auto left = StartNode::make(qctx_.get());
+    auto right = StartNode::make(qctx_.get());
+    auto unionNode = Union::make(qctx_.get(), left, right);
     unionNode->setLeftVar(left->varName());
     unionNode->setRightVar(right->varName());
 
@@ -253,9 +253,9 @@ TEST_F(SetExecutorTest, TestUnionDifferentValueType) {
 
 TEST_F(SetExecutorTest, TestIntersect) {
     auto testInterset = [this](const DataSet& lds, const DataSet& rds, const DataSet& expected) {
-        auto left = StartNode::make(plan_);
-        auto right = StartNode::make(plan_);
-        auto intersect = Intersect::make(plan_, left, right);
+        auto left = StartNode::make(qctx_.get());
+        auto right = StartNode::make(qctx_.get());
+        auto intersect = Intersect::make(qctx_.get(), left, right);
         intersect->setLeftVar(left->varName());
         intersect->setRightVar(right->varName());
 
@@ -360,9 +360,9 @@ TEST_F(SetExecutorTest, TestIntersect) {
 
 TEST_F(SetExecutorTest, TestMinus) {
     auto testMinus = [this](const DataSet& lds, const DataSet& rds, const DataSet& expected) {
-        auto left = StartNode::make(plan_);
-        auto right = StartNode::make(plan_);
-        auto minus = Minus::make(plan_, left, right);
+        auto left = StartNode::make(qctx_.get());
+        auto right = StartNode::make(qctx_.get());
+        auto minus = Minus::make(qctx_.get(), left, right);
         minus->setLeftVar(left->varName());
         minus->setRightVar(right->varName());
 

--- a/src/executor/query/test/SortTest.cpp
+++ b/src/executor/query/test/SortTest.cpp
@@ -7,47 +7,47 @@
 #include <gtest/gtest.h>
 
 #include "context/QueryContext.h"
-#include "planner/Query.h"
-#include "executor/query/SortExecutor.h"
 #include "executor/query/ProjectExecutor.h"
+#include "executor/query/SortExecutor.h"
 #include "executor/query/test/QueryTestBase.h"
+#include "planner/Logic.h"
+#include "planner/Query.h"
 
 namespace nebula {
 namespace graph {
-class SortTest : public QueryTestBase {
-};
 
-#define SORT_RESUTL_CHECK(input_name, outputName, multi, factors, expected)           \
-    do {                                                                              \
-        auto* plan = qctx_->plan();                                                   \
-        auto* sortNode = Sort::make(qctx_, nullptr, factors);                          \
-        sortNode->setInputVar(input_name);                                            \
-        sortNode->setOutputVar(outputName);                                           \
-        auto sortExec = std::make_unique<SortExecutor>(sortNode, qctx_.get());        \
-        EXPECT_TRUE(sortExec->execute().get().ok());                                  \
-        auto& sortResult = qctx_->ectx()->getResult(sortNode->varName());             \
-        EXPECT_EQ(sortResult.state(), Result::State::kSuccess);                       \
-        std::string sentence;                                                         \
-        std::vector<std::string> colNames;                                            \
-        if (multi) {                                                                  \
-            sentence = "YIELD $-.v_age AS age, $-.e_start_year AS start_year";        \
-            colNames.emplace_back("age");                                             \
-            colNames.emplace_back("start_year");                                      \
-        } else {                                                                      \
-            sentence = "YIELD $-.v_age AS age";                                       \
-            colNames.emplace_back("age");                                             \
-        }                                                                             \
-        auto yieldSentence = getYieldSentence(sentence);                              \
-        auto* project = Project::make(qctx_, nullptr, yieldSentence->yieldColumns());  \
-        project->setInputVar(sortNode->varName());                                    \
-        project->setColNames(std::move(colNames));                                    \
-        auto proExe = std::make_unique<ProjectExecutor>(project, qctx_.get());        \
-        EXPECT_TRUE(proExe->execute().get().ok());                                    \
-        auto& proResult = qctx_->ectx()->getResult(project->varName());               \
-        EXPECT_EQ(proResult.value().getDataSet(), expected);                          \
-        EXPECT_EQ(proResult.state(), Result::State::kSuccess);                        \
+class SortTest : public QueryTestBase {};
+
+#define SORT_RESUTL_CHECK(input_name, outputName, multi, factors, expected)                        \
+    do {                                                                                           \
+        auto start = StartNode::make(qctx_.get());                                                 \
+        auto* sortNode = Sort::make(qctx_.get(), start, factors);                                  \
+        sortNode->setInputVar(input_name);                                                         \
+        sortNode->setOutputVar(outputName);                                                        \
+        auto sortExec = Executor::create(sortNode, qctx_.get());                                   \
+        EXPECT_TRUE(sortExec->execute().get().ok());                                               \
+        auto& sortResult = qctx_->ectx()->getResult(sortNode->varName());                          \
+        EXPECT_EQ(sortResult.state(), Result::State::kSuccess);                                    \
+        std::string sentence;                                                                      \
+        std::vector<std::string> colNames;                                                         \
+        if (multi) {                                                                               \
+            sentence = "YIELD $-.v_age AS age, $-.e_start_year AS start_year";                     \
+            colNames.emplace_back("age");                                                          \
+            colNames.emplace_back("start_year");                                                   \
+        } else {                                                                                   \
+            sentence = "YIELD $-.v_age AS age";                                                    \
+            colNames.emplace_back("age");                                                          \
+        }                                                                                          \
+        auto yieldSentence = getYieldSentence(sentence);                                           \
+        auto* project = Project::make(qctx_.get(), start, yieldSentence->yieldColumns());          \
+        project->setInputVar(sortNode->varName());                                                 \
+        project->setColNames(std::move(colNames));                                                 \
+        auto proExe = Executor::create(project, qctx_.get());                                      \
+        EXPECT_TRUE(proExe->execute().get().ok());                                                 \
+        auto& proResult = qctx_->ectx()->getResult(project->varName());                            \
+        EXPECT_EQ(proResult.value().getDataSet(), expected);                                       \
+        EXPECT_EQ(proResult.state(), Result::State::kSuccess);                                     \
     } while (false)
-
 
 TEST_F(SortTest, sortOneColAsc) {
     DataSet expected({"age"});
@@ -130,5 +130,5 @@ TEST_F(SortTest, sortTwoColDesDes_union) {
     factors.emplace_back(std::make_pair("e_start_year", OrderFactor::OrderType::DESCEND));
     SORT_RESUTL_CHECK("union_sequential", "union_sort_two_cols_des_des", true, factors, expected);
 }
-}  // namespace graph
-}  // namespace nebula
+}   // namespace graph
+}   // namespace nebula

--- a/src/executor/query/test/SortTest.cpp
+++ b/src/executor/query/test/SortTest.cpp
@@ -20,7 +20,7 @@ class SortTest : public QueryTestBase {
 #define SORT_RESUTL_CHECK(input_name, outputName, multi, factors, expected)           \
     do {                                                                              \
         auto* plan = qctx_->plan();                                                   \
-        auto* sortNode = Sort::make(plan, nullptr, factors);                          \
+        auto* sortNode = Sort::make(qctx_, nullptr, factors);                          \
         sortNode->setInputVar(input_name);                                            \
         sortNode->setOutputVar(outputName);                                           \
         auto sortExec = std::make_unique<SortExecutor>(sortNode, qctx_.get());        \
@@ -38,7 +38,7 @@ class SortTest : public QueryTestBase {
             colNames.emplace_back("age");                                             \
         }                                                                             \
         auto yieldSentence = getYieldSentence(sentence);                              \
-        auto* project = Project::make(plan, nullptr, yieldSentence->yieldColumns());  \
+        auto* project = Project::make(qctx_, nullptr, yieldSentence->yieldColumns());  \
         project->setInputVar(sortNode->varName());                                    \
         project->setColNames(std::move(colNames));                                    \
         auto proExe = std::make_unique<ProjectExecutor>(project, qctx_.get());        \

--- a/src/parser/test/CMakeLists.txt
+++ b/src/parser/test/CMakeLists.txt
@@ -26,6 +26,7 @@ set(PARSER_TEST_LIBS
     $<TARGET_OBJECTS:common_conf_obj>
     $<TARGET_OBJECTS:common_file_based_cluster_id_man_obj>
     $<TARGET_OBJECTS:session_obj>
+    $<TARGET_OBJECTS:graph_flags_obj>
     $<TARGET_OBJECTS:util_obj>
     $<TARGET_OBJECTS:context_obj>
     $<TARGET_OBJECTS:planner_obj>

--- a/src/parser/test/CMakeLists.txt
+++ b/src/parser/test/CMakeLists.txt
@@ -25,6 +25,7 @@ set(PARSER_TEST_LIBS
     $<TARGET_OBJECTS:common_meta_client_obj>
     $<TARGET_OBJECTS:common_conf_obj>
     $<TARGET_OBJECTS:common_file_based_cluster_id_man_obj>
+    $<TARGET_OBJECTS:session_obj>
     $<TARGET_OBJECTS:util_obj>
     $<TARGET_OBJECTS:context_obj>
     $<TARGET_OBJECTS:planner_obj>

--- a/src/planner/ExecutionPlan.cpp
+++ b/src/planner/ExecutionPlan.cpp
@@ -6,33 +6,18 @@
 
 #include "planner/ExecutionPlan.h"
 
-#include <folly/String.h>
-
 #include "common/interface/gen-cpp2/graph_types.h"
-#include "executor/Executor.h"
 #include "planner/Logic.h"
 #include "planner/PlanNode.h"
 #include "planner/Query.h"
-#include "scheduler/Scheduler.h"
 #include "util/IdGenerator.h"
-#include "util/ObjectPool.h"
-
-using folly::stringPrintf;
 
 namespace nebula {
 namespace graph {
 
-ExecutionPlan::ExecutionPlan(ObjectPool* objectPool)
-    : id_(EPIdGenerator::instance().id()),
-      objPool_(objectPool),
-      nodeIdGen_(std::make_unique<IdGenerator>(0)) {}
+ExecutionPlan::ExecutionPlan() : id_(EPIdGenerator::instance().id()) {}
 
 ExecutionPlan::~ExecutionPlan() {}
-
-PlanNode* ExecutionPlan::addPlanNode(PlanNode* node) {
-    node->setId(nodeIdGen_->id());
-    return objPool_->add(node);
-}
 
 static size_t makePlanNodeDesc(const PlanNode* node, cpp2::PlanDescription* planDesc) {
     auto found = planDesc->node_index_map.find(node->id());

--- a/src/planner/ExecutionPlan.h
+++ b/src/planner/ExecutionPlan.h
@@ -53,7 +53,7 @@ public:
 
     // follow the flavor like std::make_unique, combine the object creation and ownership holding
     template <typename T, typename... Args>
-    T* makeAndSave(Args&&... args) {
+    T* makeAndAdd(Args&&... args) {
         return objPool_->makeAndAdd<T>(std::forward<Args>(args)...);
     }
 

--- a/src/planner/ExecutionPlan.h
+++ b/src/planner/ExecutionPlan.h
@@ -8,53 +8,23 @@
 #define PLANNER_EXECUTIONPLAN_H_
 
 #include <cstdint>
-#include <memory>
-
-#include <folly/futures/Future.h>
-
-#include "common/base/Status.h"
-#include "common/expression/Expression.h"
-#include "util/ObjectPool.h"
 
 namespace nebula {
 namespace graph {
 
 namespace cpp2 {
 class PlanDescription;
-}  // namespace cpp2
+}   // namespace cpp2
 
-class Executor;
-class IdGenerator;
 class PlanNode;
-class Scheduler;
 
 class ExecutionPlan final {
 public:
-    explicit ExecutionPlan(ObjectPool* objectPool);
-
+    ExecutionPlan();
     ~ExecutionPlan();
 
     void setRoot(PlanNode* root) {
         root_ = root;
-    }
-
-    /**
-     * Save all generated plan node in object pool.
-     */
-    PlanNode* addPlanNode(PlanNode* node);
-
-    /**
-     * Save all generated object in object pool.
-     */
-    template <typename T>
-    T* saveObject(T* obj) {
-        return objPool_->add(obj);
-    }
-
-    // follow the flavor like std::make_unique, combine the object creation and ownership holding
-    template <typename T, typename... Args>
-    T* makeAndAdd(Args&&... args) {
-        return objPool_->makeAndAdd<T>(std::forward<Args>(args)...);
     }
 
     int64_t id() const {
@@ -65,22 +35,14 @@ public:
         return root_;
     }
 
-    ObjectPool* objPool() const {
-        return objPool_;
-    }
-
     void fillPlanDescription(cpp2::PlanDescription* planDesc) const;
 
 private:
-    Executor* createExecutor();
-
-    int64_t                                 id_;
-    PlanNode*                               root_{nullptr};
-    ObjectPool*                             objPool_{nullptr};
-    std::unique_ptr<IdGenerator>            nodeIdGen_;
+    int64_t id_{-1};
+    PlanNode* root_{nullptr};
 };
 
-}  // namespace graph
-}  // namespace nebula
+}   // namespace graph
+}   // namespace nebula
 
 #endif

--- a/src/planner/Logic.cpp
+++ b/src/planner/Logic.cpp
@@ -17,8 +17,8 @@ std::unique_ptr<cpp2::PlanNodeDescription> BinarySelect::explain() const {
     return desc;
 }
 
-Loop::Loop(ExecutionPlan* plan, PlanNode* input, PlanNode* body, Expression* condition)
-    : BinarySelect(plan, Kind::kLoop, input, condition), body_(body) {}
+Loop::Loop(int64_t id, PlanNode* input, PlanNode* body, Expression* condition)
+    : BinarySelect(id, Kind::kLoop, input, condition), body_(body) {}
 
 }   // namespace graph
 }   // namespace nebula

--- a/src/planner/Maintain.h
+++ b/src/planner/Maintain.h
@@ -17,13 +17,13 @@ namespace graph {
 // which would make them in a single and big execution plan
 class CreateSchemaNode : public SingleInputNode {
 protected:
-    CreateSchemaNode(ExecutionPlan* plan,
+    CreateSchemaNode(int64_t id,
                      PlanNode* input,
                      Kind kind,
                      std::string name,
                      meta::cpp2::Schema schema,
                      bool ifNotExists)
-        : SingleInputNode(plan, kind, input)
+        : SingleInputNode(id, kind, input)
         , name_(std::move(name))
         , schema_(std::move(schema))
         , ifNotExists_(ifNotExists) {}
@@ -51,25 +51,22 @@ protected:
 
 class CreateTag final : public CreateSchemaNode {
 public:
-    static CreateTag* make(ExecutionPlan* plan,
+    static CreateTag* make(QueryContext* qctx,
                            PlanNode* input,
                            std::string tagName,
                            meta::cpp2::Schema schema,
                            bool ifNotExists) {
-    return new CreateTag(plan,
-                         input,
-                         std::move(tagName),
-                         std::move(schema),
-                         ifNotExists);
+        return qctx->objPool()->add(new CreateTag(
+            qctx->genId(), input, std::move(tagName), std::move(schema), ifNotExists));
     }
 
 private:
-    CreateTag(ExecutionPlan* plan,
+    CreateTag(int64_t id,
               PlanNode* input,
               std::string tagName,
               meta::cpp2::Schema schema,
               bool ifNotExists)
-        : CreateSchemaNode(plan,
+        : CreateSchemaNode(id,
                            input,
                            Kind::kCreateTag,
                            std::move(tagName),
@@ -80,25 +77,22 @@ private:
 
 class CreateEdge final : public CreateSchemaNode {
 public:
-    static CreateEdge* make(ExecutionPlan* plan,
+    static CreateEdge* make(QueryContext* qctx,
                             PlanNode* input,
                             std::string edgeName,
                             meta::cpp2::Schema schema,
                             bool ifNotExists) {
-    return new CreateEdge(plan,
-                          input,
-                          std::move(edgeName),
-                          std::move(schema),
-                          ifNotExists);
+        return qctx->objPool()->add(new CreateEdge(
+            qctx->genId(), input, std::move(edgeName), std::move(schema), ifNotExists));
     }
 
 private:
-    CreateEdge(ExecutionPlan* plan,
+    CreateEdge(int64_t id,
                PlanNode* input,
                std::string edgeName,
                meta::cpp2::Schema schema,
                bool ifNotExists)
-        : CreateSchemaNode(plan,
+        : CreateSchemaNode(id,
                            input,
                            Kind::kCreateEdge,
                            std::move(edgeName),
@@ -109,14 +103,14 @@ private:
 
 class AlterSchemaNode : public SingleInputNode {
 protected:
-    AlterSchemaNode(ExecutionPlan* plan,
+    AlterSchemaNode(int64_t id,
                     Kind kind,
                     PlanNode* input,
                     GraphSpaceID space,
                     std::string name,
                     std::vector<meta::cpp2::AlterSchemaItem> items,
                     meta::cpp2::SchemaProp schemaProp)
-        : SingleInputNode(plan, kind, input)
+        : SingleInputNode(id, kind, input)
         , space_(space)
         , name_(std::move(name))
         , schemaItems_(std::move(items))
@@ -150,28 +144,24 @@ protected:
 
 class AlterTag final : public AlterSchemaNode {
 public:
-    static AlterTag* make(ExecutionPlan* plan,
+    static AlterTag* make(QueryContext* qctx,
                           PlanNode* input,
                           GraphSpaceID space,
                           std::string name,
                           std::vector<meta::cpp2::AlterSchemaItem> items,
                           meta::cpp2::SchemaProp schemaProp) {
-        return new AlterTag(plan,
-                            input,
-                            space,
-                            std::move(name),
-                            std::move(items),
-                            std::move(schemaProp));
+        return qctx->objPool()->add(new AlterTag(
+            qctx->genId(), input, space, std::move(name), std::move(items), std::move(schemaProp)));
     }
 
 private:
-    AlterTag(ExecutionPlan* plan,
+    AlterTag(int64_t id,
              PlanNode* input,
              GraphSpaceID space,
              std::string name,
              std::vector<meta::cpp2::AlterSchemaItem> items,
              meta::cpp2::SchemaProp schemaProp)
-        : AlterSchemaNode(plan,
+        : AlterSchemaNode(id,
                             Kind::kAlterTag,
                             input,
                             space,
@@ -183,28 +173,24 @@ private:
 
 class AlterEdge final : public AlterSchemaNode {
 public:
-    static AlterEdge* make(ExecutionPlan* plan,
+    static AlterEdge* make(QueryContext* qctx,
                            PlanNode* input,
                            GraphSpaceID space,
                            std::string name,
                            std::vector<meta::cpp2::AlterSchemaItem> items,
                            meta::cpp2::SchemaProp schemaProp) {
-        return new AlterEdge(plan,
-                             input,
-                             space,
-                             std::move(name),
-                             std::move(items),
-                             std::move(schemaProp));
+        return qctx->objPool()->add(new AlterEdge(
+            qctx->genId(), input, space, std::move(name), std::move(items), std::move(schemaProp)));
     }
 
 private:
-    AlterEdge(ExecutionPlan* plan,
+    AlterEdge(int64_t id,
               PlanNode* input,
               GraphSpaceID space,
               std::string name,
               std::vector<meta::cpp2::AlterSchemaItem> items,
               meta::cpp2::SchemaProp schemaProp)
-        : AlterSchemaNode(plan,
+        : AlterSchemaNode(id,
                             Kind::kAlterEdge,
                             input,
                             space,
@@ -216,11 +202,11 @@ private:
 
 class DescSchema : public SingleInputNode {
 protected:
-    DescSchema(ExecutionPlan* plan,
+    DescSchema(int64_t id,
                PlanNode* input,
                Kind kind,
                std::string name)
-        : SingleInputNode(plan, kind, input)
+        : SingleInputNode(id, kind, input)
         , name_(std::move(name)) {
     }
 
@@ -237,104 +223,104 @@ protected:
 
 class DescTag final : public DescSchema {
 public:
-    static DescTag* make(ExecutionPlan* plan,
+    static DescTag* make(QueryContext* qctx,
                          PlanNode* input,
                          std::string tagName) {
-        return new DescTag(plan, input, std::move(tagName));
+        return qctx->objPool()->add(new DescTag(qctx->genId(), input, std::move(tagName)));
     }
 
 private:
-    DescTag(ExecutionPlan* plan,
+    DescTag(int64_t id,
             PlanNode* input,
             std::string tagName)
-        : DescSchema(plan, input, Kind::kDescTag, std::move(tagName)) {
+        : DescSchema(id, input, Kind::kDescTag, std::move(tagName)) {
     }
 };
 
 class DescEdge final : public DescSchema {
 public:
-    static DescEdge* make(ExecutionPlan* plan,
+    static DescEdge* make(QueryContext* qctx,
                           PlanNode* input,
                           std::string edgeName) {
-        return new DescEdge(plan, input, std::move(edgeName));
+        return qctx->objPool()->add(new DescEdge(qctx->genId(), input, std::move(edgeName)));
     }
 
 private:
-    DescEdge(ExecutionPlan* plan,
+    DescEdge(int64_t id,
              PlanNode* input,
              std::string edgeName)
-        : DescSchema(plan, input, Kind::kDescEdge, std::move(edgeName)) {
+        : DescSchema(id, input, Kind::kDescEdge, std::move(edgeName)) {
     }
 };
 
 class ShowCreateTag final : public DescSchema {
 public:
-    static ShowCreateTag* make(ExecutionPlan* plan,
+    static ShowCreateTag* make(QueryContext* qctx,
                                PlanNode* input,
                                std::string name) {
-        return new ShowCreateTag(plan, input, std::move(name));
+        return qctx->objPool()->add(new ShowCreateTag(qctx->genId(), input, std::move(name)));
     }
 
 private:
-    ShowCreateTag(ExecutionPlan* plan,
+    ShowCreateTag(int64_t id,
                   PlanNode* input,
                   std::string name)
-        : DescSchema(plan, input, Kind::kShowCreateTag, std::move(name)) {
+        : DescSchema(id, input, Kind::kShowCreateTag, std::move(name)) {
     }
 };
 
 class ShowCreateEdge final : public DescSchema {
 public:
-    static ShowCreateEdge* make(ExecutionPlan* plan,
+    static ShowCreateEdge* make(QueryContext* qctx,
                                 PlanNode* input,
                                 std::string name) {
-        return new ShowCreateEdge(plan, input, std::move(name));
+        return qctx->objPool()->add(new ShowCreateEdge(qctx->genId(), input, std::move(name)));
     }
 
 private:
-    ShowCreateEdge(ExecutionPlan* plan,
+    ShowCreateEdge(int64_t id,
                    PlanNode* input,
                    std::string name)
-        : DescSchema(plan, input, Kind::kShowCreateEdge, std::move(name)) {
+        : DescSchema(id, input, Kind::kShowCreateEdge, std::move(name)) {
     }
 };
 
 class ShowTags final : public SingleInputNode {
 public:
-    static ShowTags* make(ExecutionPlan* plan,
+    static ShowTags* make(QueryContext* qctx,
                           PlanNode* input) {
-        return new ShowTags(plan, input);
+        return qctx->objPool()->add(new ShowTags(qctx->genId(), input));
     }
 
 private:
-    ShowTags(ExecutionPlan* plan,
+    ShowTags(int64_t id,
              PlanNode* input)
-        : SingleInputNode(plan, Kind::kShowTags, input) {
+        : SingleInputNode(id, Kind::kShowTags, input) {
     }
 };
 
 class ShowEdges final : public SingleInputNode {
 public:
-    static ShowEdges* make(ExecutionPlan* plan,
+    static ShowEdges* make(QueryContext* qctx,
                            PlanNode* input) {
-        return new ShowEdges(plan, input);
+        return qctx->objPool()->add(new ShowEdges(qctx->genId(), input));
     }
 
 private:
-    ShowEdges(ExecutionPlan* plan,
+    ShowEdges(int64_t id,
               PlanNode* input)
-        : SingleInputNode(plan, Kind::kShowEdges, input) {
+        : SingleInputNode(id, Kind::kShowEdges, input) {
     }
 };
 
 class DropSchema : public SingleInputNode {
 protected:
-    DropSchema(ExecutionPlan* plan,
+    DropSchema(int64_t id,
                Kind kind,
                PlanNode* input,
                std::string name,
                bool ifExists)
-        : SingleInputNode(plan, kind, input)
+        : SingleInputNode(id, kind, input)
         , name_(std::move(name))
         , ifExists_(ifExists) {}
 
@@ -357,37 +343,37 @@ protected:
 
 class DropTag final : public DropSchema {
 public:
-    static DropTag* make(ExecutionPlan* plan,
+    static DropTag* make(QueryContext* qctx,
                          PlanNode* input,
                          std::string name,
                          bool ifExists) {
-        return new DropTag(plan, input, std::move(name), ifExists);
+        return qctx->objPool()->add(new DropTag(qctx->genId(), input, std::move(name), ifExists));
     }
 
 private:
-    DropTag(ExecutionPlan* plan,
+    DropTag(int64_t id,
             PlanNode* input,
             std::string name,
             bool ifExists)
-        : DropSchema(plan, Kind::kDropTag, input, std::move(name), ifExists) {
+        : DropSchema(id, Kind::kDropTag, input, std::move(name), ifExists) {
     }
 };
 
 class DropEdge final : public DropSchema {
 public:
-    static DropEdge* make(ExecutionPlan* plan,
+    static DropEdge* make(QueryContext* qctx,
                           PlanNode* input,
                           std::string name,
                           bool ifExists) {
-        return new DropEdge(plan, input, std::move(name), ifExists);
+        return qctx->objPool()->add(new DropEdge(qctx->genId(), input, std::move(name), ifExists));
     }
 
 private:
-    DropEdge(ExecutionPlan* plan,
+    DropEdge(int64_t id,
              PlanNode* input,
              std::string name,
              bool ifExists)
-        : DropSchema(plan, Kind::kDropEdge, input, std::move(name), ifExists) {
+        : DropSchema(id, Kind::kDropEdge, input, std::move(name), ifExists) {
     }
 };
 

--- a/src/planner/Mutate.h
+++ b/src/planner/Mutate.h
@@ -8,7 +8,7 @@
 #define PLANNER_MUTATE_H_
 
 #include "common/interface/gen-cpp2/storage_types.h"
-
+#include "context/QueryContext.h"
 #include "planner/Query.h"
 #include "parser/TraverseSentences.h"
 
@@ -19,19 +19,18 @@ namespace nebula {
 namespace graph {
 class InsertVertices final : public SingleInputNode {
 public:
-    static InsertVertices* make(
-            ExecutionPlan* plan,
-            PlanNode* input,
-            GraphSpaceID spaceId,
-            std::vector<storage::cpp2::NewVertex> vertices,
-            std::unordered_map<TagID, std::vector<std::string>> tagPropNames,
-            bool overwritable) {
-        return new InsertVertices(plan,
-                                  input,
-                                  spaceId,
-                                  std::move(vertices),
-                                  std::move(tagPropNames),
-                                  overwritable);
+    static InsertVertices* make(QueryContext* qctx,
+                                PlanNode* input,
+                                GraphSpaceID spaceId,
+                                std::vector<storage::cpp2::NewVertex> vertices,
+                                std::unordered_map<TagID, std::vector<std::string>> tagPropNames,
+                                bool overwritable) {
+        return qctx->objPool()->add(new InsertVertices(qctx->genId(),
+                                                       input,
+                                                       spaceId,
+                                                       std::move(vertices),
+                                                       std::move(tagPropNames),
+                                                       overwritable));
     }
 
     std::unique_ptr<cpp2::PlanNodeDescription> explain() const override;
@@ -53,40 +52,35 @@ public:
     }
 
 private:
-    InsertVertices(ExecutionPlan* plan,
+    InsertVertices(int64_t id,
                    PlanNode* input,
                    GraphSpaceID spaceId,
                    std::vector<storage::cpp2::NewVertex> vertices,
                    std::unordered_map<TagID, std::vector<std::string>> tagPropNames,
                    bool overwritable)
-        : SingleInputNode(plan, Kind::kInsertVertices, input)
-        , spaceId_(spaceId)
-        , vertices_(std::move(vertices))
-        , tagPropNames_(std::move(tagPropNames))
-        , overwritable_(overwritable) {
-    }
+        : SingleInputNode(id, Kind::kInsertVertices, input),
+          spaceId_(spaceId),
+          vertices_(std::move(vertices)),
+          tagPropNames_(std::move(tagPropNames)),
+          overwritable_(overwritable) {}
 
 private:
-    GraphSpaceID                                               spaceId_{-1};
-    std::vector<storage::cpp2::NewVertex>                      vertices_;
-    std::unordered_map<TagID, std::vector<std::string>>        tagPropNames_;
-    bool                                                       overwritable_;
+    GraphSpaceID spaceId_{-1};
+    std::vector<storage::cpp2::NewVertex> vertices_;
+    std::unordered_map<TagID, std::vector<std::string>> tagPropNames_;
+    bool overwritable_;
 };
 
 class InsertEdges final : public SingleInputNode {
 public:
-    static InsertEdges* make(ExecutionPlan* plan,
+    static InsertEdges* make(QueryContext* qctx,
                              PlanNode* input,
                              GraphSpaceID spaceId,
                              std::vector<storage::cpp2::NewEdge> edges,
                              std::vector<std::string> propNames,
                              bool overwritable) {
-        return new InsertEdges(plan,
-                               input,
-                               spaceId,
-                               std::move(edges),
-                               std::move(propNames),
-                               overwritable);
+        return qctx->objPool()->add(new InsertEdges(
+            qctx->genId(), input, spaceId, std::move(edges), std::move(propNames), overwritable));
     }
 
     std::unique_ptr<cpp2::PlanNodeDescription> explain() const override;
@@ -108,24 +102,23 @@ public:
     }
 
 private:
-    InsertEdges(ExecutionPlan* plan,
+    InsertEdges(int64_t id,
                 PlanNode* input,
                 GraphSpaceID spaceId,
                 std::vector<storage::cpp2::NewEdge> edges,
                 std::vector<std::string> propNames,
                 bool overwritable)
-        : SingleInputNode(plan, Kind::kInsertEdges, input)
-        , spaceId_(spaceId)
-        , edges_(std::move(edges))
-        , propNames_(std::move(propNames))
-        , overwritable_(overwritable) {
-    }
+        : SingleInputNode(id, Kind::kInsertEdges, input),
+          spaceId_(spaceId),
+          edges_(std::move(edges)),
+          propNames_(std::move(propNames)),
+          overwritable_(overwritable) {}
 
 private:
-    GraphSpaceID                               spaceId_{-1};
-    std::vector<storage::cpp2::NewEdge>        edges_;
-    std::vector<std::string>                   propNames_;
-    bool                                       overwritable_;
+    GraphSpaceID spaceId_{-1};
+    std::vector<storage::cpp2::NewEdge> edges_;
+    std::vector<std::string> propNames_;
+    bool overwritable_;
 };
 
 class Update : public SingleInputNode {
@@ -162,7 +155,7 @@ public:
 
 protected:
     Update(Kind kind,
-           ExecutionPlan* plan,
+           int64_t id,
            PlanNode* input,
            GraphSpaceID spaceId,
            std::string name,
@@ -171,28 +164,28 @@ protected:
            std::vector<std::string> returnProps,
            std::string condition,
            std::vector<std::string> yieldNames)
-        : SingleInputNode(plan, kind, input)
-        , spaceId_(spaceId)
-        , schemaName_(std::move(name))
-        , insertable_(insertable)
-        , updatedProps_(std::move(updatedProps))
-        , returnProps_(std::move(returnProps))
-        , condition_(std::move(condition))
-        , yieldNames_(std::move(yieldNames)) {}
+        : SingleInputNode(id, kind, input),
+          spaceId_(spaceId),
+          schemaName_(std::move(name)),
+          insertable_(insertable),
+          updatedProps_(std::move(updatedProps)),
+          returnProps_(std::move(returnProps)),
+          condition_(std::move(condition)),
+          yieldNames_(std::move(yieldNames)) {}
 
 protected:
-    GraphSpaceID                                        spaceId_{-1};
-    std::string                                         schemaName_;
-    bool                                                insertable_;
-    std::vector<storage::cpp2::UpdatedProp>             updatedProps_;
-    std::vector<std::string>                            returnProps_;
-    std::string                                         condition_;
-    std::vector<std::string>                            yieldNames_;
+    GraphSpaceID spaceId_{-1};
+    std::string schemaName_;
+    bool insertable_;
+    std::vector<storage::cpp2::UpdatedProp> updatedProps_;
+    std::vector<std::string> returnProps_;
+    std::string condition_;
+    std::vector<std::string> yieldNames_;
 };
 
 class UpdateVertex final : public Update {
 public:
-    static UpdateVertex* make(ExecutionPlan* plan,
+    static UpdateVertex* make(QueryContext* qctx,
                               PlanNode* input,
                               GraphSpaceID spaceId,
                               std::string name,
@@ -203,17 +196,17 @@ public:
                               std::vector<std::string> returnProps,
                               std::string condition,
                               std::vector<std::string> yieldNames) {
-        return new UpdateVertex(plan,
-                                input,
-                                spaceId,
-                                std::move(name),
-                                std::move(vId),
-                                tagId,
-                                insertable,
-                                std::move(updatedProps),
-                                std::move(returnProps),
-                                std::move(condition),
-                                std::move(yieldNames));
+        return qctx->objPool()->add(new UpdateVertex(qctx->genId(),
+                                                     input,
+                                                     spaceId,
+                                                     std::move(name),
+                                                     std::move(vId),
+                                                     tagId,
+                                                     insertable,
+                                                     std::move(updatedProps),
+                                                     std::move(returnProps),
+                                                     std::move(condition),
+                                                     std::move(yieldNames)));
     }
 
     std::unique_ptr<cpp2::PlanNodeDescription> explain() const override;
@@ -227,7 +220,7 @@ public:
     }
 
 private:
-    UpdateVertex(ExecutionPlan* plan,
+    UpdateVertex(int64_t id,
                  PlanNode* input,
                  GraphSpaceID spaceId,
                  std::string name,
@@ -239,7 +232,7 @@ private:
                  std::string condition,
                  std::vector<std::string> yieldNames)
         : Update(Kind::kUpdateVertex,
-                 plan,
+                 id,
                  input,
                  spaceId,
                  std::move(name),
@@ -247,18 +240,18 @@ private:
                  std::move(updatedProps),
                  std::move(returnProps),
                  std::move(condition),
-                 std::move(yieldNames))
-        , vId_(std::move(vId))
-        , tagId_(tagId) {}
+                 std::move(yieldNames)),
+          vId_(std::move(vId)),
+          tagId_(tagId) {}
 
 private:
-    std::string                                     vId_;
-    TagID                                           tagId_{-1};
+    std::string vId_;
+    TagID tagId_{-1};
 };
 
 class UpdateEdge final : public Update {
 public:
-    static UpdateEdge* make(ExecutionPlan* plan,
+    static UpdateEdge* make(QueryContext* qctx,
                             PlanNode* input,
                             GraphSpaceID spaceId,
                             std::string name,
@@ -271,19 +264,19 @@ public:
                             std::vector<std::string> returnProps,
                             std::string condition,
                             std::vector<std::string> yieldNames) {
-        return new UpdateEdge(plan,
-                              input,
-                              spaceId,
-                              std::move(name),
-                              std::move(srcId),
-                              std::move(dstId),
-                              edgeType,
-                              rank,
-                              insertable,
-                              std::move(updatedProps),
-                              std::move(returnProps),
-                              std::move(condition),
-                              std::move(yieldNames));
+        return qctx->objPool()->add(new UpdateEdge(qctx->genId(),
+                                                   input,
+                                                   spaceId,
+                                                   std::move(name),
+                                                   std::move(srcId),
+                                                   std::move(dstId),
+                                                   edgeType,
+                                                   rank,
+                                                   insertable,
+                                                   std::move(updatedProps),
+                                                   std::move(returnProps),
+                                                   std::move(condition),
+                                                   std::move(yieldNames)));
     }
 
     std::unique_ptr<cpp2::PlanNodeDescription> explain() const override;
@@ -309,7 +302,7 @@ public:
     }
 
 private:
-    UpdateEdge(ExecutionPlan* plan,
+    UpdateEdge(int64_t id,
                PlanNode* input,
                GraphSpaceID spaceId,
                std::string name,
@@ -323,7 +316,7 @@ private:
                std::string condition,
                std::vector<std::string> yieldNames)
         : Update(Kind::kUpdateEdge,
-                 plan,
+                 id,
                  input,
                  spaceId,
                  std::move(name),
@@ -333,28 +326,26 @@ private:
                  std::move(condition),
                  std::move(yieldNames))
 
-        , srcId_(std::move(srcId))
-        , dstId_(std::move(dstId))
-        , rank_(rank)
-        , edgeType_(edgeType) {}
+          ,
+          srcId_(std::move(srcId)),
+          dstId_(std::move(dstId)),
+          rank_(rank),
+          edgeType_(edgeType) {}
 
 private:
-    std::string                                         srcId_;
-    std::string                                         dstId_;
-    int64_t                                             rank_{0};
-    EdgeType                                            edgeType_{-1};
+    std::string srcId_;
+    std::string dstId_;
+    int64_t rank_{0};
+    EdgeType edgeType_{-1};
 };
 
 class DeleteVertices final : public SingleInputNode {
 public:
-    static DeleteVertices* make(ExecutionPlan* plan,
+    static DeleteVertices* make(QueryContext* qctx,
                                 PlanNode* input,
                                 GraphSpaceID spaceId,
                                 Expression* vidRef_) {
-        return new DeleteVertices(plan,
-                                  input,
-                                  spaceId,
-                                  vidRef_);
+        return qctx->objPool()->add(new DeleteVertices(qctx->genId(), input, spaceId, vidRef_));
     }
 
     std::unique_ptr<cpp2::PlanNodeDescription> explain() const override;
@@ -368,29 +359,22 @@ public:
     }
 
 private:
-    DeleteVertices(ExecutionPlan* plan,
-                   PlanNode* input,
-                   GraphSpaceID spaceId,
-                   Expression* vidRef)
-        : SingleInputNode(plan, Kind::kDeleteVertices, input)
-        , space_(spaceId)
-        , vidRef_(vidRef) {}
+    DeleteVertices(int64_t id, PlanNode* input, GraphSpaceID spaceId, Expression* vidRef)
+        : SingleInputNode(id, Kind::kDeleteVertices, input), space_(spaceId), vidRef_(vidRef) {}
 
 private:
-    GraphSpaceID                            space_;
-    Expression                             *vidRef_{nullptr};
+    GraphSpaceID space_;
+    Expression* vidRef_{nullptr};
 };
 
 class DeleteEdges final : public SingleInputNode {
 public:
-    static DeleteEdges* make(ExecutionPlan* plan,
+    static DeleteEdges* make(QueryContext* qctx,
                              PlanNode* input,
                              GraphSpaceID spaceId,
                              std::vector<EdgeKeyRef*> edgeKeyRefs) {
-        return new DeleteEdges(plan,
-                               input,
-                               spaceId,
-                               std::move(edgeKeyRefs));
+        return qctx->objPool()->add(new DeleteEdges(
+            qctx->genId(), input, spaceId, std::move(edgeKeyRefs)));
     }
 
     std::unique_ptr<cpp2::PlanNodeDescription> explain() const override;
@@ -404,11 +388,11 @@ public:
     }
 
 private:
-    DeleteEdges(ExecutionPlan* plan,
+    DeleteEdges(int64_t id,
                 PlanNode* input,
                 GraphSpaceID spaceId,
                 std::vector<EdgeKeyRef*> edgeKeyRefs)
-        : SingleInputNode(plan, Kind::kDeleteEdges, input)
+        : SingleInputNode(id, Kind::kDeleteEdges, input)
         , space_(spaceId)
         , edgeKeyRefs_(std::move(edgeKeyRefs)) {}
 

--- a/src/planner/Mutate.h
+++ b/src/planner/Mutate.h
@@ -324,9 +324,7 @@ private:
                  std::move(updatedProps),
                  std::move(returnProps),
                  std::move(condition),
-                 std::move(yieldNames))
-
-          ,
+                 std::move(yieldNames)),
           srcId_(std::move(srcId)),
           dstId_(std::move(dstId)),
           rank_(rank),

--- a/src/planner/PlanNode.cpp
+++ b/src/planner/PlanNode.cpp
@@ -7,15 +7,14 @@
 #include "planner/PlanNode.h"
 
 #include "common/interface/gen-cpp2/graph_types.h"
-#include "planner/ExecutionPlan.h"
+#include "context/QueryContext.h"
 #include "util/ToJson.h"
 
 namespace nebula {
 namespace graph {
 
-PlanNode::PlanNode(ExecutionPlan* plan, Kind kind) : kind_(kind), plan_(plan) {
-    DCHECK(plan_ != nullptr);
-    plan_->addPlanNode(this);
+PlanNode::PlanNode(int64_t id, Kind kind) : kind_(kind), id_(id) {
+    DCHECK_LE(id_, 0);
 }
 
 // static
@@ -158,7 +157,7 @@ const char* PlanNode::toString(PlanNode::Kind kind) {
             return "SetConfig";
         case Kind::kGetConfig:
             return "GetConfig";
-        // no default so the compiler will warning when lack
+            // no default so the compiler will warning when lack
     }
     LOG(FATAL) << "Impossible kind plan node " << static_cast<int>(kind);
 }

--- a/src/planner/PlanNode.cpp
+++ b/src/planner/PlanNode.cpp
@@ -14,7 +14,8 @@ namespace nebula {
 namespace graph {
 
 PlanNode::PlanNode(int64_t id, Kind kind) : kind_(kind), id_(id) {
-    DCHECK_LE(id_, 0);
+    DCHECK_GE(id_, 0);
+    outputVar_ = folly::stringPrintf("__%s_%ld", toString(kind_), id_);
 }
 
 // static
@@ -112,11 +113,11 @@ const char* PlanNode::toString(PlanNode::Kind kind) {
         case Kind::kDropEdge:
             return "DropEdge";
         case Kind::kShowSpaces:
-            return "kShowSpaces";
+            return "ShowSpaces";
         case Kind::kShowTags:
-            return "kShowTags";
+            return "ShowTags";
         case Kind::kShowEdges:
-            return "kShowEdges";
+            return "ShowEdges";
         case Kind::kCreateSnapshot:
             return "CreateSnapshot";
         case Kind::kDropSnapshot:

--- a/src/planner/PlanNode.h
+++ b/src/planner/PlanNode.h
@@ -128,7 +128,6 @@ public:
 
     void setId(int64_t id) {
         id_ = id;
-        outputVar_ = folly::stringPrintf("__%s_%ld", toString(kind_), id_);
     }
 
     void setColNames(std::vector<std::string>&& cols) {
@@ -140,10 +139,6 @@ public:
     }
 
     static const char* toString(Kind kind);
-
-    const std::string& nodeLabel() const {
-        return outputVar_;
-    }
 
 protected:
     static void addDescription(std::string key, std::string value, cpp2::PlanNodeDescription* desc);

--- a/src/planner/PlanNode.h
+++ b/src/planner/PlanNode.h
@@ -9,7 +9,6 @@
 
 #include "common/base/Base.h"
 #include "common/expression/Expression.h"
-#include "util/IdGenerator.h"
 
 namespace nebula {
 namespace graph {
@@ -17,8 +16,6 @@ namespace graph {
 namespace cpp2 {
 class PlanNodeDescription;
 }   // namespace cpp2
-
-class ExecutionPlan;
 
 /**
  * PlanNode is an abstraction of nodes in an execution plan which
@@ -98,7 +95,7 @@ public:
         kGetConfig,
     };
 
-    PlanNode(ExecutionPlan* plan, Kind kind);
+    PlanNode(int64_t id, Kind kind);
 
     virtual ~PlanNode() = default;
 
@@ -121,10 +118,6 @@ public:
         return outputVar_;
     }
 
-    const ExecutionPlan* plan() const {
-        return plan_;
-    }
-
     std::vector<std::string> colNames() const {
         return colNames_;
     }
@@ -136,10 +129,6 @@ public:
     void setId(int64_t id) {
         id_ = id;
         outputVar_ = folly::stringPrintf("__%s_%ld", toString(kind_), id_);
-    }
-
-    void setPlan(ExecutionPlan* plan) {
-        plan_ = plan;
     }
 
     void setColNames(std::vector<std::string>&& cols) {
@@ -160,10 +149,8 @@ protected:
     static void addDescription(std::string key, std::string value, cpp2::PlanNodeDescription* desc);
 
     Kind                                     kind_{Kind::kUnknown};
-    int64_t                                  id_{IdGenerator::INVALID_ID};
-    ExecutionPlan*                           plan_{nullptr};
-    using VariableName = std::string;
-    VariableName                             outputVar_;
+    int64_t                                  id_{-1};
+    std::string                              outputVar_;
     std::vector<std::string>                 colNames_;
 };
 
@@ -184,8 +171,8 @@ public:
     }
 
 protected:
-    SingleDependencyNode(ExecutionPlan *plan, Kind kind, const PlanNode *dep)
-        : PlanNode(plan, kind), dependency_(dep) {}
+    SingleDependencyNode(int64_t id, Kind kind, const PlanNode* dep)
+        : PlanNode(id, kind), dependency_(dep) {}
 
     std::unique_ptr<cpp2::PlanNodeDescription> explain() const override;
 
@@ -205,8 +192,8 @@ public:
     std::unique_ptr<cpp2::PlanNodeDescription> explain() const override;
 
 protected:
-    SingleInputNode(ExecutionPlan* plan, Kind kind, const PlanNode* dep)
-        : SingleDependencyNode(plan, kind, dep) {
+    SingleInputNode(int64_t id, Kind kind, const PlanNode* dep)
+        : SingleDependencyNode(id, kind, dep) {
     }
 
     // Datasource for this node.
@@ -215,11 +202,11 @@ protected:
 
 class BiInputNode : public PlanNode {
 public:
-    void setLeft(PlanNode* left) {
+    void setLeft(const PlanNode* left) {
         left_ = left;
     }
 
-    void setRight(PlanNode* right) {
+    void setRight(const PlanNode* right) {
         right_ = right;
     }
 
@@ -250,12 +237,12 @@ public:
     std::unique_ptr<cpp2::PlanNodeDescription> explain() const override;
 
 protected:
-    BiInputNode(ExecutionPlan* plan, Kind kind, PlanNode* left, PlanNode* right)
-        : PlanNode(plan, kind), left_(left), right_(right) {
+    BiInputNode(int64_t id, Kind kind, PlanNode* left, PlanNode* right)
+        : PlanNode(id, kind), left_(left), right_(right) {
     }
 
-    PlanNode* left_{nullptr};
-    PlanNode* right_{nullptr};
+    const PlanNode* left_{nullptr};
+    const PlanNode* right_{nullptr};
     // Datasource for this node.
     std::string leftVar_;
     std::string rightVar_;

--- a/src/planner/test/ExecutionPlanTest.cpp
+++ b/src/planner/test/ExecutionPlanTest.cpp
@@ -52,25 +52,25 @@ protected:
 };
 
 TEST_F(ExecutionPlanTest, TestSimplePlan) {
-    auto start = StartNode::make(plan_);
+    auto start = StartNode::make(qctx_.get());
     Expression* expr = nullptr;
-    auto filter = Filter::make(plan_, start, expr);
-    auto dedup = Dedup::make(plan_, filter, nullptr);
+    auto filter = Filter::make(qctx_.get(), start, expr);
+    auto dedup = Dedup::make(qctx_.get(), filter, nullptr);
     YieldColumns* cols = nullptr;
-    auto proj = Project::make(plan_, dedup, cols);
+    auto proj = Project::make(qctx_.get(), dedup, cols);
     plan_->setRoot(proj);
 
     run();
 }
 
 TEST_F(ExecutionPlanTest, TestSelect) {
-    auto start = StartNode::make(plan_);
-    auto thenStart = StartNode::make(plan_);
-    auto filter = Filter::make(plan_, thenStart, nullptr);
-    auto elseStart = StartNode::make(plan_);
-    auto project = Project::make(plan_, elseStart, nullptr);
-    auto select = Selector::make(plan_, start, filter, project, nullptr);
-    auto output = Project::make(plan_, select, nullptr);
+    auto start = StartNode::make(qctx_.get());
+    auto thenStart = StartNode::make(qctx_.get());
+    auto filter = Filter::make(qctx_.get(), thenStart, nullptr);
+    auto elseStart = StartNode::make(qctx_.get());
+    auto project = Project::make(qctx_.get(), elseStart, nullptr);
+    auto select = Selector::make(qctx_.get(), start, filter, project, nullptr);
+    auto output = Project::make(qctx_.get(), select, nullptr);
 
     plan_->setRoot(output);
 
@@ -78,11 +78,11 @@ TEST_F(ExecutionPlanTest, TestSelect) {
 }
 
 TEST_F(ExecutionPlanTest, TestLoopPlan) {
-    auto start = StartNode::make(plan_);
-    auto bodyStart = StartNode::make(plan_);
-    auto filter = Filter::make(plan_, bodyStart, nullptr);
-    auto loop = Loop::make(plan_, start, filter, nullptr);
-    auto project = Project::make(plan_, loop, nullptr);
+    auto start = StartNode::make(qctx_.get());
+    auto bodyStart = StartNode::make(qctx_.get());
+    auto filter = Filter::make(qctx_.get(), bodyStart, nullptr);
+    auto loop = Loop::make(qctx_.get(), start, filter, nullptr);
+    auto project = Project::make(qctx_.get(), loop, nullptr);
 
     plan_->setRoot(project);
 
@@ -90,12 +90,12 @@ TEST_F(ExecutionPlanTest, TestLoopPlan) {
 }
 
 TEST_F(ExecutionPlanTest, TestMultiOutputs) {
-    auto start = StartNode::make(plan_);
-    auto mout = MultiOutputsNode::make(plan_, start);
-    auto filter = Filter::make(plan_, mout, nullptr);
-    auto project = Project::make(plan_, mout, nullptr);
-    auto uni = Union::make(plan_, filter, project);
-    auto output = Project::make(plan_, uni, nullptr);
+    auto start = StartNode::make(qctx_.get());
+    auto mout = MultiOutputsNode::make(qctx_.get(), start);
+    auto filter = Filter::make(qctx_.get(), mout, nullptr);
+    auto project = Project::make(qctx_.get(), mout, nullptr);
+    auto uni = Union::make(qctx_.get(), filter, project);
+    auto output = Project::make(qctx_.get(), uni, nullptr);
 
     plan_->setRoot(output);
 
@@ -103,15 +103,15 @@ TEST_F(ExecutionPlanTest, TestMultiOutputs) {
 }
 
 TEST_F(ExecutionPlanTest, TestMultiOutputsInLoop) {
-    auto loopStart = StartNode::make(plan_);
-    auto mout = MultiOutputsNode::make(plan_, loopStart);
-    auto filter = Filter::make(plan_, mout, nullptr);
-    auto project = Project::make(plan_, mout, nullptr);
-    auto uni = Union::make(plan_, filter, project);
-    auto loopEnd = Project::make(plan_, uni, nullptr);
-    auto start = StartNode::make(plan_);
-    auto loop = Loop::make(plan_, start, loopEnd, nullptr);
-    auto end = Project::make(plan_, loop, nullptr);
+    auto loopStart = StartNode::make(qctx_.get());
+    auto mout = MultiOutputsNode::make(qctx_.get(), loopStart);
+    auto filter = Filter::make(qctx_.get(), mout, nullptr);
+    auto project = Project::make(qctx_.get(), mout, nullptr);
+    auto uni = Union::make(qctx_.get(), filter, project);
+    auto loopEnd = Project::make(qctx_.get(), uni, nullptr);
+    auto start = StartNode::make(qctx_.get());
+    auto loop = Loop::make(qctx_.get(), start, loopEnd, nullptr);
+    auto end = Project::make(qctx_.get(), loop, nullptr);
 
     plan_->setRoot(end);
 

--- a/src/scheduler/Scheduler.cpp
+++ b/src/scheduler/Scheduler.cpp
@@ -25,7 +25,7 @@ Scheduler::PassThroughData::PassThroughData(int32_t outputs)
 Scheduler::Scheduler(QueryContext *qctx) : qctx_(DCHECK_NOTNULL(qctx)) {}
 
 folly::Future<Status> Scheduler::schedule() {
-    auto executor = Executor::makeExecutor(qctx_->plan()->root(), qctx_);
+    auto executor = Executor::create(qctx_->plan()->root(), qctx_);
     analyze(executor);
     return doSchedule(executor);
 }

--- a/src/util/IdGenerator.h
+++ b/src/util/IdGenerator.h
@@ -11,6 +11,7 @@
 
 namespace nebula {
 namespace graph {
+
 class IdGenerator {
 public:
     explicit IdGenerator(int64_t init = 0) : counter_(init) {
@@ -42,6 +43,7 @@ private:
 private:
     static EPIdGenerator instance_;
 };
+
 }  // namespace graph
 }  // namespace nebula
 #endif  // PLANNER_IDGENERATOR_H_

--- a/src/validator/AdminJobValidator.cpp
+++ b/src/validator/AdminJobValidator.cpp
@@ -15,8 +15,7 @@ Status AdminJobValidator::validateImpl() {
 }
 
 Status AdminJobValidator::toPlan() {
-    auto* plan = qctx_->plan();
-    auto *doNode = SubmitJob::make(plan, nullptr, sentence_->getType(), sentence_->getParas());
+    auto *doNode = SubmitJob::make(qctx_, nullptr, sentence_->getType(), sentence_->getParas());
     root_ = doNode;
     tail_ = root_;
     return Status::OK();

--- a/src/validator/AdminValidator.cpp
+++ b/src/validator/AdminValidator.cpp
@@ -106,8 +106,7 @@ Status CreateSpaceValidator::validateImpl() {
 }
 
 Status CreateSpaceValidator::toPlan() {
-    auto *plan = qctx_->plan();
-    auto *doNode = CreateSpace::make(plan, nullptr, std::move(spaceDesc_), ifNotExist_);
+    auto *doNode = CreateSpace::make(qctx_, nullptr, std::move(spaceDesc_), ifNotExist_);
     root_ = doNode;
     tail_ = root_;
     return Status::OK();
@@ -119,8 +118,7 @@ Status DescSpaceValidator::validateImpl() {
 
 Status DescSpaceValidator::toPlan() {
     auto sentence = static_cast<DescribeSpaceSentence*>(sentence_);
-    auto *plan = qctx_->plan();
-    auto *doNode = DescSpace::make(plan, nullptr, *sentence->spaceName());
+    auto *doNode = DescSpace::make(qctx_, nullptr, *sentence->spaceName());
     root_ = doNode;
     tail_ = root_;
     return Status::OK();
@@ -131,8 +129,7 @@ Status ShowSpacesValidator::validateImpl() {
 }
 
 Status ShowSpacesValidator::toPlan() {
-    auto *plan = qctx_->plan();
-    auto *doNode = ShowSpaces::make(plan, nullptr);
+    auto *doNode = ShowSpaces::make(qctx_, nullptr);
     root_ = doNode;
     tail_ = root_;
     return Status::OK();
@@ -143,9 +140,8 @@ Status DropSpaceValidator::validateImpl() {
 }
 
 Status DropSpaceValidator::toPlan() {
-    auto *plan = qctx_->plan();
     auto sentence = static_cast<DropSpaceSentence*>(sentence_);
-    auto *doNode = DropSpace::make(plan, nullptr, *sentence->spaceName(), sentence->isIfExists());
+    auto *doNode = DropSpace::make(qctx_, nullptr, *sentence->spaceName(), sentence->isIfExists());
     root_ = doNode;
     tail_ = root_;
     return Status::OK();
@@ -156,10 +152,9 @@ Status ShowCreateSpaceValidator::validateImpl() {
 }
 
 Status ShowCreateSpaceValidator::toPlan() {
-    auto* plan = qctx_->plan();
     auto sentence = static_cast<ShowCreateSpaceSentence*>(sentence_);
     auto spaceName = *sentence->spaceName();
-    auto *doNode = ShowCreateSpace::make(plan, nullptr, std::move(spaceName));
+    auto *doNode = ShowCreateSpace::make(qctx_, nullptr, std::move(spaceName));
     root_ = doNode;
     tail_ = root_;
     return Status::OK();
@@ -170,8 +165,7 @@ Status CreateSnapshotValidator::validateImpl() {
 }
 
 Status CreateSnapshotValidator::toPlan() {
-    auto* plan = qctx_->plan();
-    auto *doNode = CreateSnapshot::make(plan, nullptr);
+    auto *doNode = CreateSnapshot::make(qctx_, nullptr);
     root_ = doNode;
     tail_ = root_;
     return Status::OK();
@@ -182,9 +176,8 @@ Status DropSnapshotValidator::validateImpl() {
 }
 
 Status DropSnapshotValidator::toPlan() {
-    auto* plan = qctx_->plan();
     auto sentence = static_cast<DropSnapshotSentence*>(sentence_);
-    auto *doNode = DropSnapshot::make(plan, nullptr, *sentence->name());
+    auto *doNode = DropSnapshot::make(qctx_, nullptr, *sentence->name());
     root_ = doNode;
     tail_ = root_;
     return Status::OK();
@@ -195,8 +188,7 @@ Status ShowSnapshotsValidator::validateImpl() {
 }
 
 Status ShowSnapshotsValidator::toPlan() {
-    auto* plan = qctx_->plan();
-    auto *doNode = ShowSnapshots::make(plan, nullptr);
+    auto *doNode = ShowSnapshots::make(qctx_, nullptr);
     root_ = doNode;
     tail_ = root_;
     return Status::OK();
@@ -207,7 +199,7 @@ Status ShowHostsValidator::validateImpl() {
 }
 
 Status ShowHostsValidator::toPlan() {
-    auto *showHosts = ShowHosts::make(qctx_->plan(), nullptr);
+    auto *showHosts = ShowHosts::make(qctx_, nullptr);
     root_ = showHosts;
     tail_ = root_;
     return Status::OK();
@@ -218,13 +210,12 @@ Status ShowPartsValidator::validateImpl() {
 }
 
 Status ShowPartsValidator::toPlan() {
-    auto* plan = qctx_->plan();
     auto sentence = static_cast<ShowPartsSentence*>(sentence_);
     std::vector<PartitionID> partIds;
     if (sentence->getList() != nullptr) {
         partIds = *sentence->getList();
     }
-    auto *node = ShowParts::make(plan,
+    auto *node = ShowParts::make(qctx_,
                                  nullptr,
                                  vctx_->whichSpace().id,
                                  std::move(partIds));
@@ -238,8 +229,7 @@ Status ShowCharsetValidator::validateImpl() {
 }
 
 Status ShowCharsetValidator::toPlan() {
-    auto* plan = qctx_->plan();
-    auto *node = ShowCharset::make(plan, nullptr);
+    auto *node = ShowCharset::make(qctx_, nullptr);
     root_ = node;
     tail_ = root_;
     return Status::OK();
@@ -250,8 +240,7 @@ Status ShowCollationValidator::validateImpl() {
 }
 
 Status ShowCollationValidator::toPlan() {
-    auto* plan = qctx_->plan();
-    auto *node = ShowCollation::make(plan, nullptr);
+    auto *node = ShowCollation::make(qctx_, nullptr);
     root_ = node;
     tail_ = root_;
     return Status::OK();
@@ -270,8 +259,7 @@ Status ShowConfigsValidator::toPlan() {
     } else {
         module = meta::cpp2::ConfigModule::ALL;
     }
-    auto* plan = qctx_->plan();
-    auto *doNode = ShowConfigs::make(plan, nullptr, module);
+    auto *doNode = ShowConfigs::make(qctx_, nullptr, module);
     root_ = doNode;
     tail_ = root_;
     return Status::OK();
@@ -323,8 +311,7 @@ Status SetConfigValidator::validateImpl() {
 }
 
 Status SetConfigValidator::toPlan() {
-    auto* plan = qctx_->plan();
-    auto *doNode = SetConfig::make(plan,
+    auto *doNode = SetConfig::make(qctx_,
                                    nullptr,
                                    module_,
                                    std::move(name_),
@@ -350,8 +337,7 @@ Status GetConfigValidator::validateImpl() {
 }
 
 Status GetConfigValidator::toPlan() {
-    auto* plan = qctx_->plan();
-    auto *doNode = GetConfig::make(plan,
+    auto *doNode = GetConfig::make(qctx_,
                                    nullptr,
                                    module_,
                                    std::move(name_));

--- a/src/validator/BalanceValidator.cpp
+++ b/src/validator/BalanceValidator.cpp
@@ -13,25 +13,24 @@ namespace nebula {
 namespace graph {
 
 Status BalanceValidator::toPlan() {
-    auto* plan = qctx_->plan();
     PlanNode *current = nullptr;
     BalanceSentence *sentence = static_cast<BalanceSentence*>(sentence_);
     switch (sentence->subType()) {
     case BalanceSentence::SubType::kLeader:
-        current = BalanceLeaders::make(plan, nullptr);
+        current = BalanceLeaders::make(qctx_, nullptr);
         break;
     case BalanceSentence::SubType::kData:
-        current = Balance::make(plan,
+        current = Balance::make(qctx_,
                                 nullptr,
                                 sentence->hostDel() == nullptr
                                     ? std::vector<HostAddr>()
                                     : sentence->hostDel()->hosts());
         break;
     case BalanceSentence::SubType::kDataStop:
-        current = StopBalance::make(plan, nullptr);
+        current = StopBalance::make(qctx_, nullptr);
         break;
     case BalanceSentence::SubType::kShowBalancePlan:
-        current = ShowBalance::make(plan, nullptr, sentence->balanceId());
+        current = ShowBalance::make(qctx_, nullptr, sentence->balanceId());
         break;
     case BalanceSentence::SubType::kUnknown:
         // fallthrough

--- a/src/validator/GetSubgraphValidator.cpp
+++ b/src/validator/GetSubgraphValidator.cpp
@@ -186,7 +186,7 @@ Status GetSubgraphValidator::toPlan() {
 
     // collect(gn2._vids) as listofvids
     auto& listOfVids = varGen_->getVar();
-    columns = new YieldColumns();
+    columns = qctx_->objPool()->add(new YieldColumns());
     column = new YieldColumn(
             new VariablePropertyExpression(
                 new std::string(gn2->varGenerated()),
@@ -194,7 +194,7 @@ Status GetSubgraphValidator::toPlan() {
             new std::string(listOfVids));
     column->setFunction(new std::string("collect"));
     columns->addColumn(column);
-    auto* group = Aggregate::make(qctx_, gn2, plan->saveObject(columns));
+    auto* group = Aggregate::make(qctx_, gn2, columns);
 
     auto* filter = Filter::make(
                         qctx_,

--- a/src/validator/GetSubgraphValidator.cpp
+++ b/src/validator/GetSubgraphValidator.cpp
@@ -122,13 +122,12 @@ Status GetSubgraphValidator::validateBothInOutBound(BothInOutClause* out) {
 }
 
 Status GetSubgraphValidator::toPlan() {
-    auto* plan = qctx_->plan();
     auto& space = vctx_->whichSpace();
 
     //                           bodyStart->gn->project(dst)
     //                                            |
     // start [->previous] [-> project(input)] -> loop -> collect
-    auto* bodyStart = StartNode::make(plan);
+    auto* bodyStart = StartNode::make(qctx_);
 
     auto vertexProps = std::make_unique<std::vector<storage::cpp2::VertexProp>>();
     auto edgeProps = std::make_unique<std::vector<storage::cpp2::EdgeProp>>();
@@ -145,7 +144,7 @@ Status GetSubgraphValidator::toPlan() {
     }
 
     auto* gn1 = GetNeighbors::make(
-            plan,
+            qctx_,
             bodyStart,
             space.id,
             src_,
@@ -165,16 +164,16 @@ Status GetSubgraphValidator::toPlan() {
     // TODO(shylock) add condition when gn get empty result
     auto* condition = buildNStepLoopCondition(steps_);
     // The input of loop will set by father validator.
-    auto* loop = Loop::make(plan, nullptr, projectVids, condition);
+    auto* loop = Loop::make(qctx_, nullptr, projectVids, condition);
 
     /*
     // selector -> loop
     // selector -> filter -> gn2 -> ifStrart
-    auto* ifStart = StartNode::make(plan);
+    auto* ifStart = StartNode::make(qctx_);
 
     std::vector<Row> starts;
     auto* gn2 = GetNeighbors::make(
-            plan,
+            qctx_,
             ifStart,
             space.id,
             std::move(starts),
@@ -195,14 +194,14 @@ Status GetSubgraphValidator::toPlan() {
             new std::string(listOfVids));
     column->setFunction(new std::string("collect"));
     columns->addColumn(column);
-    auto* group = Aggregate::make(plan, gn2, plan->saveObject(columns));
+    auto* group = Aggregate::make(qctx_, gn2, plan->saveObject(columns));
 
     auto* filter = Filter::make(
-                        plan,
+                        qctx_,
                         group,
                         nullptr// TODO: build IN condition.
                         );
-    auto* selector = Selector::make(plan, loop, filter, nullptr, nullptr);
+    auto* selector = Selector::make(qctx_, loop, filter, nullptr, nullptr);
 
     // TODO: A data collector.
 
@@ -210,7 +209,7 @@ Status GetSubgraphValidator::toPlan() {
     tail_ = loop;
     */
     std::vector<std::string> collects = {gn1->varName()};
-    auto* dc = DataCollect::make(plan, loop,
+    auto* dc = DataCollect::make(qctx_, loop,
             DataCollect::CollectKind::kSubgraph, std::move(collects));
     dc->setColNames({"_vertices", "_edges"});
     root_ = dc;

--- a/src/validator/GroupByValidator.cpp
+++ b/src/validator/GroupByValidator.cpp
@@ -143,9 +143,7 @@ Status GroupByValidator::validateGroup(const GroupClause *groupClause) {
 }
 
 Status GroupByValidator::toPlan() {
-    auto *plan = qctx_->plan();
-    auto *groupBy =
-        Aggregate::make(plan, nullptr, std::move(groupKeys_), std::move(groupItems_));
+    auto *groupBy = Aggregate::make(qctx_, nullptr, std::move(groupKeys_), std::move(groupItems_));
     groupBy->setColNames(std::vector<std::string>(outputColumnNames_));
     root_ = groupBy;
     tail_ = groupBy;

--- a/src/validator/LimitValidator.cpp
+++ b/src/validator/LimitValidator.cpp
@@ -27,7 +27,7 @@ Status LimitValidator::validateImpl() {
 
 Status LimitValidator::toPlan() {
     auto* plan = qctx_->plan();
-    auto *limitNode = Limit::make(plan, plan->root(), offset_, count_);
+    auto *limitNode = Limit::make(qctx_, plan->root(), offset_, count_);
     std::vector<std::string> colNames;
     for (auto &col : outputs_) {
         colNames.emplace_back(col.first);

--- a/src/validator/MaintainValidator.cpp
+++ b/src/validator/MaintainValidator.cpp
@@ -51,7 +51,7 @@ Status CreateTagValidator::validateImpl() {
 
 Status CreateTagValidator::toPlan() {
     auto *plan = qctx_->plan();
-    auto doNode = CreateTag::make(plan,
+    auto doNode = CreateTag::make(qctx_,
             plan->root(), std::move(name_), std::move(schema_), ifNotExist_);
     root_ = doNode;
     tail_ = root_;
@@ -94,7 +94,7 @@ Status CreateEdgeValidator::validateImpl() {
 
 Status CreateEdgeValidator::toPlan() {
     auto *plan = qctx_->plan();
-    auto doNode = CreateEdge::make(plan,
+    auto doNode = CreateEdge::make(qctx_,
             plan->root(), std::move(name_), std::move(schema_), ifNotExist_);
     root_ = doNode;
     tail_ = root_;
@@ -108,8 +108,7 @@ Status DescTagValidator::validateImpl() {
 Status DescTagValidator::toPlan() {
     auto sentence = static_cast<DescribeTagSentence*>(sentence_);
     auto name = *sentence->name();
-    auto *plan = qctx_->plan();
-    auto doNode = DescTag::make(plan, nullptr, std::move(name));
+    auto doNode = DescTag::make(qctx_, nullptr, std::move(name));
     root_ = doNode;
     tail_ = root_;
     return Status::OK();
@@ -122,8 +121,7 @@ Status DescEdgeValidator::validateImpl() {
 Status DescEdgeValidator::toPlan() {
     auto sentence = static_cast<DescribeEdgeSentence*>(sentence_);
     auto name = *sentence->name();
-    auto *plan = qctx_->plan();
-    auto doNode = DescEdge::make(plan, nullptr, std::move(name));
+    auto doNode = DescEdge::make(qctx_, nullptr, std::move(name));
     root_ = doNode;
     tail_ = root_;
     return Status::OK();
@@ -202,8 +200,7 @@ Status AlterTagValidator::validateImpl() {
 }
 
 Status AlterTagValidator::toPlan() {
-    auto* plan = qctx_->plan();
-    auto *doNode = AlterTag::make(plan,
+    auto *doNode = AlterTag::make(qctx_,
                                   nullptr,
                                   vctx_->whichSpace().id,
                                   std::move(name_),
@@ -221,8 +218,7 @@ Status AlterEdgeValidator::validateImpl() {
 }
 
 Status AlterEdgeValidator::toPlan() {
-    auto* plan = qctx_->plan();
-    auto *doNode = AlterEdge::make(plan,
+    auto *doNode = AlterEdge::make(qctx_,
                                    nullptr,
                                    vctx_->whichSpace().id,
                                    std::move(name_),
@@ -238,8 +234,7 @@ Status ShowTagsValidator::validateImpl() {
 }
 
 Status ShowTagsValidator::toPlan() {
-    auto* plan = qctx_->plan();
-    auto *doNode = ShowTags::make(plan, nullptr);
+    auto *doNode = ShowTags::make(qctx_, nullptr);
     root_ = doNode;
     tail_ = root_;
     return Status::OK();
@@ -250,8 +245,7 @@ Status ShowEdgesValidator::validateImpl() {
 }
 
 Status ShowEdgesValidator::toPlan() {
-    auto* plan = qctx_->plan();
-    auto *doNode = ShowEdges::make(plan, nullptr);
+    auto *doNode = ShowEdges::make(qctx_, nullptr);
     root_ = doNode;
     tail_ = root_;
     return Status::OK();
@@ -263,8 +257,7 @@ Status ShowCreateTagValidator::validateImpl() {
 
 Status ShowCreateTagValidator::toPlan() {
     auto sentence = static_cast<ShowCreateTagSentence*>(sentence_);
-    auto* plan = qctx_->plan();
-    auto *doNode = ShowCreateTag::make(plan,
+    auto *doNode = ShowCreateTag::make(qctx_,
                                        nullptr,
                                       *sentence->name());
     root_ = doNode;
@@ -278,8 +271,7 @@ Status ShowCreateEdgeValidator::validateImpl() {
 
 Status ShowCreateEdgeValidator::toPlan() {
     auto sentence = static_cast<ShowCreateEdgeSentence*>(sentence_);
-    auto* plan = qctx_->plan();
-    auto *doNode = ShowCreateEdge::make(plan,
+    auto *doNode = ShowCreateEdge::make(qctx_,
                                         nullptr,
                                        *sentence->name());
     root_ = doNode;
@@ -293,8 +285,7 @@ Status DropTagValidator::validateImpl() {
 
 Status DropTagValidator::toPlan() {
     auto sentence = static_cast<DropTagSentence*>(sentence_);
-    auto* plan = qctx_->plan();
-    auto *doNode = DropTag::make(plan,
+    auto *doNode = DropTag::make(qctx_,
                                  nullptr,
                                 *sentence->name(),
                                  sentence->isIfExists());
@@ -309,8 +300,7 @@ Status DropEdgeValidator::validateImpl() {
 
 Status DropEdgeValidator::toPlan() {
     auto sentence = static_cast<DropEdgeSentence*>(sentence_);
-    auto* plan = qctx_->plan();
-    auto *doNode = DropEdge::make(plan,
+    auto *doNode = DropEdge::make(qctx_,
                                   nullptr,
                                  *sentence->name(),
                                   sentence->isIfExists());

--- a/src/validator/MutateValidator.cpp
+++ b/src/validator/MutateValidator.cpp
@@ -330,7 +330,7 @@ std::string DeleteVerticesValidator::buildVIds() {
     auto* vIds = new VariablePropertyExpression(
             new std::string(input),
             new std::string(kVid));
-    qctx_->plan()->saveObject(vIds);
+    qctx_->objPool()->add(vIds);
     vidRef_ = vIds;
     return input;
 }
@@ -353,7 +353,7 @@ Status DeleteVerticesValidator::toPlan() {
                 new EdgeDstIdExpression(new std::string(name)),
                 new EdgeRankExpression(new std::string(name)));
         edgeKeyRef->setType(new EdgeTypeExpression(new std::string(name)));
-        qctx_->plan()->saveObject(edgeKeyRef);
+        qctx_->objPool()->add(edgeKeyRef);
         edgeKeyRefs_.emplace_back(edgeKeyRef);
 
         storage::cpp2::EdgeProp edgeProp;
@@ -459,7 +459,7 @@ Status DeleteEdgesValidator::buildEdgeKeyRef(const std::vector<EdgeKey*> &edgeKe
     auto* dstIdExpr = new InputPropertyExpression(new std::string(kDst));
     auto* edgeKeyRef = new EdgeKeyRef(srcIdExpr, dstIdExpr, rankExpr);
     edgeKeyRef->setType(typeExpr);
-    qctx_->plan()->saveObject(edgeKeyRef);
+    qctx_->objPool()->add(edgeKeyRef);
 
     edgeKeyRefs_.emplace_back(edgeKeyRef);
     return Status::OK();

--- a/src/validator/MutateValidator.cpp
+++ b/src/validator/MutateValidator.cpp
@@ -27,8 +27,7 @@ Status InsertVerticesValidator::validateImpl() {
 }
 
 Status InsertVerticesValidator::toPlan() {
-    auto *plan = qctx_->plan();
-    auto doNode = InsertVertices::make(plan,
+    auto doNode = InsertVertices::make(qctx_,
                                        nullptr,
                                        spaceId_,
                                        std::move(vertices_),
@@ -161,8 +160,7 @@ Status InsertEdgesValidator::validateImpl() {
 }
 
 Status InsertEdgesValidator::toPlan() {
-    auto *plan = qctx_->plan();
-    auto doNode = InsertEdges::make(plan,
+    auto doNode = InsertEdges::make(qctx_,
                                     nullptr,
                                     spaceId_,
                                     std::move(edges_),
@@ -338,7 +336,6 @@ std::string DeleteVerticesValidator::buildVIds() {
 }
 
 Status DeleteVerticesValidator::toPlan() {
-    auto plan = qctx_->plan();
     std::string vidVar;
     if (!vertices_.empty() && vidRef_ == nullptr) {
         vidVar = buildVIds();
@@ -376,7 +373,7 @@ Status DeleteVerticesValidator::toPlan() {
     auto edgePropsPtr = std::make_unique<std::vector<storage::cpp2::EdgeProp>>(edgeProps);
     auto statPropsPtr = std::make_unique<std::vector<storage::cpp2::StatProp>>();
     auto exprPtr = std::make_unique<std::vector<storage::cpp2::Expr>>();
-    auto* getNeighbors = GetNeighbors::make(plan,
+    auto* getNeighbors = GetNeighbors::make(qctx_,
                                             nullptr,
                                             spaceId_,
                                             vidRef_,
@@ -389,14 +386,14 @@ Status DeleteVerticesValidator::toPlan() {
     getNeighbors->setInputVar(vidVar);
 
     // create deleteEdges node
-    auto *deNode = DeleteEdges::make(plan,
+    auto *deNode = DeleteEdges::make(qctx_,
                                      getNeighbors,
                                      spaceId_,
                                      std::move(edgeKeyRefs_));
 
     deNode->setInputVar(getNeighbors->varName());
 
-    auto *dvNode = DeleteVertices::make(plan,
+    auto *dvNode = DeleteVertices::make(qctx_,
                                         deNode,
                                         spaceId_,
                                         vidRef_);
@@ -504,8 +501,7 @@ Status DeleteEdgesValidator::checkInput() {
 }
 
 Status DeleteEdgesValidator::toPlan() {
-    auto* plan = qctx_->plan();
-    auto *doNode = DeleteEdges::make(plan,
+    auto *doNode = DeleteEdges::make(qctx_,
                                      nullptr,
                                      vctx_->whichSpace().id,
                                      edgeKeyRefs_);
@@ -772,8 +768,7 @@ Status UpdateVertexValidator::validateImpl() {
 }
 
 Status UpdateVertexValidator::toPlan() {
-    auto* plan = qctx_->plan();
-    auto *update = UpdateVertex::make(plan,
+    auto *update = UpdateVertex::make(qctx_,
                                       nullptr,
                                       spaceId_,
                                       std::move(name_),
@@ -815,8 +810,7 @@ Status UpdateEdgeValidator::validateImpl() {
 }
 
 Status UpdateEdgeValidator::toPlan() {
-    auto* plan = qctx_->plan();
-    auto *outNode = UpdateEdge::make(plan,
+    auto *outNode = UpdateEdge::make(qctx_,
                                      nullptr,
                                      spaceId_,
                                      name_,
@@ -830,7 +824,7 @@ Status UpdateEdgeValidator::toPlan() {
                                      condition_,
                                      {});
 
-    auto *inNode = UpdateEdge::make(plan,
+    auto *inNode = UpdateEdge::make(qctx_,
                                     outNode,
                                     spaceId_,
                                     std::move(name_),

--- a/src/validator/OrderByValidator.cpp
+++ b/src/validator/OrderByValidator.cpp
@@ -30,7 +30,7 @@ Status OrderByValidator::validateImpl() {
 
 Status OrderByValidator::toPlan() {
     auto* plan = qctx_->plan();
-    auto *sortNode = Sort::make(plan, plan->root(), std::move(colOrderTypes_));
+    auto *sortNode = Sort::make(qctx_, plan->root(), std::move(colOrderTypes_));
     std::vector<std::string> colNames;
     for (auto &col : outputs_) {
         colNames.emplace_back(col.first);

--- a/src/validator/SetValidator.cpp
+++ b/src/validator/SetValidator.cpp
@@ -38,7 +38,6 @@ Status SetValidator::validateImpl() {
 }
 
 Status SetValidator::toPlan() {
-    auto plan = qctx_->plan();
     auto setSentence = static_cast<const SetSentence *>(sentence_);
     auto lRoot = DCHECK_NOTNULL(lValidator_->root());
     auto rRoot = DCHECK_NOTNULL(rValidator_->root());
@@ -46,10 +45,10 @@ Status SetValidator::toPlan() {
     BiInputNode *bNode = nullptr;
     switch (setSentence->op()) {
         case SetSentence::Operator::UNION: {
-            bNode = Union::make(plan, lRoot, rRoot);
+            bNode = Union::make(qctx_, lRoot, rRoot);
             bNode->setColNames(std::move(colNames));
             if (setSentence->distinct()) {
-                auto dedup = Dedup::make(plan, bNode);
+                auto dedup = Dedup::make(qctx_, bNode);
                 dedup->setInputVar(bNode->varName());
                 dedup->setColNames(bNode->colNames());
                 root_ = dedup;
@@ -59,13 +58,13 @@ Status SetValidator::toPlan() {
             break;
         }
         case SetSentence::Operator::INTERSECT: {
-            bNode = Intersect::make(plan, lRoot, rRoot);
+            bNode = Intersect::make(qctx_, lRoot, rRoot);
             bNode->setColNames(std::move(colNames));
             root_ = bNode;
             break;
         }
         case SetSentence::Operator::MINUS: {
-            bNode = Minus::make(plan, lRoot, rRoot);
+            bNode = Minus::make(qctx_, lRoot, rRoot);
             bNode->setColNames(std::move(colNames));
             root_ = bNode;
             break;
@@ -77,7 +76,7 @@ Status SetValidator::toPlan() {
     bNode->setLeftVar(lRoot->varName());
     bNode->setRightVar(rRoot->varName());
 
-    tail_ = PassThroughNode::make(plan, nullptr);
+    tail_ = PassThroughNode::make(qctx_, nullptr);
     NG_RETURN_IF_ERROR(lValidator_->appendPlan(tail_));
     NG_RETURN_IF_ERROR(rValidator_->appendPlan(tail_));
     return Status::OK();

--- a/src/validator/TraversalValidator.cpp
+++ b/src/validator/TraversalValidator.cpp
@@ -108,7 +108,7 @@ PlanNode* TraversalValidator::projectDstVidsFromGN(PlanNode* gn, const std::stri
         columns->addColumn(column);
     }
 
-    project = Project::make(plan, gn, plan->saveObject(columns));
+    project = Project::make(qctx_, gn, plan->saveObject(columns));
     project->setInputVar(gn->varName());
     project->setColNames(deduceColNames(columns));
     VLOG(1) << project->varName();
@@ -145,7 +145,7 @@ PlanNode* TraversalValidator::buildRuntimeInput() {
     auto* column = new YieldColumn(decode.release(), new std::string(kVid));
     columns->addColumn(column);
     auto plan = qctx_->plan();
-    auto* project = Project::make(plan, nullptr, plan->saveObject(columns));
+    auto* project = Project::make(qctx_, nullptr, plan->saveObject(columns));
     if (fromType_ == kVariable) {
         project->setInputVar(userDefinedVarName_);
     }

--- a/src/validator/TraversalValidator.cpp
+++ b/src/validator/TraversalValidator.cpp
@@ -93,8 +93,7 @@ Status TraversalValidator::validateFrom(const FromClause* from) {
 
 PlanNode* TraversalValidator::projectDstVidsFromGN(PlanNode* gn, const std::string& outputVar) {
     Project* project = nullptr;
-    auto* plan = qctx_->plan();
-    auto* columns = new YieldColumns();
+    auto* columns = qctx_->objPool()->add(new YieldColumns());
     auto* column = new YieldColumn(
         new EdgePropertyExpression(new std::string("*"), new std::string(kDst)),
         new std::string(kVid));
@@ -108,12 +107,12 @@ PlanNode* TraversalValidator::projectDstVidsFromGN(PlanNode* gn, const std::stri
         columns->addColumn(column);
     }
 
-    project = Project::make(qctx_, gn, plan->saveObject(columns));
+    project = Project::make(qctx_, gn, columns);
     project->setInputVar(gn->varName());
     project->setColNames(deduceColNames(columns));
     VLOG(1) << project->varName();
 
-    auto* dedupDstVids = Dedup::make(plan, project);
+    auto* dedupDstVids = Dedup::make(qctx_, project);
     dedupDstVids->setInputVar(project->varName());
     dedupDstVids->setOutputVar(outputVar);
     dedupDstVids->setColNames(project->colNames());
@@ -133,27 +132,27 @@ std::string TraversalValidator::buildConstantInput() {
 
     auto* vids = new VariablePropertyExpression(new std::string(input),
                                                 new std::string(kVid));
-    qctx_->plan()->saveObject(vids);
+    qctx_->objPool()->add(vids);
     src_ = vids;
     return input;
 }
 
 PlanNode* TraversalValidator::buildRuntimeInput() {
-    auto* columns = new YieldColumns();
+    auto pool = qctx_->objPool();
+    auto* columns = pool->add(new YieldColumns());
     auto encode = srcRef_->encode();
     auto decode = Expression::decode(encode);
     auto* column = new YieldColumn(decode.release(), new std::string(kVid));
     columns->addColumn(column);
-    auto plan = qctx_->plan();
-    auto* project = Project::make(qctx_, nullptr, plan->saveObject(columns));
+    auto* project = Project::make(qctx_, nullptr, columns);
     if (fromType_ == kVariable) {
         project->setInputVar(userDefinedVarName_);
     }
     project->setColNames({ kVid });
     VLOG(1) << project->varName() << " input: " << project->inputVar();
-    src_ = plan->saveObject(new InputPropertyExpression(new std::string(kVid)));
+    src_ = pool->add(new InputPropertyExpression(new std::string(kVid)));
 
-    auto* dedupVids = Dedup::make(plan, project);
+    auto* dedupVids = Dedup::make(qctx_, project);
     dedupVids->setInputVar(project->varName());
     dedupVids->setColNames(project->colNames());
 
@@ -166,17 +165,13 @@ Expression* TraversalValidator::buildNStepLoopCondition(uint32_t steps) const {
     // ++loopSteps{0} <= steps
     auto loopSteps = vctx_->anonVarGen()->getVar();
     qctx_->ectx()->setValue(loopSteps, 0);
-    auto* condition = new RelationalExpression(
+    return qctx_->objPool()->add(new RelationalExpression(
         Expression::Kind::kRelLE,
         new UnaryExpression(
             Expression::Kind::kUnaryIncr,
-            new VersionedVariableExpression(new std::string(loopSteps),
-                                            new ConstantExpression(0))),
-        new ConstantExpression(static_cast<int32_t>(steps)));
-    qctx_->plan()->saveObject(condition);
-    return condition;
+            new VersionedVariableExpression(new std::string(loopSteps), new ConstantExpression(0))),
+        new ConstantExpression(static_cast<int32_t>(steps))));
 }
-
 
 }  // namespace graph
 }  // namespace nebula

--- a/src/validator/UseValidator.cpp
+++ b/src/validator/UseValidator.cpp
@@ -32,9 +32,8 @@ Status UseValidator::validateImpl() {
 
 Status UseValidator::toPlan() {
     // The input will be set by father validator later.
-    auto plan = qctx_->plan();
-    auto *start = StartNode::make(plan);
-    auto reg = SwitchSpace::make(plan, start, *spaceName_);
+    auto *start = StartNode::make(qctx_);
+    auto reg = SwitchSpace::make(qctx_, start, *spaceName_);
     root_ = reg;
     tail_ = root_;
     return Status::OK();

--- a/src/validator/Validator.h
+++ b/src/validator/Validator.h
@@ -149,8 +149,7 @@ protected:
     // use for simple Plan only contain one node
     template <typename Node, typename... Args>
     Status genSingleNodePlan(Args... args) {
-        auto* plan = qctx_->plan();
-        auto *doNode = Node::make(plan, nullptr, std::forward<Args>(args)...);
+        auto *doNode = Node::make(qctx_, nullptr, std::forward<Args>(args)...);
         root_ = doNode;
         tail_ = root_;
         return Status::OK();

--- a/src/validator/test/ACLValidatorTest.cpp
+++ b/src/validator/test/ACLValidatorTest.cpp
@@ -15,7 +15,7 @@ class ACLValidatorTest : public ValidatorTestBase {
 protected:
     const PlanNode *getPlanRoot(const std::string query) {
         auto qctxStatus = validate(query);
-        ASSERT_TRUE(qctxStatus);
+        EXPECT_TRUE(qctxStatus);
         auto qctx = std::move(qctxStatus).value();
         return qctx->plan()->root();
     }

--- a/src/validator/test/ACLValidatorTest.cpp
+++ b/src/validator/test/ACLValidatorTest.cpp
@@ -12,6 +12,13 @@ namespace graph {
 
 
 class ACLValidatorTest : public ValidatorTestBase {
+protected:
+    const PlanNode *getPlanRoot(const std::string query) {
+        auto qctxStatus = validate(query);
+        ASSERT_TRUE(qctxStatus);
+        auto qctx = std::move(qctxStatus).value();
+        return qctx->plan()->root();
+    }
 };
 
 TEST_F(ACLValidatorTest, Simple) {
@@ -22,49 +29,42 @@ TEST_F(ACLValidatorTest, Simple) {
     constexpr char space[] = "test_space";
     // create user
     {
-        const ExecutionPlan *plan = toPlan(folly::stringPrintf("CREATE USER %s", user));
-
+        auto root = getPlanRoot(folly::stringPrintf("CREATE USER %s", user));
         std::vector<PlanNode::Kind> expectedTop {
             PlanNode::Kind::kCreateUser,
             PlanNode::Kind::kStart,
         };
-        ASSERT_TRUE(verifyPlan(plan->root(), expectedTop));
+        ASSERT_TRUE(verifyPlan(root, expectedTop));
 
-        auto root = plan->root();
         ASSERT_EQ(root->kind(), PlanNode::Kind::kCreateUser);
-        auto createUser = static_cast<const CreateUser*>(root);
+        auto createUser = static_cast<const CreateUser *>(root);
         ASSERT_FALSE(createUser->ifNotExist());
         ASSERT_EQ(*createUser->username(), user);
         ASSERT_EQ(*createUser->password(), "");
     }
-    {  // if not exists
-        const ExecutionPlan *plan =
-            toPlan(folly::stringPrintf("CREATE USER IF NOT EXISTS %s", user));
-
-        std::vector<PlanNode::Kind> expectedTop {
+    {   // if not exists
+        auto root = getPlanRoot(folly::stringPrintf("CREATE USER IF NOT EXISTS %s", user));
+        std::vector<PlanNode::Kind> expectedTop{
             PlanNode::Kind::kCreateUser,
             PlanNode::Kind::kStart,
         };
-        ASSERT_TRUE(verifyPlan(plan->root(), expectedTop));
+        ASSERT_TRUE(verifyPlan(root, expectedTop));
 
-        auto root = plan->root();
         ASSERT_EQ(root->kind(), PlanNode::Kind::kCreateUser);
-        auto createUser = static_cast<const CreateUser*>(root);
+        auto createUser = static_cast<const CreateUser *>(root);
         ASSERT_TRUE(createUser->ifNotExist());
         ASSERT_EQ(*createUser->username(), user);
         ASSERT_EQ(*createUser->password(), "");
     }
-    {  // with password
-        const ExecutionPlan *plan =
-            toPlan(folly::stringPrintf("CREATE USER %s WITH PASSWORD \"%s\"", user, password));
-
+    {   // with password
+        auto root =
+            getPlanRoot(folly::stringPrintf("CREATE USER %s WITH PASSWORD \"%s\"", user, password));
         std::vector<PlanNode::Kind> expectedTop {
             PlanNode::Kind::kCreateUser,
             PlanNode::Kind::kStart,
         };
-        ASSERT_TRUE(verifyPlan(plan->root(), expectedTop));
+        ASSERT_TRUE(verifyPlan(root, expectedTop));
 
-        auto root = plan->root();
         ASSERT_EQ(root->kind(), PlanNode::Kind::kCreateUser);
         auto createUser = static_cast<const CreateUser*>(root);
         ASSERT_FALSE(createUser->ifNotExist());
@@ -74,30 +74,26 @@ TEST_F(ACLValidatorTest, Simple) {
 
     // drop user
     {
-        const ExecutionPlan *plan = toPlan(folly::stringPrintf("DROP USER %s", user));
-
+        auto root = getPlanRoot(folly::stringPrintf("DROP USER %s", user));
         std::vector<PlanNode::Kind> expectedTop {
             PlanNode::Kind::kDropUser,
             PlanNode::Kind::kStart,
         };
-        ASSERT_TRUE(verifyPlan(plan->root(), expectedTop));
+        ASSERT_TRUE(verifyPlan(root, expectedTop));
 
-        auto root = plan->root();
         ASSERT_EQ(root->kind(), PlanNode::Kind::kDropUser);
         auto dropUser = static_cast<const DropUser*>(root);
         ASSERT_FALSE(dropUser->ifExist());
         ASSERT_EQ(*dropUser->username(), user);
     }
     {  // if exits
-        const ExecutionPlan *plan = toPlan(folly::stringPrintf("DROP USER IF EXISTS %s", user));
-
+        auto root = getPlanRoot(folly::stringPrintf("DROP USER IF EXISTS %s", user));
         std::vector<PlanNode::Kind> expectedTop {
             PlanNode::Kind::kDropUser,
             PlanNode::Kind::kStart,
         };
-        ASSERT_TRUE(verifyPlan(plan->root(), expectedTop));
+        ASSERT_TRUE(verifyPlan(root, expectedTop));
 
-        auto root = plan->root();
         ASSERT_EQ(root->kind(), PlanNode::Kind::kDropUser);
         auto dropUser = static_cast<const DropUser*>(root);
         ASSERT_TRUE(dropUser->ifExist());
@@ -106,16 +102,14 @@ TEST_F(ACLValidatorTest, Simple) {
 
     // update user
     {
-        const ExecutionPlan *plan =
-            toPlan(folly::stringPrintf("ALTER USER %s WITH PASSWORD \"%s\"", user, password));
-
-        std::vector<PlanNode::Kind> expectedTop {
+        auto root =
+            getPlanRoot(folly::stringPrintf("ALTER USER %s WITH PASSWORD \"%s\"", user, password));
+        std::vector<PlanNode::Kind> expectedTop{
             PlanNode::Kind::kUpdateUser,
             PlanNode::Kind::kStart,
         };
-        ASSERT_TRUE(verifyPlan(plan->root(), expectedTop));
+        ASSERT_TRUE(verifyPlan(root, expectedTop));
 
-        auto root = plan->root();
         ASSERT_EQ(root->kind(), PlanNode::Kind::kUpdateUser);
         auto updateUser = static_cast<const UpdateUser*>(root);
         ASSERT_EQ(*updateUser->username(), user);
@@ -124,27 +118,25 @@ TEST_F(ACLValidatorTest, Simple) {
 
     // show users
     {
-        const ExecutionPlan *plan = toPlan("SHOW USERS");
-
+        auto root = getPlanRoot("SHOW USERS");
         std::vector<PlanNode::Kind> expectedTop {
             PlanNode::Kind::kListUsers,
             PlanNode::Kind::kStart,
         };
-        ASSERT_TRUE(verifyPlan(plan->root(), expectedTop));
+        ASSERT_TRUE(verifyPlan(root, expectedTop));
     }
 
     // change password
     {
-        const ExecutionPlan *plan = toPlan(folly::stringPrintf(
+        auto root = getPlanRoot(folly::stringPrintf(
             "CHANGE PASSWORD %s FROM \"%s\" TO \"%s\"", user, password, newPassword));
 
         std::vector<PlanNode::Kind> expectedTop {
             PlanNode::Kind::kChangePassword,
             PlanNode::Kind::kStart,
         };
-        ASSERT_TRUE(verifyPlan(plan->root(), expectedTop));
+        ASSERT_TRUE(verifyPlan(root, expectedTop));
 
-        auto root = plan->root();
         ASSERT_EQ(root->kind(), PlanNode::Kind::kChangePassword);
         auto changePassword = static_cast<const ChangePassword*>(root);
         ASSERT_EQ(*changePassword->username(), user);
@@ -154,16 +146,15 @@ TEST_F(ACLValidatorTest, Simple) {
 
     // grant role
     {
-        const ExecutionPlan *plan =
-            toPlan(folly::stringPrintf("GRANT ROLE %s ON %s TO %s", roleTypeName, space, user));
+        auto root = getPlanRoot(
+            folly::stringPrintf("GRANT ROLE %s ON %s TO %s", roleTypeName, space, user));
 
         std::vector<PlanNode::Kind> expectedTop {
             PlanNode::Kind::kGrantRole,
             PlanNode::Kind::kStart,
         };
-        ASSERT_TRUE(verifyPlan(plan->root(), expectedTop));
+        ASSERT_TRUE(verifyPlan(root, expectedTop));
 
-        auto root = plan->root();
         ASSERT_EQ(root->kind(), PlanNode::Kind::kGrantRole);
         auto grantRole = static_cast<const GrantRole*>(root);
         ASSERT_EQ(*grantRole->username(), user);
@@ -173,16 +164,15 @@ TEST_F(ACLValidatorTest, Simple) {
 
     // revoke role
     {
-        const ExecutionPlan *plan =
-            toPlan(folly::stringPrintf("REVOKE ROLE %s ON %s FROM %s", roleTypeName, space, user));
+        auto root = getPlanRoot(
+            folly::stringPrintf("REVOKE ROLE %s ON %s FROM %s", roleTypeName, space, user));
 
         std::vector<PlanNode::Kind> expectedTop {
             PlanNode::Kind::kRevokeRole,
             PlanNode::Kind::kStart,
         };
-        ASSERT_TRUE(verifyPlan(plan->root(), expectedTop));
+        ASSERT_TRUE(verifyPlan(root, expectedTop));
 
-        auto root = plan->root();
         ASSERT_EQ(root->kind(), PlanNode::Kind::kRevokeRole);
         auto revokeRole = static_cast<const RevokeRole*>(root);
         ASSERT_EQ(*revokeRole->username(), user);
@@ -192,15 +182,14 @@ TEST_F(ACLValidatorTest, Simple) {
 
     // show roles in space
     {
-        const ExecutionPlan *plan = toPlan(folly::stringPrintf("SHOW ROLES IN %s", space));
+        auto root = getPlanRoot(folly::stringPrintf("SHOW ROLES IN %s", space));
 
         std::vector<PlanNode::Kind> expectedTop {
             PlanNode::Kind::kListRoles,
             PlanNode::Kind::kStart,
         };
-        ASSERT_TRUE(verifyPlan(plan->root(), expectedTop));
+        ASSERT_TRUE(verifyPlan(root, expectedTop));
 
-        auto root = plan->root();
         ASSERT_EQ(root->kind(), PlanNode::Kind::kListRoles);
         auto showRoles = static_cast<const ListRoles*>(root);
         ASSERT_EQ(showRoles->space(), 1);

--- a/src/validator/test/FetchEdgesTest.cpp
+++ b/src/validator/test/FetchEdgesTest.cpp
@@ -11,7 +11,14 @@
 namespace nebula {
 namespace graph {
 
-class FetchEdgesValidatorTest : public ValidatorTestBase {};
+class FetchEdgesValidatorTest : public ValidatorTestBase {
+protected:
+    QueryContext *getQCtx(const std::string &query) {
+        auto status = validate(query);
+        ASSERT_TRUE(status);
+        return std::move(status).value();
+    }
+};
 
 TEST_F(FetchEdgesValidatorTest, FetchEdgesProp) {
     auto src = std::make_unique<VariablePropertyExpression>(new std::string("_VAR1_"),
@@ -23,10 +30,9 @@ TEST_F(FetchEdgesValidatorTest, FetchEdgesProp) {
     auto dst = std::make_unique<VariablePropertyExpression>(new std::string("_VAR4_"),
                                                             new std::string(kDst));
     {
-        auto plan = toPlan("FETCH PROP ON like \"1\"->\"2\"");
+        auto qctx = getQCtx("FETCH PROP ON like \"1\"->\"2\"");
 
-        ExecutionPlan expectedPlan(pool_.get());
-        auto *start = StartNode::make(&expectedPlan);
+        auto *start = StartNode::make(qctx);
 
         auto edgeTypeResult = schemaMng_->toEdgeType(1, "like");
         ASSERT_TRUE(edgeTypeResult.ok());
@@ -36,7 +42,7 @@ TEST_F(FetchEdgesValidatorTest, FetchEdgesProp) {
         prop.set_props({kSrc, kDst, kRank, "start", "end", "likeness"});
         std::vector<storage::cpp2::EdgeProp> props;
         props.emplace_back(std::move(prop));
-        auto *ge = GetEdges::make(&expectedPlan,
+        auto *ge = GetEdges::make(qctx,
                                   start,
                                   1,
                                   src.get(),
@@ -51,8 +57,7 @@ TEST_F(FetchEdgesValidatorTest, FetchEdgesProp) {
                          "like.start",
                          "like.end",
                          "like.likeness"});
-        expectedPlan.setRoot(ge);
-        auto result = Eq(plan->root(), ge);
+        auto result = Eq(qctx->plan()->root(), ge);
         ASSERT_TRUE(result.ok()) << result;
     }
     // With YIELD
@@ -60,7 +65,7 @@ TEST_F(FetchEdgesValidatorTest, FetchEdgesProp) {
         auto plan = toPlan("FETCH PROP ON like \"1\"->\"2\" YIELD like.start, like.end");
 
         ExecutionPlan expectedPlan(pool_.get());
-        auto *start = StartNode::make(&expectedPlan);
+        auto *start = StartNode::make(qctx);
 
         auto edgeTypeResult = schemaMng_->toEdgeType(1, "like");
         ASSERT_TRUE(edgeTypeResult.ok());
@@ -79,7 +84,7 @@ TEST_F(FetchEdgesValidatorTest, FetchEdgesProp) {
             EdgePropertyExpression(new std::string("like"), new std::string("end")).encode());
         exprs.emplace_back(std::move(expr1));
         exprs.emplace_back(std::move(expr2));
-        auto *ge = GetEdges::make(&expectedPlan,
+        auto *ge = GetEdges::make(qctx,
                                   start,
                                   1,
                                   src.get(),
@@ -103,7 +108,7 @@ TEST_F(FetchEdgesValidatorTest, FetchEdgesProp) {
             new EdgePropertyExpression(new std::string("like"), new std::string("start"))));
         yieldColumns->addColumn(new YieldColumn(
             new EdgePropertyExpression(new std::string("like"), new std::string("end"))));
-        auto *project = Project::make(&expectedPlan, ge, yieldColumns.get());
+        auto *project = Project::make(qctx, ge, yieldColumns.get());
         project->setColNames({std::string("like.") + kSrc,
                               std::string("like.") + kDst,
                               std::string("like.") + kRank,
@@ -118,7 +123,7 @@ TEST_F(FetchEdgesValidatorTest, FetchEdgesProp) {
         auto plan = toPlan("FETCH PROP ON like \"1\"->\"2\" YIELD like.start, 1 + 1, like.end");
 
         ExecutionPlan expectedPlan(pool_.get());
-        auto *start = StartNode::make(&expectedPlan);
+        auto *start = StartNode::make(qctx);
 
         // GetEdges
         auto edgeTypeResult = schemaMng_->toEdgeType(1, "like");
@@ -138,7 +143,7 @@ TEST_F(FetchEdgesValidatorTest, FetchEdgesProp) {
             EdgePropertyExpression(new std::string("like"), new std::string("end")).encode());
         exprs.emplace_back(std::move(expr1));
         exprs.emplace_back(std::move(expr2));
-        auto *ge = GetEdges::make(&expectedPlan,
+        auto *ge = GetEdges::make(qctx,
                                   start,
                                   1,
                                   src.get(),
@@ -165,7 +170,7 @@ TEST_F(FetchEdgesValidatorTest, FetchEdgesProp) {
             Expression::Kind::kAdd, new ConstantExpression(1), new ConstantExpression(1))));
         yieldColumns->addColumn(new YieldColumn(
             new EdgePropertyExpression(new std::string("like"), new std::string("end"))));
-        auto *project = Project::make(&expectedPlan, ge, yieldColumns.get());
+        auto *project = Project::make(qctx, ge, yieldColumns.get());
         project->setColNames({std::string("like.") + kSrc,
                               std::string("like.") + kDst,
                               std::string("like.") + kRank,
@@ -181,7 +186,7 @@ TEST_F(FetchEdgesValidatorTest, FetchEdgesProp) {
         auto plan = toPlan("FETCH PROP ON like \"1\"->\"2\" YIELD like.start > like.end");
 
         ExecutionPlan expectedPlan(pool_.get());
-        auto *start = StartNode::make(&expectedPlan);
+        auto *start = StartNode::make(qctx);
 
         auto edgeTypeResult = schemaMng_->toEdgeType(1, "like");
         ASSERT_TRUE(edgeTypeResult.ok());
@@ -201,7 +206,7 @@ TEST_F(FetchEdgesValidatorTest, FetchEdgesProp) {
                 new EdgePropertyExpression(new std::string("like"), new std::string("end")))
                 .encode());
         exprs.emplace_back(std::move(expr1));
-        auto *ge = GetEdges::make(&expectedPlan,
+        auto *ge = GetEdges::make(qctx,
                                   start,
                                   1,
                                   src.get(),
@@ -224,7 +229,7 @@ TEST_F(FetchEdgesValidatorTest, FetchEdgesProp) {
             Expression::Kind::kRelGT,
             new EdgePropertyExpression(new std::string("like"), new std::string("start")),
             new EdgePropertyExpression(new std::string("like"), new std::string("end")))));
-        auto *project = Project::make(&expectedPlan, ge, yieldColumns.get());
+        auto *project = Project::make(qctx, ge, yieldColumns.get());
         project->setColNames({std::string("like.") + kSrc,
                               std::string("like.") + kDst,
                               std::string("like.") + kRank,
@@ -239,7 +244,7 @@ TEST_F(FetchEdgesValidatorTest, FetchEdgesProp) {
         auto plan = toPlan("FETCH PROP ON like \"1\"->\"2\" YIELD distinct like.start, like.end");
 
         ExecutionPlan expectedPlan(pool_.get());
-        auto *start = StartNode::make(&expectedPlan);
+        auto *start = StartNode::make(qctx);
 
         auto edgeTypeResult = schemaMng_->toEdgeType(1, "like");
         ASSERT_TRUE(edgeTypeResult.ok());
@@ -258,7 +263,7 @@ TEST_F(FetchEdgesValidatorTest, FetchEdgesProp) {
             EdgePropertyExpression(new std::string("like"), new std::string("end")).encode());
         exprs.emplace_back(std::move(expr1));
         exprs.emplace_back(std::move(expr2));
-        auto *ge = GetEdges::make(&expectedPlan,
+        auto *ge = GetEdges::make(qctx,
                                   start,
                                   1,
                                   src.get(),
@@ -284,14 +289,14 @@ TEST_F(FetchEdgesValidatorTest, FetchEdgesProp) {
             new EdgePropertyExpression(new std::string("like"), new std::string("start"))));
         yieldColumns->addColumn(new YieldColumn(
             new EdgePropertyExpression(new std::string("like"), new std::string("end"))));
-        auto *project = Project::make(&expectedPlan, ge, yieldColumns.get());
+        auto *project = Project::make(qctx, ge, yieldColumns.get());
         project->setColNames({std::string("like.") + kSrc,
                               std::string("like.") + kDst,
                               std::string("like.") + kRank,
                               "like.start",
                               "like.end"});
         // dedup
-        auto *dedup = Dedup::make(&expectedPlan, project);
+        auto *dedup = Dedup::make(qctx, project);
         dedup->setColNames(colNames);
 
         // data collect

--- a/src/validator/test/ValidatorTestBase.cpp
+++ b/src/validator/test/ValidatorTestBase.cpp
@@ -131,15 +131,15 @@ Status ValidatorTestBase::EqSelf(const PlanNode *l, const PlanNode *r) {
     } else if (l == nullptr && r == nullptr) {
         return Status::OK();
     } else {
-        return Status::Error("%s.this != %s.this", l->nodeLabel().c_str(), r->nodeLabel().c_str());
+        return Status::Error("%s.this != %s.this", l->varName().c_str(), r->varName().c_str());
     }
     if (l->kind() != r->kind()) {
         return Status::Error(
-            "%s.kind_ != %s.kind_", l->nodeLabel().c_str(), r->nodeLabel().c_str());
+            "%s.kind_ != %s.kind_", l->varName().c_str(), r->varName().c_str());
     }
     if (l->colNamesRef() != r->colNamesRef()) {
         return Status::Error(
-            "%s.colNames_ != %s.colNames_", l->nodeLabel().c_str(), r->nodeLabel().c_str());
+            "%s.colNames_ != %s.colNames_", l->varName().c_str(), r->varName().c_str());
     }
     switch (l->kind()) {
         case PlanNode::Kind::kUnknown:
@@ -153,7 +153,7 @@ Status ValidatorTestBase::EqSelf(const PlanNode *l, const PlanNode *r) {
             if (lDC->collectKind() != rDC->collectKind()) {
                 return Status::Error(
                     "%s.collectKind_ != %s.collectKind_",
-                    l->nodeLabel().c_str(), r->nodeLabel().c_str());
+                    l->varName().c_str(), r->varName().c_str());
             }
             return Status::OK();
         }
@@ -165,16 +165,16 @@ Status ValidatorTestBase::EqSelf(const PlanNode *l, const PlanNode *r) {
                 // TODO(shylock) check more about the anno variable
                 if (lGV->src()->kind() != rGV->src()->kind()) {
                     return Status::Error(
-                        "%s.src_ != %s.src_", l->nodeLabel().c_str(), r->nodeLabel().c_str());
+                        "%s.src_ != %s.src_", l->varName().c_str(), r->varName().c_str());
                 }
             } else if (lGV->src() != rGV->src()) {
                     return Status::Error(
-                        "%s.src_ != %s.src_", l->nodeLabel().c_str(), r->nodeLabel().c_str());
+                        "%s.src_ != %s.src_", l->varName().c_str(), r->varName().c_str());
             }
             // props
             if (lGV->props() != rGV->props()) {
                 return Status::Error(
-                    "%s.props_ != %s.props_", l->nodeLabel().c_str(), r->nodeLabel().c_str());
+                    "%s.props_ != %s.props_", l->varName().c_str(), r->varName().c_str());
             }
             return Status::OK();
         }
@@ -186,38 +186,38 @@ Status ValidatorTestBase::EqSelf(const PlanNode *l, const PlanNode *r) {
                 // TODO(shylock) check more about the anno variable
                 if (lGE->src()->kind() != rGE->src()->kind()) {
                     return Status::Error(
-                        "%s.src_ != %s.src_", l->nodeLabel().c_str(), r->nodeLabel().c_str());
+                        "%s.src_ != %s.src_", l->varName().c_str(), r->varName().c_str());
                 }
             } else if (lGE->src() != rGE->src()) {
                     return Status::Error(
-                        "%s.src_ != %s.src_", l->nodeLabel().c_str(), r->nodeLabel().c_str());
+                        "%s.src_ != %s.src_", l->varName().c_str(), r->varName().c_str());
             }
             // dst
             if (lGE->dst() != nullptr && rGE->dst() != nullptr) {
                 if (lGE->dst()->kind() != rGE->dst()->kind()) {
                     return Status::Error(
-                        "%s.dst_ != %s.dst_", l->nodeLabel().c_str(), r->nodeLabel().c_str());
+                        "%s.dst_ != %s.dst_", l->varName().c_str(), r->varName().c_str());
                 }
             } else if (lGE->dst() != rGE->dst()) {
                     return Status::Error(
-                        "%s.dst_ != %s.dst_", l->nodeLabel().c_str(), r->nodeLabel().c_str());
+                        "%s.dst_ != %s.dst_", l->varName().c_str(), r->varName().c_str());
             }
             // ranking
             if (lGE->ranking() != nullptr && rGE->ranking() != nullptr) {
                 if (lGE->ranking()->kind() != lGE->ranking()->kind()) {
                     return Status::Error(
                         "%s.ranking_ != %s.ranking_",
-                        l->nodeLabel().c_str(), r->nodeLabel().c_str());
+                        l->varName().c_str(), r->varName().c_str());
                 }
             } else if (lGE->ranking() != rGE->ranking()) {
                     return Status::Error(
                         "%s.ranking_ != %s.ranking_",
-                        l->nodeLabel().c_str(), r->nodeLabel().c_str());
+                        l->varName().c_str(), r->varName().c_str());
             }
             // props
             if (lGE->props() != rGE->props()) {
                 return Status::Error(
-                    "%s.props_ != %s.props_", l->nodeLabel().c_str(), r->nodeLabel().c_str());
+                    "%s.props_ != %s.props_", l->varName().c_str(), r->varName().c_str());
             }
             return Status::OK();
         }
@@ -230,19 +230,19 @@ Status ValidatorTestBase::EqSelf(const PlanNode *l, const PlanNode *r) {
                 auto rCols = rp->columns()->columns();
                 if (lCols.size() != rCols.size()) {
                     return Status::Error("%s.columns_ != %s.columns_",
-                                         l->nodeLabel().c_str(),
-                                         r->nodeLabel().c_str());
+                                         l->varName().c_str(),
+                                         r->varName().c_str());
                 }
                 for (std::size_t i = 0; i < lCols.size(); ++i) {
                     if (*lCols[i] != *rCols[i]) {
                         return Status::Error("%s.columns_ != %s.columns_",
-                                             l->nodeLabel().c_str(),
-                                             r->nodeLabel().c_str());
+                                             l->varName().c_str(),
+                                             r->varName().c_str());
                     }
                 }
             } else {
                 return Status::Error(
-                    "%s.columns_ != %s.columns_", l->nodeLabel().c_str(), r->nodeLabel().c_str());
+                    "%s.columns_ != %s.columns_", l->varName().c_str(), r->varName().c_str());
             }
             return Status::OK();
         }


### PR DESCRIPTION
When rewriting execution plan, we don't know which plan new plan node belongs to. 