### PR TITLE
Add pattern match for OptRule

### DIFF
--- a/src/optimizer/OptGroup.cpp
+++ b/src/optimizer/OptGroup.cpp
@@ -59,17 +59,12 @@ Status OptGroup::explore(const OptRule *rule) {
         NG_RETURN_IF_ERROR(groupExpr->explore(rule));
 
         // Find more equivalents
-        auto &pattern = rule->pattern();
-        auto status = pattern.match(groupExpr);
+        auto status = rule->match(groupExpr);
         if (!status.ok()) {
             ++iter;
             continue;
         }
         auto matched = std::move(status).value();
-        if (!rule->match(matched)) {
-            ++iter;
-            continue;
-        }
         auto resStatus = rule->transform(qctx_, matched);
         NG_RETURN_IF_ERROR(resStatus);
         auto result = std::move(resStatus).value();

--- a/src/optimizer/OptGroup.cpp
+++ b/src/optimizer/OptGroup.cpp
@@ -139,13 +139,15 @@ Status OptGroupExpr::explore(const OptRule *rule) {
     setExplored(rule);
 
     for (auto dep : dependencies_) {
-        if (dep && !dep->isExplored(rule)) {
+        DCHECK(dep != nullptr);
+        while (!dep->isExplored(rule)) {
             NG_RETURN_IF_ERROR(dep->explore(rule));
         }
     }
 
     for (auto body : bodies_) {
-        if (body && !body->isExplored(rule)) {
+        DCHECK(body != nullptr);
+        while (!body->isExplored(rule)) {
             NG_RETURN_IF_ERROR(body->explore(rule));
         }
     }

--- a/src/optimizer/OptGroup.cpp
+++ b/src/optimizer/OptGroup.cpp
@@ -94,6 +94,19 @@ Status OptGroup::explore(const OptRule *rule) {
     return Status::OK();
 }
 
+Status OptGroup::exploreUtilMaxRound(const OptRule *rule) {
+    auto maxRound = kMaxExplorationRound;
+    while (!isExplored(rule)) {
+        if (0 < maxRound--) {
+            NG_RETURN_IF_ERROR(explore(rule));
+        } else {
+            setExplored(rule);
+            break;
+        }
+    }
+    return Status::OK();
+}
+
 std::pair<double, const OptGroupExpr *> OptGroup::findMinCostGroupExpr() const {
     double minCost = std::numeric_limits<double>::max();
     const OptGroupExpr *minGroupExpr = nullptr;
@@ -135,16 +148,12 @@ Status OptGroupExpr::explore(const OptRule *rule) {
 
     for (auto dep : dependencies_) {
         DCHECK(dep != nullptr);
-        while (!dep->isExplored(rule)) {
-            NG_RETURN_IF_ERROR(dep->explore(rule));
-        }
+        NG_RETURN_IF_ERROR(dep->exploreUtilMaxRound(rule));
     }
 
     for (auto body : bodies_) {
         DCHECK(body != nullptr);
-        while (!body->isExplored(rule)) {
-            NG_RETURN_IF_ERROR(body->explore(rule));
-        }
+        NG_RETURN_IF_ERROR(body->exploreUtilMaxRound(rule));
     }
     return Status::OK();
 }

--- a/src/optimizer/OptGroup.h
+++ b/src/optimizer/OptGroup.h
@@ -8,6 +8,7 @@
 #define OPTIMIZER_OPTGROUP_H_
 
 #include <algorithm>
+#include <list>
 #include <vector>
 #include "common/base/Status.h"
 
@@ -44,7 +45,7 @@ public:
 
     void addGroupExpr(OptGroupExpr *groupExpr);
     OptGroupExpr *makeGroupExpr(graph::QueryContext *qctx, graph::PlanNode *node);
-    const std::vector<OptGroupExpr *> &groupExprs() const {
+    const std::list<OptGroupExpr *> &groupExprs() const {
         return groupExprs_;
     }
 
@@ -58,7 +59,7 @@ private:
     std::pair<double, const OptGroupExpr *> findMinCostGroupExpr() const;
 
     graph::QueryContext *qctx_{nullptr};
-    std::vector<OptGroupExpr *> groupExprs_;
+    std::list<OptGroupExpr *> groupExprs_;
     std::vector<const OptRule *> exploredRules_;
 };
 

--- a/src/optimizer/OptGroup.h
+++ b/src/optimizer/OptGroup.h
@@ -50,11 +50,14 @@ public:
     }
 
     Status explore(const OptRule *rule);
+    Status exploreUtilMaxRound(const OptRule *rule);
     double getCost() const;
     const graph::PlanNode *getPlan() const;
 
 private:
     explicit OptGroup(graph::QueryContext *qctx) noexcept;
+
+    static constexpr int16_t kMaxExplorationRound = 128;
 
     std::pair<double, const OptGroupExpr *> findMinCostGroupExpr() const;
 

--- a/src/optimizer/OptRule.cpp
+++ b/src/optimizer/OptRule.cpp
@@ -22,6 +22,10 @@ Pattern Pattern::create(graph::PlanNode::Kind kind, std::initializer_list<Patter
 }
 
 StatusOr<MatchedResult> Pattern::match(const OptGroupExpr *groupExpr) const {
+    if (kind_ == graph::PlanNode::Kind::kUnknown) {
+        return MatchedResult{};
+    }
+
     if (groupExpr->node()->kind() != kind_) {
         return Status::Error();
     }

--- a/src/optimizer/OptRule.cpp
+++ b/src/optimizer/OptRule.cpp
@@ -22,12 +22,12 @@ Pattern Pattern::create(graph::PlanNode::Kind kind, std::initializer_list<Patter
 }
 
 StatusOr<MatchedResult> Pattern::match(const OptGroupExpr *groupExpr) const {
-    if (kind_ == graph::PlanNode::Kind::kUnknown) {
-        return MatchedResult{};
-    }
-
     if (groupExpr->node()->kind() != kind_) {
         return Status::Error();
+    }
+
+    if (dependencies_.empty()) {
+        return MatchedResult{groupExpr, {}};
     }
 
     if (groupExpr->dependencies().size() != dependencies_.size()) {

--- a/src/optimizer/OptRule.cpp
+++ b/src/optimizer/OptRule.cpp
@@ -57,6 +57,24 @@ StatusOr<MatchedResult> Pattern::match(const OptGroup *group) const {
     return Status::Error();
 }
 
+StatusOr<MatchedResult> OptRule::match(const OptGroupExpr *groupExpr) const {
+    const auto &pattern = this->pattern();
+    auto status = pattern.match(groupExpr);
+    NG_RETURN_IF_ERROR(status);
+    auto matched = std::move(status).value();
+    if (!this->match(matched)) {
+        return Status::Error();
+    }
+    return matched;
+}
+
+bool OptRule::match(const MatchedResult &matched) const {
+    UNUSED(matched);
+    // Return true if subclass doesn't override this interface,
+    // so optimizer will only check whether pattern is matched
+    return true;
+}
+
 RuleSet &RuleSet::DefaultRules() {
     static RuleSet kDefaultRules("DefaultRuleSet");
     return kDefaultRules;

--- a/src/optimizer/OptRule.h
+++ b/src/optimizer/OptRule.h
@@ -26,7 +26,7 @@ class OptGroupExpr;
 class OptGroup;
 
 struct MatchedResult {
-    const OptGroupExpr *node;
+    const OptGroupExpr *node{nullptr};
     std::vector<MatchedResult> dependencies;
 };
 

--- a/src/optimizer/OptRule.h
+++ b/src/optimizer/OptRule.h
@@ -7,11 +7,12 @@
 #ifndef OPTIMIZER_OPTRULE_H_
 #define OPTIMIZER_OPTRULE_H_
 
+#include <initializer_list>
 #include <memory>
 #include <string>
 #include <vector>
 
-#include "common/base/Status.h"
+#include "common/base/StatusOr.h"
 #include "planner/PlanNode.h"
 
 namespace nebula {
@@ -22,21 +23,41 @@ class QueryContext;
 namespace opt {
 
 class OptGroupExpr;
+class OptGroup;
+
+struct MatchedResult {
+    const OptGroupExpr *node;
+    std::vector<MatchedResult> dependencies;
+};
+
+class Pattern final {
+public:
+    static Pattern create(graph::PlanNode::Kind kind, std::initializer_list<Pattern> patterns = {});
+
+    StatusOr<MatchedResult> match(const OptGroupExpr *groupNode) const;
+
+private:
+    Pattern() = default;
+    StatusOr<MatchedResult> match(const OptGroup *group) const;
+
+    graph::PlanNode::Kind kind_;
+    std::vector<Pattern> dependencies_;
+};
 
 class OptRule {
 public:
     struct TransformResult {
-        bool eraseCurr;
-        bool eraseAll;
+        bool eraseCurr{false};
+        bool eraseAll{false};
         std::vector<OptGroupExpr *> newGroupExprs;
     };
 
     virtual ~OptRule() = default;
 
-    virtual bool match(const OptGroupExpr *groupExpr) const = 0;
-    virtual Status transform(graph::QueryContext *qctx,
-                             const OptGroupExpr *groupExpr,
-                             TransformResult *result) const = 0;
+    virtual const Pattern &pattern() const = 0;
+    virtual bool match(const MatchedResult &result) const = 0;
+    virtual StatusOr<TransformResult> transform(graph::QueryContext *qctx,
+                                                const MatchedResult &matchedResult) const = 0;
     virtual std::string toString() const = 0;
 
 protected:
@@ -45,8 +66,8 @@ protected:
 
 class RuleSet final {
 public:
-    static RuleSet &defaultRules();
-    static RuleSet &queryRules();
+    static RuleSet &DefaultRules();
+    static RuleSet &QueryRules();
 
     RuleSet *addRule(const OptRule *rule);
 

--- a/src/optimizer/OptRule.h
+++ b/src/optimizer/OptRule.h
@@ -55,9 +55,9 @@ public:
     virtual ~OptRule() = default;
 
     virtual const Pattern &pattern() const = 0;
-    virtual bool match(const MatchedResult &result) const = 0;
+    virtual bool match(const MatchedResult &matched) const = 0;
     virtual StatusOr<TransformResult> transform(graph::QueryContext *qctx,
-                                                const MatchedResult &matchedResult) const = 0;
+                                                const MatchedResult &matched) const = 0;
     virtual std::string toString() const = 0;
 
 protected:

--- a/src/optimizer/OptRule.h
+++ b/src/optimizer/OptRule.h
@@ -52,10 +52,12 @@ public:
         std::vector<OptGroupExpr *> newGroupExprs;
     };
 
+    StatusOr<MatchedResult> match(const OptGroupExpr *groupExpr) const;
+
     virtual ~OptRule() = default;
 
     virtual const Pattern &pattern() const = 0;
-    virtual bool match(const MatchedResult &matched) const = 0;
+    virtual bool match(const MatchedResult &matched) const;
     virtual StatusOr<TransformResult> transform(graph::QueryContext *qctx,
                                                 const MatchedResult &matched) const = 0;
     virtual std::string toString() const = 0;

--- a/src/optimizer/Optimizer.cpp
+++ b/src/optimizer/Optimizer.cpp
@@ -45,9 +45,7 @@ Status Optimizer::prepare() {
 Status Optimizer::doExploration() {
     for (auto ruleSet : ruleSets_) {
         for (auto rule : ruleSet->rules()) {
-            while (!rootGroup_->isExplored(rule)) {
-                NG_RETURN_IF_ERROR(rootGroup_->explore(rule));
-            }
+            NG_RETURN_IF_ERROR(rootGroup_->exploreUtilMaxRound(rule));
         }
     }
     return Status::OK();

--- a/src/optimizer/Optimizer.cpp
+++ b/src/optimizer/Optimizer.cpp
@@ -46,7 +46,7 @@ Status Optimizer::doExploration() {
     // TODO(yee): Apply all rules recursively, not only once round
     for (auto ruleSet : ruleSets_) {
         for (auto rule : ruleSet->rules()) {
-            if (!rootGroup_->isExplored(rule)) {
+            while (!rootGroup_->isExplored(rule)) {
                 NG_RETURN_IF_ERROR(rootGroup_->explore(rule));
             }
         }

--- a/src/optimizer/Optimizer.cpp
+++ b/src/optimizer/Optimizer.cpp
@@ -43,7 +43,6 @@ Status Optimizer::prepare() {
 }
 
 Status Optimizer::doExploration() {
-    // TODO(yee): Apply all rules recursively, not only once round
     for (auto ruleSet : ruleSets_) {
         for (auto rule : ruleSet->rules()) {
             while (!rootGroup_->isExplored(rule)) {

--- a/src/optimizer/rule/IndexScanRule.cpp
+++ b/src/optimizer/rule/IndexScanRule.cpp
@@ -26,11 +26,6 @@ const Pattern& IndexScanRule::pattern() const {
     return pattern;
 }
 
-bool IndexScanRule::match(const MatchedResult& matched) const {
-    UNUSED(matched);
-    return true;
-}
-
 StatusOr<OptRule::TransformResult> IndexScanRule::transform(graph::QueryContext* qctx,
                                                             const MatchedResult& matched) const {
     auto groupExpr = matched.node;

--- a/src/optimizer/rule/IndexScanRule.cpp
+++ b/src/optimizer/rule/IndexScanRule.cpp
@@ -51,7 +51,7 @@ StatusOr<OptRule::TransformResult> IndexScanRule::transform(graph::QueryContext*
     newGroupExpr->dependsOn(groupExpr->dependencies()[0]);
     TransformResult result;
     result.newGroupExprs.emplace_back(newGroupExpr);
-    result.eraseCurr = true;
+    result.eraseAll = true;
     return result;
 }
 
@@ -258,6 +258,7 @@ IndexScanRule::filterExpr(const OptGroupExpr *groupExpr) const {
     auto in = static_cast<const IndexScan *>(groupExpr->node());
     auto qct = in->queryContext();
     // The initial IndexScan plan node has only one queryContext.
+    // TODO(yee): Move this condition to match interface
     if (qct->size() != 1) {
         LOG(ERROR) << "Index Scan plan node error";
         return nullptr;

--- a/src/optimizer/rule/IndexScanRule.cpp
+++ b/src/optimizer/rule/IndexScanRule.cpp
@@ -18,22 +18,28 @@ std::unique_ptr<OptRule> IndexScanRule::kInstance =
     std::unique_ptr<IndexScanRule>(new IndexScanRule());
 
 IndexScanRule::IndexScanRule() {
-    RuleSet::defaultRules().addRule(this);
+    RuleSet::DefaultRules().addRule(this);
 }
 
-bool IndexScanRule::match(const OptGroupExpr *groupExpr) const {
-    return groupExpr->node()->kind() == PlanNode::Kind::kIndexScan;
+const Pattern& IndexScanRule::pattern() const {
+    static Pattern pattern = Pattern::create(graph::PlanNode::Kind::kIndexScan);
+    return pattern;
 }
 
-Status IndexScanRule::transform(graph::QueryContext *qctx,
-                                const OptGroupExpr *groupExpr,
-                                TransformResult *result) const {
-    FilterItems items;
-    ScanKind kind;
+bool IndexScanRule::match(const MatchedResult& result) const {
+    UNUSED(result);
+    return true;
+}
+
+StatusOr<OptRule::TransformResult> IndexScanRule::transform(graph::QueryContext* qctx,
+                                                            const MatchedResult& matched) const {
+    auto groupExpr = matched.node;
     auto filter = filterExpr(groupExpr);
     if (filter == nullptr) {
         return Status::SemanticError("WHERE clause error");
     }
+    FilterItems items;
+    ScanKind kind;
     auto ret = analyzeExpression(filter.get(), &items, &kind, isEdge(groupExpr));
     NG_RETURN_IF_ERROR(ret);
 
@@ -48,9 +54,10 @@ Status IndexScanRule::transform(graph::QueryContext *qctx,
         return Status::Error("Plan node dependencies error");
     }
     newGroupExpr->dependsOn(groupExpr->dependencies()[0]);
-    result->newGroupExprs.emplace_back(newGroupExpr);
-    result->eraseAll = true;
-    return Status::OK();
+    TransformResult result;
+    result.newGroupExprs.emplace_back(newGroupExpr);
+    result.eraseCurr = true;
+    return result;
 }
 
 std::string IndexScanRule::toString() const {

--- a/src/optimizer/rule/IndexScanRule.cpp
+++ b/src/optimizer/rule/IndexScanRule.cpp
@@ -26,8 +26,8 @@ const Pattern& IndexScanRule::pattern() const {
     return pattern;
 }
 
-bool IndexScanRule::match(const MatchedResult& result) const {
-    UNUSED(result);
+bool IndexScanRule::match(const MatchedResult& matched) const {
+    UNUSED(matched);
     return true;
 }
 

--- a/src/optimizer/rule/IndexScanRule.cpp
+++ b/src/optimizer/rule/IndexScanRule.cpp
@@ -22,7 +22,7 @@ IndexScanRule::IndexScanRule() {
 }
 
 const Pattern& IndexScanRule::pattern() const {
-    // pattern: AnyPlanNode -> IndexScanNode
+    // pattern: AnyPlanNode <- IndexScanNode
     static Pattern pattern = Pattern::create(graph::PlanNode::Kind::kIndexScan,
                                              {Pattern::create(graph::PlanNode::Kind::kUnknown)});
     return pattern;

--- a/src/optimizer/rule/IndexScanRule.cpp
+++ b/src/optimizer/rule/IndexScanRule.cpp
@@ -22,7 +22,9 @@ IndexScanRule::IndexScanRule() {
 }
 
 const Pattern& IndexScanRule::pattern() const {
-    static Pattern pattern = Pattern::create(graph::PlanNode::Kind::kIndexScan);
+    // pattern: AnyPlanNode -> IndexScanNode
+    static Pattern pattern = Pattern::create(graph::PlanNode::Kind::kIndexScan,
+                                             {Pattern::create(graph::PlanNode::Kind::kUnknown)});
     return pattern;
 }
 

--- a/src/optimizer/rule/IndexScanRule.cpp
+++ b/src/optimizer/rule/IndexScanRule.cpp
@@ -22,9 +22,7 @@ IndexScanRule::IndexScanRule() {
 }
 
 const Pattern& IndexScanRule::pattern() const {
-    // pattern: AnyPlanNode <- IndexScanNode
-    static Pattern pattern = Pattern::create(graph::PlanNode::Kind::kIndexScan,
-                                             {Pattern::create(graph::PlanNode::Kind::kUnknown)});
+    static Pattern pattern = Pattern::create(graph::PlanNode::Kind::kIndexScan);
     return pattern;
 }
 

--- a/src/optimizer/rule/IndexScanRule.h
+++ b/src/optimizer/rule/IndexScanRule.h
@@ -31,13 +31,11 @@ class IndexScanRule final : public OptRule {
     FRIEND_TEST(IndexScanRuleTest, IQCtxTest);
 
 public:
-    static std::unique_ptr<OptRule> kInstance;
+    const Pattern& pattern() const override;
+    bool match(const MatchedResult& result) const override;
 
-    bool match(const OptGroupExpr *groupExpr) const override;
-
-    Status transform(graph::QueryContext *qctx,
-                     const OptGroupExpr *groupExpr,
-                     TransformResult *result) const override;
+    StatusOr<TransformResult> transform(graph::QueryContext* qctx,
+                                        const MatchedResult& matched) const override;
 
     std::string toString() const override;
 
@@ -99,6 +97,8 @@ private:
             items.emplace_back(FilterItem(field, kind, v));
         }
     };
+
+    static std::unique_ptr<OptRule> kInstance;
 
     IndexScanRule();
 

--- a/src/optimizer/rule/IndexScanRule.h
+++ b/src/optimizer/rule/IndexScanRule.h
@@ -32,7 +32,7 @@ class IndexScanRule final : public OptRule {
 
 public:
     const Pattern& pattern() const override;
-    bool match(const MatchedResult& result) const override;
+    bool match(const MatchedResult& matched) const override;
 
     StatusOr<TransformResult> transform(graph::QueryContext* qctx,
                                         const MatchedResult& matched) const override;

--- a/src/optimizer/rule/IndexScanRule.h
+++ b/src/optimizer/rule/IndexScanRule.h
@@ -32,7 +32,6 @@ class IndexScanRule final : public OptRule {
 
 public:
     const Pattern& pattern() const override;
-    bool match(const MatchedResult& matched) const override;
 
     StatusOr<TransformResult> transform(graph::QueryContext* qctx,
                                         const MatchedResult& matched) const override;

--- a/src/optimizer/rule/PushFilterDownGetNbrsRule.cpp
+++ b/src/optimizer/rule/PushFilterDownGetNbrsRule.cpp
@@ -38,8 +38,8 @@ const Pattern &PushFilterDownGetNbrsRule::pattern() const {
     return pattern;
 }
 
-bool PushFilterDownGetNbrsRule::match(const MatchedResult &result) const {
-    UNUSED(result);
+bool PushFilterDownGetNbrsRule::match(const MatchedResult &matched) const {
+    UNUSED(matched);
     return true;
 }
 

--- a/src/optimizer/rule/PushFilterDownGetNbrsRule.cpp
+++ b/src/optimizer/rule/PushFilterDownGetNbrsRule.cpp
@@ -33,7 +33,7 @@ PushFilterDownGetNbrsRule::PushFilterDownGetNbrsRule() {
 }
 
 const Pattern &PushFilterDownGetNbrsRule::pattern() const {
-    // pattern: AnyPlanNode -> GetNeighbors -> Filter
+    // pattern: AnyPlanNode <- GetNeighbors <- Filter
     static Pattern pattern =
         Pattern::create(graph::PlanNode::Kind::kFilter,
                         {Pattern::create(graph::PlanNode::Kind::kGetNeighbors,

--- a/src/optimizer/rule/PushFilterDownGetNbrsRule.cpp
+++ b/src/optimizer/rule/PushFilterDownGetNbrsRule.cpp
@@ -33,11 +33,8 @@ PushFilterDownGetNbrsRule::PushFilterDownGetNbrsRule() {
 }
 
 const Pattern &PushFilterDownGetNbrsRule::pattern() const {
-    // pattern: AnyPlanNode <- GetNeighbors <- Filter
-    static Pattern pattern =
-        Pattern::create(graph::PlanNode::Kind::kFilter,
-                        {Pattern::create(graph::PlanNode::Kind::kGetNeighbors,
-                                         {Pattern::create(graph::PlanNode::Kind::kUnknown)})});
+    static Pattern pattern = Pattern::create(
+        graph::PlanNode::Kind::kFilter, {Pattern::create(graph::PlanNode::Kind::kGetNeighbors)});
     return pattern;
 }
 

--- a/src/optimizer/rule/PushFilterDownGetNbrsRule.cpp
+++ b/src/optimizer/rule/PushFilterDownGetNbrsRule.cpp
@@ -33,8 +33,11 @@ PushFilterDownGetNbrsRule::PushFilterDownGetNbrsRule() {
 }
 
 const Pattern &PushFilterDownGetNbrsRule::pattern() const {
-    static Pattern pattern = Pattern::create(
-        graph::PlanNode::Kind::kFilter, {Pattern::create(graph::PlanNode::Kind::kGetNeighbors)});
+    // pattern: AnyPlanNode -> GetNeighbors -> Filter
+    static Pattern pattern =
+        Pattern::create(graph::PlanNode::Kind::kFilter,
+                        {Pattern::create(graph::PlanNode::Kind::kGetNeighbors,
+                                         {Pattern::create(graph::PlanNode::Kind::kUnknown)})});
     return pattern;
 }
 

--- a/src/optimizer/rule/PushFilterDownGetNbrsRule.cpp
+++ b/src/optimizer/rule/PushFilterDownGetNbrsRule.cpp
@@ -38,11 +38,6 @@ const Pattern &PushFilterDownGetNbrsRule::pattern() const {
     return pattern;
 }
 
-bool PushFilterDownGetNbrsRule::match(const MatchedResult &matched) const {
-    UNUSED(matched);
-    return true;
-}
-
 StatusOr<OptRule::TransformResult> PushFilterDownGetNbrsRule::transform(
     QueryContext *qctx,
     const MatchedResult &matched) const {

--- a/src/optimizer/rule/PushFilterDownGetNbrsRule.cpp
+++ b/src/optimizer/rule/PushFilterDownGetNbrsRule.cpp
@@ -29,32 +29,33 @@ std::unique_ptr<OptRule> PushFilterDownGetNbrsRule::kInstance =
     std::unique_ptr<PushFilterDownGetNbrsRule>(new PushFilterDownGetNbrsRule());
 
 PushFilterDownGetNbrsRule::PushFilterDownGetNbrsRule() {
-    RuleSet::queryRules().addRule(this);
+    RuleSet::QueryRules().addRule(this);
 }
 
-bool PushFilterDownGetNbrsRule::match(const OptGroupExpr *groupExpr) const {
-    auto pair = findMatchedGroupExpr(groupExpr);
-    if (!pair.first) {
-        return false;
-    }
+const Pattern &PushFilterDownGetNbrsRule::pattern() const {
+    static Pattern pattern = Pattern::create(
+        graph::PlanNode::Kind::kFilter, {Pattern::create(graph::PlanNode::Kind::kGetNeighbors)});
+    return pattern;
+}
 
+bool PushFilterDownGetNbrsRule::match(const MatchedResult &result) const {
+    UNUSED(result);
     return true;
 }
 
-Status PushFilterDownGetNbrsRule::transform(QueryContext *qctx,
-                                            const OptGroupExpr *groupExpr,
-                                            TransformResult *result) const {
-    auto pair = findMatchedGroupExpr(groupExpr);
-    auto filter = static_cast<const Filter *>(groupExpr->node());
-    auto gn = static_cast<const GetNeighbors *>(pair.second->node());
+StatusOr<OptRule::TransformResult> PushFilterDownGetNbrsRule::transform(
+    QueryContext *qctx,
+    const MatchedResult &matched) const {
+    auto filterGroupExpr = matched.node;
+    auto gnGroupExpr = matched.dependencies.front().node;
+    auto filter = static_cast<const Filter *>(filterGroupExpr->node());
+    auto gn = static_cast<const GetNeighbors *>(gnGroupExpr->node());
 
     auto condition = filter->condition()->clone();
     graph::ExtractFilterExprVisitor visitor;
     condition->accept(&visitor);
     if (!visitor.ok()) {
-        result->eraseCurr = false;
-        result->eraseAll = false;
-        return Status::OK();
+        return TransformResult{false, false, {}};
     }
 
     auto pool = qctx->objPool();
@@ -64,7 +65,7 @@ Status PushFilterDownGetNbrsRule::transform(QueryContext *qctx,
         auto newFilter = Filter::make(qctx, nullptr, pool->add(remainedExpr.release()));
         newFilter->setOutputVar(filter->outputVar());
         newFilter->setInputVar(filter->inputVar());
-        newFilterGroupExpr = OptGroupExpr::create(qctx, newFilter, groupExpr->group());
+        newFilterGroupExpr = OptGroupExpr::create(qctx, newFilter, filterGroupExpr->group());
     }
 
     auto newGNFilter = condition->encode();
@@ -78,47 +79,30 @@ Status PushFilterDownGetNbrsRule::transform(QueryContext *qctx,
     auto newGN = gn->clone(qctx);
     newGN->setFilter(newGNFilter);
 
-    OptGroupExpr *newGroupExpr = nullptr;
+    OptGroupExpr *newGnGroupExpr = nullptr;
     if (newFilterGroupExpr != nullptr) {
         // Filter(A&&B)->GetNeighbors(C) => Filter(A)->GetNeighbors(B&&C)
         auto newGroup = OptGroup::create(qctx);
-        newGroupExpr = OptGroupExpr::create(qctx, newGN, newGroup);
+        newGnGroupExpr = OptGroupExpr::create(qctx, newGN, newGroup);
         newFilterGroupExpr->dependsOn(newGroup);
     } else {
         // Filter(A)->GetNeighbors(C) => GetNeighbors(A&&C)
-        newGroupExpr = OptGroupExpr::create(qctx, newGN, groupExpr->group());
+        newGnGroupExpr = OptGroupExpr::create(qctx, newGN, filterGroupExpr->group());
         newGN->setOutputVar(filter->outputVar());
     }
 
-    for (auto dep : pair.second->dependencies()) {
-        newGroupExpr->dependsOn(dep);
+    for (auto dep : gnGroupExpr->dependencies()) {
+        newGnGroupExpr->dependsOn(dep);
     }
-    result->newGroupExprs.emplace_back(newFilterGroupExpr ? newFilterGroupExpr : newGroupExpr);
-    result->eraseAll = true;
-    result->eraseCurr = true;
 
-    return Status::OK();
+    TransformResult result;
+    result.newGroupExprs.emplace_back(newFilterGroupExpr ? newFilterGroupExpr : newGnGroupExpr);
+    result.eraseCurr = true;
+    return result;
 }
 
 std::string PushFilterDownGetNbrsRule::toString() const {
     return "PushFilterDownGetNbrsRule";
-}
-
-std::pair<bool, const OptGroupExpr *> PushFilterDownGetNbrsRule::findMatchedGroupExpr(
-    const OptGroupExpr *groupExpr) const {
-    auto node = groupExpr->node();
-    if (node->kind() != PlanNode::Kind::kFilter) {
-        return std::make_pair(false, nullptr);
-    }
-
-    for (auto dep : groupExpr->dependencies()) {
-        for (auto expr : dep->groupExprs()) {
-            if (expr->node()->kind() == PlanNode::Kind::kGetNeighbors) {
-                return std::make_pair(true, expr);
-            }
-        }
-    }
-    return std::make_pair(false, nullptr);
 }
 
 }   // namespace opt

--- a/src/optimizer/rule/PushFilterDownGetNbrsRule.h
+++ b/src/optimizer/rule/PushFilterDownGetNbrsRule.h
@@ -20,18 +20,16 @@ namespace opt {
 
 class PushFilterDownGetNbrsRule final : public OptRule {
 public:
-    static std::unique_ptr<OptRule> kInstance;
-
-    bool match(const OptGroupExpr *groupExpr) const override;
-    Status transform(graph::QueryContext *qctx,
-                     const OptGroupExpr *groupExpr,
-                     TransformResult *result) const override;
+    const Pattern &pattern() const override;
+    bool match(const MatchedResult &result) const override;
+    StatusOr<TransformResult> transform(graph::QueryContext *qctx,
+                                        const MatchedResult &result) const override;
     std::string toString() const override;
 
 private:
     PushFilterDownGetNbrsRule();
 
-    std::pair<bool, const OptGroupExpr *> findMatchedGroupExpr(const OptGroupExpr *groupExpr) const;
+    static std::unique_ptr<OptRule> kInstance;
 };
 
 }   // namespace opt

--- a/src/optimizer/rule/PushFilterDownGetNbrsRule.h
+++ b/src/optimizer/rule/PushFilterDownGetNbrsRule.h
@@ -21,7 +21,6 @@ namespace opt {
 class PushFilterDownGetNbrsRule final : public OptRule {
 public:
     const Pattern &pattern() const override;
-    bool match(const MatchedResult &matched) const override;
     StatusOr<TransformResult> transform(graph::QueryContext *qctx,
                                         const MatchedResult &matched) const override;
     std::string toString() const override;

--- a/src/optimizer/rule/PushFilterDownGetNbrsRule.h
+++ b/src/optimizer/rule/PushFilterDownGetNbrsRule.h
@@ -21,9 +21,9 @@ namespace opt {
 class PushFilterDownGetNbrsRule final : public OptRule {
 public:
     const Pattern &pattern() const override;
-    bool match(const MatchedResult &result) const override;
+    bool match(const MatchedResult &matched) const override;
     StatusOr<TransformResult> transform(graph::QueryContext *qctx,
-                                        const MatchedResult &result) const override;
+                                        const MatchedResult &matched) const override;
     std::string toString() const override;
 
 private:

--- a/src/service/QueryInstance.cpp
+++ b/src/service/QueryInstance.cpp
@@ -27,9 +27,9 @@ namespace graph {
 QueryInstance::QueryInstance(std::unique_ptr<QueryContext> qctx) {
     qctx_ = std::move(qctx);
     scheduler_ = std::make_unique<Scheduler>(qctx_.get());
-    std::vector<const RuleSet *> rulesets{&RuleSet::defaultRules()};
+    std::vector<const RuleSet *> rulesets{&RuleSet::DefaultRules()};
     if (FLAGS_enable_optimizer) {
-        rulesets.emplace_back(&RuleSet::queryRules());
+        rulesets.emplace_back(&RuleSet::QueryRules());
     }
     optimizer_ = std::make_unique<Optimizer>(qctx_.get(), std::move(rulesets));
 }

--- a/tests/common/nebula_service.py
+++ b/tests/common/nebula_service.py
@@ -111,7 +111,6 @@ class NebulaService(object):
             time.sleep(1)
         return False
 
-
     def start(self, debug_log=True):
         os.chdir(self.work_dir)
 

--- a/tests/nebula-test-run.py
+++ b/tests/nebula-test-run.py
@@ -110,7 +110,7 @@ if __name__ == "__main__":
         # Switch to your $src_dir/tests
         os.chdir(TEST_DIR)
         error_code = executor.run_tests(args)
-        data_loader.drop_data()
+        # data_loader.drop_data()
     except Exception as x:
         print('\033[31m' + str(x) + '\033[0m')
 

--- a/tests/nebula-test-run.py
+++ b/tests/nebula-test-run.py
@@ -110,7 +110,7 @@ if __name__ == "__main__":
         # Switch to your $src_dir/tests
         os.chdir(TEST_DIR)
         error_code = executor.run_tests(args)
-        # data_loader.drop_data()
+        data_loader.drop_data()
     except Exception as x:
         print('\033[31m' + str(x) + '\033[0m')
 


### PR DESCRIPTION
When we add new optimize rules, we must find expected OptGroupExpr twice in match and transform interfaces. This PR try to simplify this process by introducing the pattern match method.


