### PR TITLE
Fix match return vertex undefined labels 

### DIFF
--- a/src/context/Iterator.cpp
+++ b/src/context/Iterator.cpp
@@ -633,7 +633,11 @@ Value PropIter::getVertex() const {
         Tag tag;
         tag.name = tagProp.first;
         for (auto& propIndex : tagProp.second) {
-            tag.props.emplace(propIndex.first, row[propIndex.second]);
+            if (propIndex.first == "_tag") {
+                continue;
+            } else {
+                tag.props.emplace(propIndex.first, row[propIndex.second]);
+            }
         }
         vertex.tags.emplace_back(std::move(tag));
     }

--- a/src/context/Iterator.cpp
+++ b/src/context/Iterator.cpp
@@ -618,7 +618,9 @@ Value PropIter::getVertex() const {
     auto& tagPropsMap = dsIndex_.propsMap;
     bool isVertexProps = true;
     auto& row = *(iter_->row_);
+    // tagPropsMap -> <std::string, std::unordered_map<std::string, size_t> >
     for (auto& tagProp : tagPropsMap) {
+        // propIndex -> std::unordered_map<std::string, size_t>
         for (auto& propIndex : tagProp.second) {
             if (row[propIndex.second].empty()) {
                 // Not current vertex's prop

--- a/src/context/Iterator.cpp
+++ b/src/context/Iterator.cpp
@@ -137,7 +137,7 @@ StatusOr<int64_t> GetNeighborsIter::buildIndex(DataSetIndex* dsIndex) {
     for (size_t i = 0; i < colNames.size(); ++i) {
         dsIndex->colIndices.emplace(colNames[i], i);
         auto& colName = colNames[i];
-        if (colName.find("_tag") == 0) {
+        if (colName.find(nebula::kTag) == 0) {  // "_tag"
             NG_RETURN_IF_ERROR(buildPropIndex(colName, i, false, dsIndex));
         } else if (colName.find("_edge") == 0) {
             NG_RETURN_IF_ERROR(buildPropIndex(colName, i, true, dsIndex));
@@ -635,7 +635,7 @@ Value PropIter::getVertex() const {
         Tag tag;
         tag.name = tagProp.first;
         for (auto& propIndex : tagProp.second) {
-            if (propIndex.first == "_tag") {
+            if (propIndex.first == nebula::kTag) {  // "_tag"
                 continue;
             } else {
                 tag.props.emplace(propIndex.first, row[propIndex.second]);

--- a/src/parser/parser.yy
+++ b/src/parser/parser.yy
@@ -868,6 +868,9 @@ function_call_expression
     | KW_DATETIME L_PAREN opt_argument_list R_PAREN {
         $$ = new FunctionCallExpression(new std::string("datetime"), $3);
     }
+    | KW_TAGS L_PAREN opt_argument_list R_PAREN {
+        $$ = new FunctionCallExpression(new std::string("tags"), $3);
+    }
     ;
 
 aggregate_expression

--- a/src/planner/match/MatchClausePlanner.cpp
+++ b/src/planner/match/MatchClausePlanner.cpp
@@ -310,12 +310,13 @@ StatusOr<std::vector<storage::cpp2::VertexProp>>
     // Get all tags in the space
     const auto allTagsResult = qctx->schemaMng()->getAllVerTagSchema(space.id);
     NG_RETURN_IF_ERROR(allTagsResult);
+    // allTags: std::unordered_map<TagID, std::vector<std::shared_ptr<const NebulaSchemaProvider>>>
     const auto allTags = std::move(allTagsResult).value();
-    // std::unordered_map<TagID, std::vector<std::shared_ptr<const NebulaSchemaProvider>>>
 
     std::vector<storage::cpp2::VertexProp> props;
-    // tag: pair<TagID, std::vector<std::shared_ptr<const NebulaSchemaProvider>>>
+    // Retrieve prop names of each tag and append "_tag" to the name list to query empty tags
     for (const auto &tag : allTags) {
+        // tag: pair<TagID, std::vector<std::shared_ptr<const NebulaSchemaProvider>>>
         std::vector<std::string> propNames;
         storage::cpp2::VertexProp vProp;
 

--- a/src/planner/match/MatchClausePlanner.cpp
+++ b/src/planner/match/MatchClausePlanner.cpp
@@ -272,7 +272,6 @@ Status MatchClausePlanner::appendFetchVertexPlan(const Expression* nodeFilter,
         space.id,
         qctx->objPool()->add(srcExpr.release()),
         std::move(props).value(),
-        // {},
         {});
 
     PlanNode* root = gv;

--- a/src/planner/match/MatchClausePlanner.cpp
+++ b/src/planner/match/MatchClausePlanner.cpp
@@ -307,7 +307,7 @@ Status MatchClausePlanner::appendFetchVertexPlan(const Expression* nodeFilter,
 StatusOr<std::vector<storage::cpp2::VertexProp>>
 MatchClausePlanner::flattenTags(QueryContext *qctx, const SpaceInfo& space) {
     // Get all tags in the space
-    const auto allTagsResult = qctx->schemaMng()->getAllVerTagSchema(space.id);
+    const auto allTagsResult = qctx->schemaMng()->getAllLatestVerTagSchema(space.id);
     NG_RETURN_IF_ERROR(allTagsResult);
     // allTags: std::unordered_map<TagID, std::vector<std::shared_ptr<const NebulaSchemaProvider>>>
     const auto allTags = std::move(allTagsResult).value();

--- a/src/planner/match/MatchClausePlanner.cpp
+++ b/src/planner/match/MatchClausePlanner.cpp
@@ -305,7 +305,7 @@ Status MatchClausePlanner::appendFetchVertexPlan(const Expression* nodeFilter,
 }
 
 StatusOr<std::vector<storage::cpp2::VertexProp>>
-        MatchClausePlanner::flattenTags(QueryContext *qctx, const SpaceInfo& space) {
+MatchClausePlanner::flattenTags(QueryContext *qctx, const SpaceInfo& space) {
     // Get all tags in the space
     const auto allTagsResult = qctx->schemaMng()->getAllVerTagSchema(space.id);
     NG_RETURN_IF_ERROR(allTagsResult);

--- a/src/planner/match/MatchClausePlanner.cpp
+++ b/src/planner/match/MatchClausePlanner.cpp
@@ -311,23 +311,47 @@ StatusOr<std::vector<storage::cpp2::VertexProp>>
     std::set<std::string> dummySet;
     DeducePropsVisitor deducePropsVisitor(qctx, space.id, &exprProps, &dummySet);
 
-    // Get props
-    std::vector<storage::cpp2::VertexProp> props;
-    for (const auto &tagNameId : exprProps.tagNameIds()) {
-        storage::cpp2::VertexProp vProp;
+    // Get all tags in the space
+    const auto allTagsResult = qctx->schemaMng()->getAllVerTagSchema(space.id);
+    NG_RETURN_IF_ERROR(allTagsResult);
+    const auto allTags = std::move(allTagsResult).value();
+    // std::map<TagID, std::shared_ptr<const meta::SchemaProviderIf>> tagsSchema;
+
+     std::vector<storage::cpp2::VertexProp> props;
+    for (const auto &tag : allTags) {
+        // tagsSchema.emplace(tag.first, tag.second.back());
         std::vector<std::string> propNames;
-        propNames.reserve(exprProps.tagProps().at(tagNameId.second).size());
-        vProp.set_tag(tagNameId.second);
-        for (const auto &prop : exprProps.tagProps().at(tagNameId.second)) {
-            propNames.emplace_back(prop.toString());
-             VLOG(1) << "propNames: \n" << prop.toString() << "\n";
+        storage::cpp2::VertexProp vProp;
+
+        // const auto tagId = tag.first;
+        const auto tagSchema = tag.second.back();  // nebulaSchemaProvider
+        for (size_t i=0; i < tagSchema->size(); i++) {
+            const auto propName = tagSchema->getFieldName(i);
+            propNames.emplace_back(propName);
         }
         propNames.emplace_back("_tag");
-         VLOG(1) << "_tag added \n";
         vProp.set_props(std::move(propNames));
         props.emplace_back(std::move(vProp));
     }
     return props;
+    // Get props
+    // std::vector<storage::cpp2::VertexProp> props;
+    // for (const auto &tagNameId : exprProps.tagNameIds()) {
+    //     storage::cpp2::VertexProp vProp;
+    //     std::vector<std::string> propNames;
+    //     propNames.reserve(exprProps.tagProps().at(tagNameId.second).size());
+    //     vProp.set_tag(tagNameId.second);
+    //     for (const auto &prop : exprProps.tagProps().at(tagNameId.second)) {
+    //         propNames.emplace_back(prop.toString());
+    //          VLOG(1) << "propNames: \n" << prop.toString() << "\n";
+    //     }
+    //     // Insert "_tag" to make empty tags be to recognized
+    //     propNames.emplace_back("_tag");
+    //      VLOG(1) << "_tag added \n";
+    //     vProp.set_props(std::move(propNames));
+    //     props.emplace_back(std::move(vProp));
+    // }
+    // return props;
 }
 
 Status MatchClausePlanner::projectColumnsBySymbols(MatchClauseContext* matchClauseCtx,

--- a/src/planner/match/MatchClausePlanner.cpp
+++ b/src/planner/match/MatchClausePlanner.cpp
@@ -309,24 +309,25 @@ MatchClausePlanner::flattenTags(QueryContext *qctx, const SpaceInfo& space) {
     // Get all tags in the space
     const auto allTagsResult = qctx->schemaMng()->getAllLatestVerTagSchema(space.id);
     NG_RETURN_IF_ERROR(allTagsResult);
-    // allTags: std::unordered_map<TagID, std::vector<std::shared_ptr<const NebulaSchemaProvider>>>
+    // allTags: std::unordered_map<TagID, std::shared_ptr<const meta::NebulaSchemaProvider>>
     const auto allTags = std::move(allTagsResult).value();
 
     std::vector<storage::cpp2::VertexProp> props;
+    props.reserve(allTags.size());
     // Retrieve prop names of each tag and append "_tag" to the name list to query empty tags
     for (const auto &tag : allTags) {
-        // tag: pair<TagID, std::vector<std::shared_ptr<const NebulaSchemaProvider>>>
+        // tag: pair<TagID, std::shared_ptr<const meta::NebulaSchemaProvider>>
         std::vector<std::string> propNames;
         storage::cpp2::VertexProp vProp;
 
         const auto tagId = tag.first;
         vProp.set_tag(tagId);
-        const auto tagSchema = tag.second.back();  // nebulaSchemaProvider
+        const auto tagSchema = tag.second;  // nebulaSchemaProvider
         for (size_t i=0; i < tagSchema->getNumFields(); i++) {
             const auto propName = tagSchema->getFieldName(i);
             propNames.emplace_back(propName);
         }
-        propNames.emplace_back("_tag");
+        propNames.emplace_back(nebula::kTag);  // "_tag"
         vProp.set_props(std::move(propNames));
         props.emplace_back(std::move(vProp));
     }

--- a/src/planner/match/MatchClausePlanner.h
+++ b/src/planner/match/MatchClausePlanner.h
@@ -80,7 +80,7 @@ private:
                                  size_t nodeInfoSize) const;
 
     Status appendFilterPlan(MatchClauseContext* matchClauseCtx, SubPlan& subplan);
-
+    // Fetch all tags in the space and retrieve props from tags
     StatusOr<std::vector<storage::cpp2::VertexProp>>
         flattenTags(QueryContext *qctx, const SpaceInfo& space);
 

--- a/src/planner/match/MatchClausePlanner.h
+++ b/src/planner/match/MatchClausePlanner.h
@@ -81,6 +81,9 @@ private:
 
     Status appendFilterPlan(MatchClauseContext* matchClauseCtx, SubPlan& subplan);
 
+    StatusOr<std::vector<storage::cpp2::VertexProp>>
+        flattenTags(QueryContext *qctx, const SpaceInfo& space);
+
 private:
     std::unique_ptr<Expression> initialExpr_;
 };

--- a/src/planner/match/MatchClausePlanner.h
+++ b/src/planner/match/MatchClausePlanner.h
@@ -81,8 +81,8 @@ private:
 
     Status appendFilterPlan(MatchClauseContext* matchClauseCtx, SubPlan& subplan);
     // Fetch all tags in the space and retrieve props from tags
-    StatusOr<std::vector<storage::cpp2::VertexProp>>
-        flattenTags(QueryContext *qctx, const SpaceInfo& space);
+    StatusOr<std::vector<storage::cpp2::VertexProp>> flattenTags(QueryContext *qctx,
+                                                                 const SpaceInfo& space);
 
 private:
     std::unique_ptr<Expression> initialExpr_;

--- a/src/validator/FetchVerticesValidator.cpp
+++ b/src/validator/FetchVerticesValidator.cpp
@@ -81,11 +81,11 @@ Status FetchVerticesValidator::check() {
         }
     } else {
         onStar_ = true;
-        const auto allTagsResult = qctx_->schemaMng()->getAllVerTagSchema(space_.id);
+        const auto allTagsResult = qctx_->schemaMng()->getAllLatestVerTagSchema(space_.id);
         NG_RETURN_IF_ERROR(allTagsResult);
         const auto allTags = std::move(allTagsResult).value();
         for (const auto &tag : allTags) {
-            tagsSchema_.emplace(tag.first, tag.second.back());
+            tagsSchema_.emplace(tag.first, tag.second);
         }
         for (const auto &tagSchema : tagsSchema_) {
             auto tagNameResult = qctx_->schemaMng()->toTagName(space_.id, tagSchema.first);

--- a/src/validator/FetchVerticesValidator.h
+++ b/src/validator/FetchVerticesValidator.h
@@ -50,8 +50,8 @@ private:
     std::vector<storage::cpp2::OrderBy> orderBy_{};
     int64_t limit_{std::numeric_limits<int64_t>::max()};
     std::string filter_{};
-    // valid when yield expression not require storage
-    // So expression like these will be evaluate in Project Executor
+    // valid when yield expression does not require storage
+    // So expression like these will be evaluated in Project Executor
     bool withProject_{false};
     // outputs
     std::vector<std::string> gvColNames_;

--- a/src/validator/GetSubgraphValidator.cpp
+++ b/src/validator/GetSubgraphValidator.cpp
@@ -342,11 +342,11 @@ Status GetSubgraphValidator::toPlan() {
 StatusOr<std::vector<storage::cpp2::VertexProp>> GetSubgraphValidator::buildVertexProp() {
     // list all tag properties
     std::map<TagID, std::shared_ptr<const meta::SchemaProviderIf>> tagsSchema;
-    const auto allTagsResult = qctx()->schemaMng()->getAllVerTagSchema(space_.id);
+    const auto allTagsResult = qctx()->schemaMng()->getAllLatestVerTagSchema(space_.id);
     NG_RETURN_IF_ERROR(allTagsResult);
     const auto allTags = std::move(allTagsResult).value();
     for (const auto& tag : allTags) {
-        tagsSchema.emplace(tag.first, tag.second.back());
+        tagsSchema.emplace(tag.first, tag.second);
     }
     std::vector<storage::cpp2::VertexProp> vProps;
     for (const auto& tagSchema : tagsSchema) {

--- a/src/validator/MatchValidator.cpp
+++ b/src/validator/MatchValidator.cpp
@@ -427,8 +427,8 @@ Status MatchValidator::validateStepRange(const MatchStepRange *range) const {
     if (max == std::numeric_limits<int64_t>::max()) {
         return Status::SemanticError("Not set maximum hop for variable length relationships");
     }
-    if (min == 0) {
-        return Status::SemanticError("Zero steps implementation coming soon.");
+    if (min < 0) {
+        return Status::SemanticError("Negtive steps are invalid");
     }
     return Status::OK();
 }

--- a/src/validator/test/MockSchemaManager.h
+++ b/src/validator/test/MockSchemaManager.h
@@ -79,8 +79,8 @@ public:
     }
 
     // Returns all latest version of schesmas of all tags in the given space
-    StatusOr<meta::TagLatestSchema> getAllLatestVerTagSchema(GraphSpaceID space) override {
-        meta::TagLatestSchema allLatestVerTagSchemas;
+    StatusOr<meta::TagSchema> getAllLatestVerTagSchema(GraphSpaceID space) override {
+        meta::TagSchema allLatestVerTagSchemas;
         const auto& tagSchemas = tagSchemas_[space];
         for (const auto &tagSchema : tagSchemas) {
             allLatestVerTagSchemas.emplace(tagSchema.first, tagSchema.second);

--- a/src/validator/test/MockSchemaManager.h
+++ b/src/validator/test/MockSchemaManager.h
@@ -78,6 +78,18 @@ public:
         return allVerTagSchemas;
     }
 
+    // get all latest version of all tags
+    StatusOr<meta::TagSchemas> getAllLatestVerTagSchema(GraphSpaceID space) override {
+        meta::TagSchemas allLatestVerTagSchemas;
+        const auto& tagSchemas = tagSchemas_[space];
+        for (const auto &tagSchema : tagSchemas) {
+            allLatestVerTagSchemas.emplace(tagSchema.first,
+                                     std::vector<std::shared_ptr<const meta::NebulaSchemaProvider>>
+                                        {tagSchema.second});
+        }
+        return allLatestVerTagSchemas;
+    }
+
     // get all version of all edges
     StatusOr<meta::EdgeSchemas> getAllVerEdgeSchema(GraphSpaceID space) override {
         meta::EdgeSchemas allVerEdgeSchemas;

--- a/src/validator/test/MockSchemaManager.h
+++ b/src/validator/test/MockSchemaManager.h
@@ -66,7 +66,7 @@ public:
         return 8;
     }
 
-    // get all version of all tags
+    // Returns all version of all tags
     StatusOr<meta::TagSchemas> getAllVerTagSchema(GraphSpaceID space) override {
         meta::TagSchemas allVerTagSchemas;
         const auto& tagSchemas = tagSchemas_[space];
@@ -78,19 +78,17 @@ public:
         return allVerTagSchemas;
     }
 
-    // get all latest version of all tags
-    StatusOr<meta::TagSchemas> getAllLatestVerTagSchema(GraphSpaceID space) override {
-        meta::TagSchemas allLatestVerTagSchemas;
+    // Returns all latest version of schesmas of all tags in the given space
+    StatusOr<meta::TagLatestSchema> getAllLatestVerTagSchema(GraphSpaceID space) override {
+        meta::TagLatestSchema allLatestVerTagSchemas;
         const auto& tagSchemas = tagSchemas_[space];
         for (const auto &tagSchema : tagSchemas) {
-            allLatestVerTagSchemas.emplace(tagSchema.first,
-                                     std::vector<std::shared_ptr<const meta::NebulaSchemaProvider>>
-                                        {tagSchema.second});
+            allLatestVerTagSchemas.emplace(tagSchema.first, tagSchema.second);
         }
         return allLatestVerTagSchemas;
     }
 
-    // get all version of all edges
+    // Returns all version of all edges
     StatusOr<meta::EdgeSchemas> getAllVerEdgeSchema(GraphSpaceID space) override {
         meta::EdgeSchemas allVerEdgeSchemas;
         const auto& edgeSchemas = edgeSchemas_[space];

--- a/tests/tck/features/bugfix/MatchReturnEmptyTag.feature
+++ b/tests/tck/features/bugfix/MatchReturnEmptyTag.feature
@@ -2,11 +2,16 @@
 #
 # This source code is licensed under Apache 2.0 License,
 # attached with Common Clause Condition 1.0, found in the LICENSES directory.
+@test
 Feature: Fix match losing undefined vertex tag info
+    Examples:
+      | space       | vid                |
+      | nba         | "Tim Duncan"       |
+      | nba_int_vid | hash("Tim Duncan") |
 
-  Background: Prepare Space
+  Background: Prepare a new space with nba loaded and insert an empty tag
     Given an empty graph
-    And load "nba" csv data to a new space
+    And load "<space>" csv data to a new space
     And having executed:
       """
       CREATE TAG IF NOT EXISTS empty_tag();
@@ -14,11 +19,11 @@ Feature: Fix match losing undefined vertex tag info
     And wait 2 seconds
     And having executed:
       """
-      INSERT VERTEX empty_tag() values "Tim Duncan":()
+      INSERT VERTEX empty_tag() values <vid>:()
       """
     And wait 2 seconds
 
-  Scenario: single vertex
+  Scenario Outline: single vertex
     When executing query:
       """
       MATCH (v:player{name:"Tim Duncan"})
@@ -36,7 +41,7 @@ Feature: Fix match losing undefined vertex tag info
       | Labels                              |
       | ["player", "empty_tag", "bachelor"] |
 
-  Scenario: one step with direction
+  Scenario Outline: one step with direction
     When executing query:
       """
       MATCH (v:player{name:"Tim Duncan"})-->()
@@ -66,7 +71,7 @@ Feature: Fix match losing undefined vertex tag info
       | ["player", "empty_tag", "bachelor"] |
       | ["player", "empty_tag", "bachelor"] |
 
-  Scenario: one step without direction
+  Scenario Outline: one step without direction
     When executing query:
       """
       MATCH (v:player{name:"Tim Duncan"})--()

--- a/tests/tck/features/bugfix/MatchReturnEmptyTag.feature
+++ b/tests/tck/features/bugfix/MatchReturnEmptyTag.feature
@@ -2,12 +2,11 @@
 #
 # This source code is licensed under Apache 2.0 License,
 # attached with Common Clause Condition 1.0, found in the LICENSES directory.
-@test
 Feature: Fix match losing undefined vertex tag info
-    Examples:
-      | space       | vid                |
-      | nba         | "Tim Duncan"       |
-      | nba_int_vid | hash("Tim Duncan") |
+  Examples:
+    | space       | vid                |
+    | nba         | "Tim Duncan"       |
+    | nba_int_vid | hash("Tim Duncan") |
 
   Background: Prepare a new space with nba loaded and insert an empty tag
     Given an empty graph

--- a/tests/tck/features/bugfix/MatchReturnEmptyTag.feature
+++ b/tests/tck/features/bugfix/MatchReturnEmptyTag.feature
@@ -2,11 +2,11 @@
 #
 # This source code is licensed under Apache 2.0 License,
 # attached with Common Clause Condition 1.0, found in the LICENSES directory.
-@wyc
 Feature: Fix match losing undefined vertex tag info
 
-  Background:
-    Given a graph with space named "nba"
+  Background: Prepare Space
+    Given an empty graph
+    And load "nba" csv data to a new space
     And having executed:
       """
       CREATE TAG IF NOT EXISTS empty_tag();

--- a/tests/tck/features/bugfix/MatchReturnEmptyTag.feature
+++ b/tests/tck/features/bugfix/MatchReturnEmptyTag.feature
@@ -2,7 +2,6 @@
 #
 # This source code is licensed under Apache 2.0 License,
 # attached with Common Clause Condition 1.0, found in the LICENSES directory.
-@test
 Feature: Fix match losing undefined vertex tag info
 
   Background: Prepare Space

--- a/tests/tck/features/bugfix/MatchReturnEmptyTag.feature
+++ b/tests/tck/features/bugfix/MatchReturnEmptyTag.feature
@@ -1,0 +1,45 @@
+# Copyright (c) 2020 vesoft inc. All rights reserved.
+#
+# This source code is licensed under Apache 2.0 License,
+# attached with Common Clause Condition 1.0, found in the LICENSES directory.
+@wyc
+Feature: Fix match losing undefined vertex tag info
+
+  Background:
+    Given a graph with space named "nba"
+    And having executed:
+      """
+      CREATE TAG IF NOT EXISTS empty_tag();
+      """
+    And wait 2 seconds
+    And having executed:
+      """
+      INSERT VERTEX empty_tag() values "Tim Duncan":()
+      """
+    And wait 2 seconds
+
+  Scenario: single vertex
+    When executing query:
+      """
+      MATCH (v:player{name:"Tim Duncan"})
+      RETURN labels(v) AS Labels
+      """
+    Then the result should be, in any order:
+      | Labels                            |
+      | ["empty_tag","bachelor","player"] |
+
+  Scenario: one step
+    When executing query:
+      """
+      MATCH (v:player{name:"Tim Duncan"})-->()
+      RETURN labels(v) AS Labels
+      """
+    Then the result should be, in any order:
+      | Labels                            |
+      | ["empty_tag","bachelor","player"] |
+      | ["empty_tag","bachelor","player"] |
+      | ["empty_tag","bachelor","player"] |
+      | ["empty_tag","bachelor","player"] |
+      | ["empty_tag","bachelor","player"] |
+      | ["empty_tag","bachelor","player"] |
+      | ["empty_tag","bachelor","player"] |

--- a/tests/tck/features/bugfix/MatchReturnEmptyTag.feature
+++ b/tests/tck/features/bugfix/MatchReturnEmptyTag.feature
@@ -2,6 +2,7 @@
 #
 # This source code is licensed under Apache 2.0 License,
 # attached with Common Clause Condition 1.0, found in the LICENSES directory.
+@test
 Feature: Fix match losing undefined vertex tag info
 
   Background: Prepare Space
@@ -27,6 +28,14 @@ Feature: Fix match losing undefined vertex tag info
     Then the result should be, in any order:
       | Labels                              |
       | ["player", "empty_tag", "bachelor"] |
+    When executing query:
+      """
+      MATCH (v:player{name:"Tim Duncan"})
+      RETURN tags(v) AS Labels
+      """
+    Then the result should be, in any order:
+      | Labels                              |
+      | ["player", "empty_tag", "bachelor"] |
 
   Scenario: one step with direction
     When executing query:
@@ -43,12 +52,52 @@ Feature: Fix match losing undefined vertex tag info
       | ["player", "empty_tag", "bachelor"] |
       | ["player", "empty_tag", "bachelor"] |
       | ["player", "empty_tag", "bachelor"] |
+    When executing query:
+      """
+      MATCH (v:player{name:"Tim Duncan"})-->()
+      RETURN tags(v) AS Labels
+      """
+    Then the result should be, in any order:
+      | Labels                              |
+      | ["player", "empty_tag", "bachelor"] |
+      | ["player", "empty_tag", "bachelor"] |
+      | ["player", "empty_tag", "bachelor"] |
+      | ["player", "empty_tag", "bachelor"] |
+      | ["player", "empty_tag", "bachelor"] |
+      | ["player", "empty_tag", "bachelor"] |
+      | ["player", "empty_tag", "bachelor"] |
 
   Scenario: one step without direction
     When executing query:
       """
       MATCH (v:player{name:"Tim Duncan"})--()
       RETURN labels(v) AS Labels
+      """
+    Then the result should be, in any order:
+      | Labels                              |
+      | ["empty_tag", "bachelor", "player"] |
+      | ["empty_tag", "bachelor", "player"] |
+      | ["empty_tag", "bachelor", "player"] |
+      | ["empty_tag", "bachelor", "player"] |
+      | ["empty_tag", "bachelor", "player"] |
+      | ["empty_tag", "bachelor", "player"] |
+      | ["empty_tag", "bachelor", "player"] |
+      | ["empty_tag", "bachelor", "player"] |
+      | ["empty_tag", "bachelor", "player"] |
+      | ["empty_tag", "bachelor", "player"] |
+      | ["empty_tag", "bachelor", "player"] |
+      | ["empty_tag", "bachelor", "player"] |
+      | ["empty_tag", "bachelor", "player"] |
+      | ["empty_tag", "bachelor", "player"] |
+      | ["empty_tag", "bachelor", "player"] |
+      | ["empty_tag", "bachelor", "player"] |
+      | ["empty_tag", "bachelor", "player"] |
+      | ["empty_tag", "bachelor", "player"] |
+      | ["empty_tag", "bachelor", "player"] |
+    When executing query:
+      """
+      MATCH (v:player{name:"Tim Duncan"})--()
+      RETURN tags(v) AS Labels
       """
     Then the result should be, in any order:
       | Labels                              |

--- a/tests/tck/features/bugfix/MatchReturnEmptyTag.feature
+++ b/tests/tck/features/bugfix/MatchReturnEmptyTag.feature
@@ -25,21 +25,49 @@ Feature: Fix match losing undefined vertex tag info
       RETURN labels(v) AS Labels
       """
     Then the result should be, in any order:
-      | Labels                            |
-      | ["empty_tag","bachelor","player"] |
+      | Labels                              |
+      | ["player", "empty_tag", "bachelor"] |
 
-  Scenario: one step
+  Scenario: one step with direction
     When executing query:
       """
       MATCH (v:player{name:"Tim Duncan"})-->()
       RETURN labels(v) AS Labels
       """
     Then the result should be, in any order:
-      | Labels                            |
-      | ["empty_tag","bachelor","player"] |
-      | ["empty_tag","bachelor","player"] |
-      | ["empty_tag","bachelor","player"] |
-      | ["empty_tag","bachelor","player"] |
-      | ["empty_tag","bachelor","player"] |
-      | ["empty_tag","bachelor","player"] |
-      | ["empty_tag","bachelor","player"] |
+      | Labels                              |
+      | ["player", "empty_tag", "bachelor"] |
+      | ["player", "empty_tag", "bachelor"] |
+      | ["player", "empty_tag", "bachelor"] |
+      | ["player", "empty_tag", "bachelor"] |
+      | ["player", "empty_tag", "bachelor"] |
+      | ["player", "empty_tag", "bachelor"] |
+      | ["player", "empty_tag", "bachelor"] |
+
+  Scenario: one step without direction
+    When executing query:
+      """
+      MATCH (v:player{name:"Tim Duncan"})--()
+      RETURN labels(v) AS Labels
+      """
+    Then the result should be, in any order:
+      | Labels                              |
+      | ["empty_tag", "bachelor", "player"] |
+      | ["empty_tag", "bachelor", "player"] |
+      | ["empty_tag", "bachelor", "player"] |
+      | ["empty_tag", "bachelor", "player"] |
+      | ["empty_tag", "bachelor", "player"] |
+      | ["empty_tag", "bachelor", "player"] |
+      | ["empty_tag", "bachelor", "player"] |
+      | ["empty_tag", "bachelor", "player"] |
+      | ["empty_tag", "bachelor", "player"] |
+      | ["empty_tag", "bachelor", "player"] |
+      | ["empty_tag", "bachelor", "player"] |
+      | ["empty_tag", "bachelor", "player"] |
+      | ["empty_tag", "bachelor", "player"] |
+      | ["empty_tag", "bachelor", "player"] |
+      | ["empty_tag", "bachelor", "player"] |
+      | ["empty_tag", "bachelor", "player"] |
+      | ["empty_tag", "bachelor", "player"] |
+      | ["empty_tag", "bachelor", "player"] |
+      | ["empty_tag", "bachelor", "player"] |


### PR DESCRIPTION
Address a problem that storage does not recognize vertex tag without property

Fix https://jira.nebula-graph.io/browse/NG-344

Updates:
1. add a new interface in metaClient getAllLatestTagSchema()
2. update tck frame to add support for using Examples keyword when loading data into space
3. replace getAllVerTagSchema() with getAllLatestVerTagSchema() in graph

Depends on https://github.com/vesoft-inc/nebula-storage/pull/288 and https://github.com/vesoft-inc/nebula-common/pull/379