### PR TITLE
Pull dependencies fields Up to plan node class

### DIFF
--- a/src/executor/logic/LoopExecutor.h
+++ b/src/executor/logic/LoopExecutor.h
@@ -4,8 +4,8 @@
  * attached with Common Clause Condition 1.0, found in the LICENSES directory.
  */
 
-#ifndef EXECUTOR_QUERY_LOOPEXECUTOR_H_
-#define EXECUTOR_QUERY_LOOPEXECUTOR_H_
+#ifndef EXECUTOR_LOGIC_LOOPEXECUTOR_H_
+#define EXECUTOR_LOGIC_LOOPEXECUTOR_H_
 
 #include "executor/Executor.h"
 
@@ -30,4 +30,4 @@ private:
 }   // namespace graph
 }   // namespace nebula
 
-#endif   // EXECUTOR_QUERY_LOOPEXECUTOR_H_
+#endif   // EXECUTOR_LOGIC_LOOPEXECUTOR_H_

--- a/src/executor/logic/PassThroughExecutor.h
+++ b/src/executor/logic/PassThroughExecutor.h
@@ -4,13 +4,8 @@
  * attached with Common Clause Condition 1.0, found in the LICENSES directory.
  */
 
-#ifndef EXEC_QUERY_PASSTHROUGHEXECUTOR_H_
-#define EXEC_QUERY_PASSTHROUGHEXECUTOR_H_
-
-#include <unordered_map>
-
-#include <folly/SpinLock.h>
-#include <folly/futures/SharedPromise.h>
+#ifndef EXECUTOR_LOGIC_PASSTHROUGHEXECUTOR_H_
+#define EXECUTOR_LOGIC_PASSTHROUGHEXECUTOR_H_
 
 #include "executor/Executor.h"
 
@@ -19,7 +14,7 @@ namespace graph {
 
 class PassThroughExecutor final : public Executor {
 public:
-    PassThroughExecutor(const PlanNode *node, QueryContext* qctx)
+    PassThroughExecutor(const PlanNode* node, QueryContext* qctx)
         : Executor("PassThroughExecutor", node, qctx) {}
 
     folly::Future<Status> execute() override;
@@ -28,4 +23,4 @@ public:
 }   // namespace graph
 }   // namespace nebula
 
-#endif   // EXEC_QUERY_PASSTHROUGHEXECUTOR_H_
+#endif   // EXECUTOR_LOGIC_PASSTHROUGHEXECUTOR_H_

--- a/src/executor/logic/SelectExecutor.h
+++ b/src/executor/logic/SelectExecutor.h
@@ -4,8 +4,8 @@
  * attached with Common Clause Condition 1.0, found in the LICENSES directory.
  */
 
-#ifndef EXECUTOR_QUERY_SELECTEXECUTOR_H_
-#define EXECUTOR_QUERY_SELECTEXECUTOR_H_
+#ifndef EXECUTOR_LOGIC_SELECTEXECUTOR_H_
+#define EXECUTOR_LOGIC_SELECTEXECUTOR_H_
 
 #include "executor/Executor.h"
 
@@ -34,4 +34,4 @@ private:
 }   // namespace graph
 }   // namespace nebula
 
-#endif   // EXECUTOR_QUERY_SELECTEXECUTOR_H_
+#endif   // EXECUTOR_LOGIC_SELECTEXECUTOR_H_

--- a/src/executor/logic/StartExecutor.h
+++ b/src/executor/logic/StartExecutor.h
@@ -4,8 +4,8 @@
  * attached with Common Clause Condition 1.0, found in the LICENSES directory.
  */
 
-#ifndef EXECUTOR_QUERY_STARTEXECUTOR_H_
-#define EXECUTOR_QUERY_STARTEXECUTOR_H_
+#ifndef EXECUTOR_LOGIC_STARTEXECUTOR_H_
+#define EXECUTOR_LOGIC_STARTEXECUTOR_H_
 
 #include "executor/Executor.h"
 
@@ -23,4 +23,4 @@ public:
 }   // namespace graph
 }   // namespace nebula
 
-#endif   // EXECUTOR_QUERY_STARTEXECUTOR_H_
+#endif   // EXECUTOR_LOGIC_STARTEXECUTOR_H_

--- a/src/planner/Logic.h
+++ b/src/planner/Logic.h
@@ -20,7 +20,7 @@ public:
     }
 
 private:
-    explicit StartNode(int64_t id) : PlanNode(id, DepKind::kNoDep, Kind::kStart) {}
+    explicit StartNode(int64_t id) : PlanNode(id, Kind::kStart) {}
 };
 
 class BinarySelect : public SingleInputNode {

--- a/src/planner/Logic.h
+++ b/src/planner/Logic.h
@@ -20,7 +20,7 @@ public:
     }
 
 private:
-    explicit StartNode(int64_t id) : PlanNode(id, Kind::kStart) {}
+    explicit StartNode(int64_t id) : PlanNode(id, DepKind::kNoDep, Kind::kStart) {}
 };
 
 class BinarySelect : public SingleInputNode {

--- a/src/planner/PlanNode.cpp
+++ b/src/planner/PlanNode.cpp
@@ -191,7 +191,7 @@ std::ostream& operator<<(std::ostream& os, PlanNode::Kind kind) {
 std::unique_ptr<cpp2::PlanNodeDescription> SingleDependencyNode::explain() const {
     auto desc = PlanNode::explain();
     DCHECK(!desc->__isset.dependencies);
-    desc->set_dependencies({dependency_->id()});
+    desc->set_dependencies({dep()->id()});
     return desc;
 }
 
@@ -204,7 +204,7 @@ std::unique_ptr<cpp2::PlanNodeDescription> SingleInputNode::explain() const {
 std::unique_ptr<cpp2::PlanNodeDescription> BiInputNode::explain() const {
     auto desc = PlanNode::explain();
     DCHECK(!desc->__isset.dependencies);
-    desc->set_dependencies({left_->id(), right_->id()});
+    desc->set_dependencies({left()->id(), right()->id()});
     addDescription("leftVar", leftVar_, desc.get());
     addDescription("rightVar", rightVar_, desc.get());
     return desc;

--- a/src/planner/PlanNode.cpp
+++ b/src/planner/PlanNode.cpp
@@ -13,8 +13,7 @@
 namespace nebula {
 namespace graph {
 
-PlanNode::PlanNode(int64_t id, DepKind depKind, Kind kind)
-    : depKind_(depKind), kind_(kind), id_(id) {
+PlanNode::PlanNode(int64_t id, Kind kind) : kind_(kind), id_(id) {
     DCHECK_GE(id_, 0);
     outputVar_ = folly::stringPrintf("__%s_%ld", toString(kind_), id_);
 }

--- a/src/planner/PlanNode.cpp
+++ b/src/planner/PlanNode.cpp
@@ -13,7 +13,8 @@
 namespace nebula {
 namespace graph {
 
-PlanNode::PlanNode(int64_t id, Kind kind) : kind_(kind), id_(id) {
+PlanNode::PlanNode(int64_t id, DepKind depKind, Kind kind)
+    : depKind_(depKind), kind_(kind), id_(id) {
     DCHECK_GE(id_, 0);
     outputVar_ = folly::stringPrintf("__%s_%ld", toString(kind_), id_);
 }

--- a/src/planner/PlanNode.h
+++ b/src/planner/PlanNode.h
@@ -23,12 +23,6 @@ class PlanNodeDescription;
  */
 class PlanNode {
 public:
-    enum class DepKind : uint8_t {
-        kSingleDep = 0,
-        kBinaryDep,
-        kNoDep,
-    };
-
     enum class Kind : uint8_t {
         kUnknown = 0,
         kStart,
@@ -101,16 +95,12 @@ public:
         kGetConfig,
     };
 
-    PlanNode(int64_t id, DepKind depKind, Kind kind);
+    PlanNode(int64_t id, Kind kind);
 
     virtual ~PlanNode() = default;
 
     // Describe plan node
     virtual std::unique_ptr<cpp2::PlanNodeDescription> explain() const;
-
-    DepKind depKind() const {
-        return depKind_;
-    }
 
     Kind kind() const {
         return kind_;
@@ -167,7 +157,6 @@ public:
 protected:
     static void addDescription(std::string key, std::string value, cpp2::PlanNodeDescription* desc);
 
-    DepKind                                  depKind_{DepKind::kNoDep};
     Kind                                     kind_{Kind::kUnknown};
     int64_t                                  id_{-1};
     std::string                              outputVar_;
@@ -189,7 +178,7 @@ public:
 
 protected:
     SingleDependencyNode(int64_t id, Kind kind, const PlanNode* dep)
-        : PlanNode(id, DepKind::kSingleDep, kind) {
+        : PlanNode(id, kind) {
         dependencies_.emplace_back(dep);
     }
 
@@ -255,7 +244,7 @@ public:
 
 protected:
     BiInputNode(int64_t id, Kind kind, PlanNode* left, PlanNode* right)
-        : PlanNode(id, DepKind::kBinaryDep, kind) {
+        : PlanNode(id, kind) {
         dependencies_.emplace_back(DCHECK_NOTNULL(left));
         dependencies_.emplace_back(DCHECK_NOTNULL(right));
     }

--- a/src/planner/PlanNode.h
+++ b/src/planner/PlanNode.h
@@ -138,6 +138,20 @@ public:
         colNames_ = cols;
     }
 
+    const PlanNode* dep(size_t index = 0) const {
+        DCHECK_LT(index, dependencies_.size());
+        return dependencies_.at(index);
+    }
+
+    void setDep(size_t index, const PlanNode* dep) {
+        DCHECK_LT(index, dependencies_.size());
+        dependencies_[index] = DCHECK_NOTNULL(dep);
+    }
+
+    const std::vector<const PlanNode*>& dependencies() const {
+        return dependencies_;
+    }
+
     static const char* toString(Kind kind);
 
 protected:
@@ -147,6 +161,7 @@ protected:
     int64_t                                  id_{-1};
     std::string                              outputVar_;
     std::vector<std::string>                 colNames_;
+    std::vector<const PlanNode*>             dependencies_;
 };
 
 std::ostream& operator<<(std::ostream& os, PlanNode::Kind kind);
@@ -157,21 +172,17 @@ std::ostream& operator<<(std::ostream& os, PlanNode::Kind kind);
 // It's useful for admin plan node
 class SingleDependencyNode : public PlanNode {
 public:
-    const PlanNode* dep() const {
-        return dependency_;
-    }
-
-    void dependsOn(PlanNode *dep) {
-        dependency_ = DCHECK_NOTNULL(dep);
+    void dependsOn(const PlanNode* dep) {
+        setDep(0, dep);
     }
 
 protected:
     SingleDependencyNode(int64_t id, Kind kind, const PlanNode* dep)
-        : PlanNode(id, kind), dependency_(dep) {}
+        : PlanNode(id, kind), dependency_(dep) {
+        dependencies_.emplace_back(dep);
+    }
 
     std::unique_ptr<cpp2::PlanNodeDescription> explain() const override;
-
-    const PlanNode *dependency_;
 };
 
 class SingleInputNode : public SingleDependencyNode {
@@ -198,11 +209,11 @@ protected:
 class BiInputNode : public PlanNode {
 public:
     void setLeft(const PlanNode* left) {
-        left_ = left;
+        setDep(0, left);
     }
 
     void setRight(const PlanNode* right) {
-        right_ = right;
+        setDep(1, right);
     }
 
     void setLeftVar(std::string leftVar) {
@@ -214,11 +225,11 @@ public:
     }
 
     const PlanNode* left() const {
-        return left_;
+        return dep(0);
     }
 
     const PlanNode* right() const {
-        return right_;
+        return dep(1);
     }
 
     const std::string& leftInputVar() const {
@@ -234,10 +245,10 @@ public:
 protected:
     BiInputNode(int64_t id, Kind kind, PlanNode* left, PlanNode* right)
         : PlanNode(id, kind), left_(left), right_(right) {
+        dependencies_.emplace_back(DCHECK_NOTNULL(left));
+        dependencies_.emplace_back(DCHECK_NOTNULL(right));
     }
 
-    const PlanNode* left_{nullptr};
-    const PlanNode* right_{nullptr};
     // Datasource for this node.
     std::string leftVar_;
     std::string rightVar_;

--- a/src/validator/Validator.cpp
+++ b/src/validator/Validator.cpp
@@ -210,75 +210,13 @@ Status Validator::validate(Sentence* sentence, QueryContext* qctx) {
 }
 
 Status Validator::appendPlan(PlanNode* node, PlanNode* appended) {
-    switch (DCHECK_NOTNULL(node)->kind()) {
-        case PlanNode::Kind::kShowHosts:
-        case PlanNode::Kind::kFilter:
-        case PlanNode::Kind::kProject:
-        case PlanNode::Kind::kSort:
-        case PlanNode::Kind::kLimit:
-        case PlanNode::Kind::kAggregate:
-        case PlanNode::Kind::kSelect:
-        case PlanNode::Kind::kLoop:
-        case PlanNode::Kind::kCreateUser:
-        case PlanNode::Kind::kDropUser:
-        case PlanNode::Kind::kUpdateUser:
-        case PlanNode::Kind::kGrantRole:
-        case PlanNode::Kind::kRevokeRole:
-        case PlanNode::Kind::kChangePassword:
-        case PlanNode::Kind::kListUserRoles:
-        case PlanNode::Kind::kListUsers:
-        case PlanNode::Kind::kListRoles:
-        case PlanNode::Kind::kPassThrough:
-        case PlanNode::Kind::kSwitchSpace:
-        case PlanNode::Kind::kGetEdges:
-        case PlanNode::Kind::kGetVertices:
-        case PlanNode::Kind::kCreateSpace:
-        case PlanNode::Kind::kCreateTag:
-        case PlanNode::Kind::kCreateEdge:
-        case PlanNode::Kind::kDescSpace:
-        case PlanNode::Kind::kDescTag:
-        case PlanNode::Kind::kDescEdge:
-        case PlanNode::Kind::kInsertVertices:
-        case PlanNode::Kind::kInsertEdges:
-        case PlanNode::Kind::kGetNeighbors:
-        case PlanNode::Kind::kAlterTag:
-        case PlanNode::Kind::kAlterEdge:
-        case PlanNode::Kind::kShowCreateSpace:
-        case PlanNode::Kind::kShowCreateTag:
-        case PlanNode::Kind::kShowCreateEdge:
-        case PlanNode::Kind::kDropSpace:
-        case PlanNode::Kind::kDropTag:
-        case PlanNode::Kind::kDropEdge:
-        case PlanNode::Kind::kShowSpaces:
-        case PlanNode::Kind::kShowTags:
-        case PlanNode::Kind::kShowEdges:
-        case PlanNode::Kind::kCreateSnapshot:
-        case PlanNode::Kind::kDropSnapshot:
-        case PlanNode::Kind::kSubmitJob:
-        case PlanNode::Kind::kShowSnapshots:
-        case PlanNode::Kind::kBalanceLeaders:
-        case PlanNode::Kind::kBalance:
-        case PlanNode::Kind::kStopBalance:
-        case PlanNode::Kind::kShowBalance:
-        case PlanNode::Kind::kDeleteVertices:
-        case PlanNode::Kind::kDeleteEdges:
-        case PlanNode::Kind::kUpdateVertex:
-        case PlanNode::Kind::kUpdateEdge:
-        case PlanNode::Kind::kShowParts:
-        case PlanNode::Kind::kShowCharset:
-        case PlanNode::Kind::kShowCollation:
-        case PlanNode::Kind::kShowConfigs:
-        case PlanNode::Kind::kSetConfig:
-        case PlanNode::Kind::kGetConfig: {
-            static_cast<SingleDependencyNode*>(node)->dependsOn(appended);
-            break;
-        }
-        default: {
-            return Status::SemanticError("%s not support to append an input.",
-                                         PlanNode::toString(node->kind()));
-        }
+    DCHECK(node != nullptr);
+    if (node->depKind() == PlanNode::DepKind::kSingleDep) {
+        static_cast<SingleDependencyNode*>(node)->dependsOn(appended);
+        return Status::OK();
     }
-    return Status::OK();
+    return Status::SemanticError("%s not support to append an input.",
+                                 PlanNode::toString(node->kind()));
 }
 
 Status Validator::appendPlan(PlanNode* root) {
@@ -1021,4 +959,3 @@ void ExpressionProps::unionProps(ExpressionProps exprProps) {
 }
 }   // namespace graph
 }   // namespace nebula
-

--- a/src/validator/Validator.cpp
+++ b/src/validator/Validator.cpp
@@ -211,16 +211,17 @@ Status Validator::validate(Sentence* sentence, QueryContext* qctx) {
 
 Status Validator::appendPlan(PlanNode* node, PlanNode* appended) {
     DCHECK(node != nullptr);
-    if (node->depKind() == PlanNode::DepKind::kSingleDep) {
-        static_cast<SingleDependencyNode*>(node)->dependsOn(appended);
-        return Status::OK();
+    DCHECK(appended != nullptr);
+    if (node->dependencies().size() != 1) {
+        return Status::SemanticError("%s not support to append an input.",
+                                     PlanNode::toString(node->kind()));
     }
-    return Status::SemanticError("%s not support to append an input.",
-                                 PlanNode::toString(node->kind()));
+    static_cast<SingleDependencyNode*>(node)->dependsOn(appended);
+    return Status::OK();
 }
 
 Status Validator::appendPlan(PlanNode* root) {
-    return appendPlan(tail_, DCHECK_NOTNULL(root));
+    return appendPlan(tail_, root);
 }
 
 Status Validator::validate() {

--- a/src/validator/test/ValidatorTestBase.cpp
+++ b/src/validator/test/ValidatorTestBase.cpp
@@ -40,32 +40,26 @@ void ValidatorTestBase::bfsTraverse(const PlanNode *root, std::vector<PlanNode::
             ASSERT_TRUE(false) << "Unknown Plan Node.";
         }
 
-        switch (node->depKind()) {
-            case PlanNode::DepKind::kSingleDep: {
+        switch (node->dependencies().size()) {
+            case 1: {
+                auto *sNode = static_cast<const SingleDependencyNode *>(node);
+                queue.emplace(sNode->dep());
                 if (node->kind() == PlanNode::Kind::kSelect) {
                     auto *current = static_cast<const Select *>(node);
-                    queue.emplace(current->dep());
                     queue.emplace(current->then());
                     if (current->otherwise() != nullptr) {
                         queue.emplace(current->otherwise());
                     }
                 } else if (node->kind() == PlanNode::Kind::kLoop) {
                     auto *current = static_cast<const Loop *>(node);
-                    queue.emplace(current->dep());
                     queue.emplace(current->body());
-                } else {
-                    auto *current = static_cast<const SingleDependencyNode *>(node);
-                    queue.emplace(current->dep());
                 }
                 break;
             }
-            case PlanNode::DepKind::kBinaryDep: {
+            case 2: {
                 auto *current = static_cast<const BiInputNode *>(node);
                 queue.emplace(current->left());
                 queue.emplace(current->right());
-                break;
-            }
-            case PlanNode::DepKind::kNoDep: {
                 break;
             }
         }

--- a/src/validator/test/ValidatorTestBase.cpp
+++ b/src/validator/test/ValidatorTestBase.cpp
@@ -36,89 +36,38 @@ void ValidatorTestBase::bfsTraverse(const PlanNode *root, std::vector<PlanNode::
         visited.emplace(node->id());
         result.emplace_back(node->kind());
 
-        switch (node->kind()) {
-            case PlanNode::Kind::kUnknown:
-                ASSERT_TRUE(false) << "Unknown Plan Node.";
-            case PlanNode::Kind::kStart: {
+        if (node->kind() == PlanNode::Kind::kUnknown) {
+            ASSERT_TRUE(false) << "Unknown Plan Node.";
+        }
+
+        switch (node->depKind()) {
+            case PlanNode::DepKind::kSingleDep: {
+                if (node->kind() == PlanNode::Kind::kSelect) {
+                    auto *current = static_cast<const Select *>(node);
+                    queue.emplace(current->dep());
+                    queue.emplace(current->then());
+                    if (current->otherwise() != nullptr) {
+                        queue.emplace(current->otherwise());
+                    }
+                } else if (node->kind() == PlanNode::Kind::kLoop) {
+                    auto *current = static_cast<const Loop *>(node);
+                    queue.emplace(current->dep());
+                    queue.emplace(current->body());
+                } else {
+                    auto *current = static_cast<const SingleDependencyNode *>(node);
+                    queue.emplace(current->dep());
+                }
                 break;
             }
-            case PlanNode::Kind::kCreateUser:
-            case PlanNode::Kind::kDropUser:
-            case PlanNode::Kind::kUpdateUser:
-            case PlanNode::Kind::kGrantRole:
-            case PlanNode::Kind::kRevokeRole:
-            case PlanNode::Kind::kChangePassword:
-            case PlanNode::Kind::kListUserRoles:
-            case PlanNode::Kind::kListUsers:
-            case PlanNode::Kind::kListRoles:
-            case PlanNode::Kind::kShowHosts:
-            case PlanNode::Kind::kGetNeighbors:
-            case PlanNode::Kind::kGetVertices:
-            case PlanNode::Kind::kGetEdges:
-            case PlanNode::Kind::kIndexScan:
-            case PlanNode::Kind::kFilter:
-            case PlanNode::Kind::kProject:
-            case PlanNode::Kind::kSort:
-            case PlanNode::Kind::kLimit:
-            case PlanNode::Kind::kAggregate:
-            case PlanNode::Kind::kSwitchSpace:
-            case PlanNode::Kind::kPassThrough:
-            case PlanNode::Kind::kDedup:
-            case PlanNode::Kind::kDataCollect:
-            case PlanNode::Kind::kCreateSpace:
-            case PlanNode::Kind::kCreateTag:
-            case PlanNode::Kind::kCreateEdge:
-            case PlanNode::Kind::kDescSpace:
-            case PlanNode::Kind::kDescTag:
-            case PlanNode::Kind::kDescEdge:
-            case PlanNode::Kind::kInsertVertices:
-            case PlanNode::Kind::kInsertEdges:
-            case PlanNode::Kind::kShowCreateSpace:
-            case PlanNode::Kind::kShowCreateTag:
-            case PlanNode::Kind::kShowCreateEdge:
-            case PlanNode::Kind::kDropSpace:
-            case PlanNode::Kind::kDropTag:
-            case PlanNode::Kind::kDropEdge:
-            case PlanNode::Kind::kShowSpaces:
-            case PlanNode::Kind::kShowTags:
-            case PlanNode::Kind::kShowEdges:
-            case PlanNode::Kind::kCreateSnapshot:
-            case PlanNode::Kind::kDropSnapshot:
-            case PlanNode::Kind::kShowSnapshots:
-            case PlanNode::Kind::kDataJoin:
-            case PlanNode::Kind::kDeleteVertices:
-            case PlanNode::Kind::kDeleteEdges:
-            case PlanNode::Kind::kUpdateVertex:
-            case PlanNode::Kind::kUpdateEdge: {
-                auto *current = static_cast<const SingleDependencyNode *>(node);
-                queue.emplace(current->dep());
-                break;
-            }
-            case PlanNode::Kind::kUnion:
-            case PlanNode::Kind::kIntersect:
-            case PlanNode::Kind::kMinus: {
+            case PlanNode::DepKind::kBinaryDep: {
                 auto *current = static_cast<const BiInputNode *>(node);
                 queue.emplace(current->left());
                 queue.emplace(current->right());
                 break;
             }
-            case PlanNode::Kind::kSelect: {
-                auto *current = static_cast<const Select *>(node);
-                queue.emplace(current->dep());
-                queue.emplace(current->then());
-                if (current->otherwise() != nullptr) {
-                    queue.emplace(current->otherwise());
-                }
+            case PlanNode::DepKind::kNoDep: {
                 break;
             }
-            case PlanNode::Kind::kLoop: {
-                auto *current = static_cast<const Loop *>(node);
-                queue.emplace(current->dep());
-                queue.emplace(current->body());
-                break;
-            }
-            default:
-                LOG(FATAL) << "Unknown PlanNode: " << static_cast<int64_t>(node->kind());
         }
     }
 }


### PR DESCRIPTION
This PR will simplify the usage of dependencies when don't care about the plan node kind.

In addition, fix logical executors include guard macros.