### PR TITLE
Extract filter node

### DIFF
--- a/src/validator/GoValidator.h
+++ b/src/validator/GoValidator.h
@@ -65,6 +65,8 @@ private:
 
     PlanNode* buildJoinDstProps(PlanNode* projectSrcDstProps);
 
+    void rewriteFilterToInputProp();
+
 private:
     Over                                                    over_;
     Expression*                                             filter_{nullptr};

--- a/src/validator/GoValidator.h
+++ b/src/validator/GoValidator.h
@@ -65,6 +65,8 @@ private:
 
     PlanNode* buildJoinDstProps(PlanNode* projectSrcDstProps);
 
+    void extractFilter();
+
 private:
     Over                                                    over_;
     Expression*                                             filter_{nullptr};
@@ -78,7 +80,7 @@ private:
     YieldColumns*                                           dstPropCols_{nullptr};
     YieldColumns*                                           inputPropCols_{nullptr};
     std::unordered_map<std::string, YieldColumn*>           propExprColMap_;
-    Expression*                                             filter1_{nullptr};
+    Expression*                                             filter1_{nullptr};  // can be push down
     Expression*                                             filter2_{nullptr};
     Expression*                                             newFilter_{nullptr};
     Expression*                                             newFilter1_{nullptr};

--- a/src/validator/GoValidator.h
+++ b/src/validator/GoValidator.h
@@ -65,8 +65,6 @@ private:
 
     PlanNode* buildJoinDstProps(PlanNode* projectSrcDstProps);
 
-    void rewriteFilterToInputProp();
-
 private:
     Over                                                    over_;
     Expression*                                             filter_{nullptr};
@@ -80,7 +78,11 @@ private:
     YieldColumns*                                           dstPropCols_{nullptr};
     YieldColumns*                                           inputPropCols_{nullptr};
     std::unordered_map<std::string, YieldColumn*>           propExprColMap_;
+    Expression*                                             filter1_{nullptr};
+    Expression*                                             filter2_{nullptr};
     Expression*                                             newFilter_{nullptr};
+    Expression*                                             newFilter1_{nullptr};
+    Expression*                                             newFilter2_{nullptr};
     YieldColumns*                                           newYieldCols_{nullptr};
     // Used for n steps to trace the path
     std::string                                             dstVidColName_;


### PR DESCRIPTION
When the filter condition in the go statement contains not only SrcProperty but also DstProperty,  the GetNeighbors and Filter plan nodes will be far apart so that the FilterPushDownGetNbrRule cannot be applied to this situation.
This PR split the filter condition into two plan node that can be pushed down and those that cannot be pushed down so that FilterPushDownGetNbrRule can be applied to such a situation.

Maybe do it in Optimizer is more elegant.