### PR TITLE
[PTAL] Match groupby

### DIFF
--- a/src/context/ast/QueryAstContext.h
+++ b/src/context/ast/QueryAstContext.h
@@ -112,12 +112,9 @@ struct YieldClauseContext final : CypherClauseContextBase {
 struct ReturnClauseContext final : CypherClauseContextBase {
     ReturnClauseContext() : CypherClauseContextBase(CypherClauseKind::kReturn) {}
 
-    // bool                                         distinct{false};
-    // const YieldColumns*                          yieldColumns{nullptr};
     std::unique_ptr<OrderByClauseContext>        order;
     std::unique_ptr<PaginationContext>           pagination;
     std::unique_ptr<YieldClauseContext>          yield;
-    // std::unordered_map<std::string, AliasType>*  aliasesUsed{nullptr};
 };
 
 struct WithClauseContext final : CypherClauseContextBase {

--- a/src/context/ast/QueryAstContext.h
+++ b/src/context/ast/QueryAstContext.h
@@ -24,6 +24,7 @@ enum class CypherClauseKind : uint8_t {
     kReturn,
     kOrderBy,
     kPagination,
+    kYield,
 };
 
 enum class PatternKind : uint8_t {
@@ -92,15 +93,31 @@ struct PaginationContext final : CypherClauseContextBase {
     int64_t     limit{std::numeric_limits<int64_t>::max()};
 };
 
+struct YieldClauseContext final : CypherClauseContextBase {
+    YieldClauseContext() : CypherClauseContextBase(CypherClauseKind::kYield) {}
+
+    bool                                              distinct{false};
+    const YieldColumns*                               yieldColumns{nullptr};
+    std::unordered_map<std::string, AliasType>*       aliasesUsed{nullptr};
+
+    bool                                              hasAgg_{false};
+    bool                                              needGenProject_{false};
+    YieldColumns*                                     projCols_;
+    std::vector<Expression*>                          groupKeys_;
+    std::vector<Expression*>                          groupItems_;
+    std::vector<std::string>                          aggOutputColumnNames_;
+    std::vector<std::string>                          projOutputColumnNames_;
+};
+
 struct ReturnClauseContext final : CypherClauseContextBase {
     ReturnClauseContext() : CypherClauseContextBase(CypherClauseKind::kReturn) {}
 
-    bool                                         distinct{false};
-    const YieldColumns*                          yieldColumns{nullptr};
+    // bool                                         distinct{false};
+    // const YieldColumns*                          yieldColumns{nullptr};
     std::unique_ptr<OrderByClauseContext>        order;
     std::unique_ptr<PaginationContext>           pagination;
-    std::unordered_map<std::string, AliasType>*  aliasesUsed{nullptr};
-    // TODO: grouping columns
+    std::unique_ptr<YieldClauseContext>          yield;
+    // std::unordered_map<std::string, AliasType>*  aliasesUsed{nullptr};
 };
 
 struct WithClauseContext final : CypherClauseContextBase {

--- a/src/executor/query/AggregateExecutor.cpp
+++ b/src/executor/query/AggregateExecutor.cpp
@@ -29,7 +29,7 @@ folly::Future<Status> AggregateExecutor::execute() {
     std::unordered_map<List, std::vector<std::unique_ptr<AggData>>, std::hash<nebula::List>> result;
     for (; iter->valid(); iter->next()) {
         List list;
-        for (auto& key : groupKeys) {
+        for (auto* key : groupKeys) {
             list.values.emplace_back(key->eval(ctx(iter.get())));
         }
 

--- a/src/planner/CMakeLists.txt
+++ b/src/planner/CMakeLists.txt
@@ -27,6 +27,7 @@ nebula_add_library(
     match/UnwindClausePlanner.cpp
     match/ReturnClausePlanner.cpp
     match/OrderByClausePlanner.cpp
+    match/YieldClausePlanner.cpp
     match/PaginationPlanner.cpp
     match/WhereClausePlanner.cpp
     match/WithClausePlanner.cpp

--- a/src/planner/match/YieldClausePlanner.cpp
+++ b/src/planner/match/YieldClausePlanner.cpp
@@ -1,0 +1,114 @@
+/* Copyright (c) 2020 vesoft inc. All rights reserved.
+ *
+ * This source code is licensed under Apache 2.0 License,
+ * attached with Common Clause Condition 1.0, found in the LICENSES directory.
+ */
+
+#include "planner/match/YieldClausePlanner.h"
+
+#include "planner/Query.h"
+#include "visitor/RewriteMatchLabelVisitor.h"
+#include "planner/match/MatchSolver.h"
+
+namespace nebula {
+namespace graph {
+StatusOr<SubPlan> YieldClausePlanner::transform(CypherClauseContextBase* clauseCtx) {
+    if (clauseCtx->kind != CypherClauseKind::kYield) {
+        return Status::Error("Not a valid context for YieldClausePlanner.");
+    }
+    auto* yieldCtx = static_cast<YieldClauseContext*>(clauseCtx);
+
+    SubPlan yieldPlan;
+    NG_RETURN_IF_ERROR(buildYield(yieldCtx, yieldPlan));
+    return yieldPlan;
+}
+
+void rewriteYieldColumns(std::unordered_map<std::string, AliasType>* aliasesUsed,
+                         const YieldColumns* yields,
+                         YieldColumns* newYields) {
+    auto rewriter = [aliasesUsed](const Expression* expr) {
+        return MatchSolver::doRewrite(*aliasesUsed, expr);
+    };
+
+    for (auto* col : yields->columns()) {
+        auto colExpr = col->expr();
+        auto kind = colExpr->kind();
+        YieldColumn* newColumn = nullptr;
+        if (kind == Expression::Kind::kLabel || kind == Expression::Kind::kLabelAttribute) {
+            newColumn = new YieldColumn(rewriter(colExpr));
+        } else {
+            auto newExpr = colExpr->clone();
+            RewriteMatchLabelVisitor visitor(rewriter);
+            newExpr->accept(&visitor);
+            newColumn = new YieldColumn(newExpr.release());
+        }
+        newYields->addColumn(newColumn);
+    }
+}
+
+void rewriteExprs(std::unordered_map<std::string, AliasType>* aliasesUsed,
+                  const std::vector<Expression*>* exprs,
+                  std::vector<Expression*>* newExprs) {
+    auto rewriter = [aliasesUsed](const Expression* expr) {
+        return MatchSolver::doRewrite(*aliasesUsed, expr);
+    };
+
+    for (auto* expr : *exprs) {
+        auto kind = expr->kind();
+        if (kind == Expression::Kind::kLabel || kind == Expression::Kind::kLabelAttribute) {
+            newExprs->emplace_back(MatchSolver::doRewrite(*aliasesUsed, expr));
+        } else {
+            auto newExpr = expr->clone();
+            RewriteMatchLabelVisitor visitor(rewriter);
+            newExpr->accept(&visitor);
+            newExprs->emplace_back(newExpr.release());
+        }
+    }
+}
+
+Status YieldClausePlanner::buildYield(YieldClauseContext* yctx, SubPlan& subplan) {
+    auto* currentRoot = subplan.root;
+    DCHECK(!currentRoot);
+    auto* newProjCols = yctx->qctx->objPool()->add(new YieldColumns());
+    rewriteYieldColumns(yctx->aliasesUsed, yctx->projCols_, newProjCols);
+    if (!yctx->hasAgg_) {
+        auto* project = Project::make(yctx->qctx,
+                                      currentRoot,
+                                      newProjCols);
+        project->setColNames(std::move(yctx->projOutputColumnNames_));
+        subplan.root = project;
+        subplan.tail = project;
+    } else {
+        std::vector<Expression*> newGroupKeys;
+        std::vector<Expression*> newGroupItems;
+        rewriteExprs(yctx->aliasesUsed, &yctx->groupKeys_, &newGroupKeys);
+        rewriteExprs(yctx->aliasesUsed, &yctx->groupItems_, &newGroupItems);
+
+        auto* agg = Aggregate::make(yctx->qctx,
+                                    currentRoot,
+                                    std::move(newGroupKeys),
+                                    std::move(newGroupItems));
+        agg->setColNames(std::vector<std::string>(yctx->aggOutputColumnNames_));
+        if (yctx->needGenProject_) {
+            auto *project = Project::make(yctx->qctx, agg, newProjCols);
+            project->setInputVar(agg->outputVar());
+            project->setColNames(std::move(yctx->projOutputColumnNames_));
+            subplan.root = project;
+        } else {
+            subplan.root = agg;
+        }
+        subplan.tail = agg;
+    }
+
+    if (yctx->distinct) {
+        auto root = subplan.root;
+        auto* dedup = Dedup::make(yctx->qctx, root);
+        dedup->setInputVar(root->outputVar());
+        dedup->setColNames(root->colNames());
+        subplan.root = dedup;
+    }
+
+    return Status::OK();
+}
+}  // namespace graph
+}  // namespace nebula

--- a/src/planner/match/YieldClausePlanner.h
+++ b/src/planner/match/YieldClausePlanner.h
@@ -1,0 +1,27 @@
+/* Copyright (c) 2020 vesoft inc. All rights reserved.
+ *
+ * This source code is licensed under Apache 2.0 License,
+ * attached with Common Clause Condition 1.0, found in the LICENSES directory.
+ */
+
+#ifndef PLANNER_MATCH_YIELDCLAUSEPLANNER_H_
+#define PLANNER_MATCH_YIELDCLAUSEPLANNER_H_
+
+#include "planner/match/CypherClausePlanner.h"
+
+namespace nebula {
+namespace graph {
+/*
+ * The YieldClausePlanner was designed to generate plan for yield clause in cypher
+ */
+class YieldClausePlanner final : public CypherClausePlanner {
+public:
+    YieldClausePlanner() = default;
+
+    StatusOr<SubPlan> transform(CypherClauseContextBase* clauseCtx) override;
+
+    Status buildYield(YieldClauseContext* yctx, SubPlan& subplan);
+};
+}  // namespace graph
+}  // namespace nebula
+#endif  // PLANNER_MATCH_YIELDCLAUSEPLANNER_H_

--- a/src/planner/match/YieldClausePlanner.h
+++ b/src/planner/match/YieldClausePlanner.h
@@ -20,6 +20,14 @@ public:
 
     StatusOr<SubPlan> transform(CypherClauseContextBase* clauseCtx) override;
 
+    void rewriteYieldColumns(const YieldClauseContext* yctx,
+                             const YieldColumns* yields,
+                             YieldColumns* newYields);
+
+    void rewriteGroupExprs(const YieldClauseContext* yctx,
+                           const std::vector<Expression*>* exprs,
+                           std::vector<Expression*>* newExprs);
+
     Status buildYield(YieldClauseContext* yctx, SubPlan& subplan);
 };
 }  // namespace graph

--- a/src/util/ExpressionUtils.h
+++ b/src/util/ExpressionUtils.h
@@ -7,6 +7,7 @@
 #ifndef _UTIL_EXPRESSION_UTILS_H_
 #define _UTIL_EXPRESSION_UTILS_H_
 
+#include "common/base/Status.h"
 #include "common/expression/BinaryExpression.h"
 #include "common/expression/Expression.h"
 #include "common/expression/FunctionCallExpression.h"
@@ -139,6 +140,10 @@ public:
     static std::unique_ptr<Expression> expandImplAnd(const Expression *expr);
 
     static std::vector<std::unique_ptr<Expression>> expandImplOr(const Expression *expr);
+
+    static Status checkAggExpr(const AggregateExpression* aggExpr);
+
+    static bool isEvaluableExpr(const Expression* expr);
 };
 
 }   // namespace graph

--- a/src/validator/GroupByValidator.cpp
+++ b/src/validator/GroupByValidator.cpp
@@ -46,7 +46,6 @@ Status GroupByValidator::validateYield(const YieldClause *yieldClause) {
         if (colExpr->kind() == Expression::Kind::kAggregate) {
             auto* aggExpr = static_cast<AggregateExpression*>(colExpr);
             NG_RETURN_IF_ERROR(checkAggExpr(aggExpr));
-            yieldAggs_.emplace_back(colExpr);
         } else {
             yieldCols_.emplace_back(colExpr);
         }

--- a/src/validator/GroupByValidator.h
+++ b/src/validator/GroupByValidator.h
@@ -35,7 +35,6 @@ private:
 
 private:
     std::vector<Expression*>                         yieldCols_;
-    std::vector<Expression*>                         yieldAggs_;
 
     // key: alias, value: input name
     std::unordered_map<std::string, YieldColumn*>     aliases_;

--- a/src/validator/MatchValidator.cpp
+++ b/src/validator/MatchValidator.cpp
@@ -8,6 +8,8 @@
 
 #include "util/ExpressionUtils.h"
 #include "visitor/RewriteMatchLabelVisitor.h"
+#include "planner/match/MatchSolver.h"
+#include "visitor/RewriteAggExprVisitor.h"
 
 namespace nebula {
 namespace graph {
@@ -30,6 +32,8 @@ Status MatchValidator::validateImpl() {
     std::unordered_map<std::string, AliasType> *aliasesUsed = nullptr;
     YieldColumns *prevYieldColumns = nullptr;
     auto retClauseCtx = getContext<ReturnClauseContext>();
+    auto yieldCtx = getContext<YieldClauseContext>();
+    retClauseCtx->yield = std::move(yieldCtx);
     for (size_t i = 0; i < clauses.size(); ++i) {
         switch (clauses[i]->kind()) {
             case ReadingClause::Kind::kMatch: {
@@ -57,7 +61,7 @@ Status MatchValidator::validateImpl() {
                 aliasesUsed = &matchClauseCtx->aliasesGenerated;
 
                 if (i == clauses.size() - 1) {
-                    retClauseCtx->aliasesUsed = aliasesUsed;
+                    retClauseCtx->yield->aliasesUsed = aliasesUsed;
                     NG_RETURN_IF_ERROR(
                         validateReturn(sentence->ret(), matchClauseCtx.get(), *retClauseCtx));
                 }
@@ -84,7 +88,7 @@ Status MatchValidator::validateImpl() {
                 prevYieldColumns = const_cast<YieldColumns *>(unwindClauseCtx->yieldColumns);
 
                 if (i == clauses.size() - 1) {
-                    retClauseCtx->aliasesUsed = aliasesUsed;
+                    retClauseCtx->yield->aliasesUsed = aliasesUsed;
                     NG_RETURN_IF_ERROR(
                         validateReturn(sentence->ret(), unwindClauseCtx.get(), *retClauseCtx));
                 }
@@ -109,7 +113,7 @@ Status MatchValidator::validateImpl() {
                 prevYieldColumns = const_cast<YieldColumns *>(withClauseCtx->yieldColumns);
 
                 if (i == clauses.size() - 1) {
-                    retClauseCtx->aliasesUsed = aliasesUsed;
+                    retClauseCtx->yield->aliasesUsed = aliasesUsed;
                     NG_RETURN_IF_ERROR(
                         validateReturn(sentence->ret(), withClauseCtx.get(), *retClauseCtx));
                 }
@@ -120,7 +124,7 @@ Status MatchValidator::validateImpl() {
         }
     }
 
-    NG_RETURN_IF_ERROR(buildOutputs(retClauseCtx->yieldColumns));
+    NG_RETURN_IF_ERROR(buildOutputs(retClauseCtx->yield->yieldColumns));
     matchCtx_->clauses.emplace_back(std::move(retClauseCtx));
     return Status::OK();
 }
@@ -359,19 +363,26 @@ Status MatchValidator::validateReturn(MatchReturn *ret,
     }
 
     if (columns == nullptr) {
-        retClauseCtx.yieldColumns = ret->columns();
+        retClauseCtx.yield->yieldColumns = ret->columns();
     } else {
-        retClauseCtx.yieldColumns = columns;
+        retClauseCtx.yield->yieldColumns = columns;
     }
+
     // Check all referencing expressions are valid
     std::vector<const Expression*> exprs;
-    exprs.reserve(retClauseCtx.yieldColumns->size());
-    for (auto *col : retClauseCtx.yieldColumns->columns()) {
+    exprs.reserve(retClauseCtx.yield->yieldColumns->size());
+    for (auto *col : retClauseCtx.yield->yieldColumns->columns()) {
+        // TODO : modify to visitor nested check  (czp)
+        if (!retClauseCtx.yield->hasAgg_ &&
+            ExpressionUtils::hasAny(col->expr(), {Expression::Kind::kAggregate})) {
+            retClauseCtx.yield->hasAgg_ = true;
+        }
         exprs.push_back(col->expr());
     }
-    NG_RETURN_IF_ERROR(validateAliases(exprs, retClauseCtx.aliasesUsed));
+    NG_RETURN_IF_ERROR(validateAliases(exprs, retClauseCtx.yield->aliasesUsed));
+    NG_RETURN_IF_ERROR(validateYield(*retClauseCtx.yield));
 
-    retClauseCtx.distinct = ret->isDistinct();
+    retClauseCtx.yield->distinct = ret->isDistinct();
 
     auto paginationCtx = getContext<PaginationContext>();
     NG_RETURN_IF_ERROR(validatePagination(ret->skip(), ret->limit(), *paginationCtx));
@@ -655,6 +666,88 @@ Status MatchValidator::validateOrderBy(const OrderFactors *factors,
     }
 
     return Status::OK();
+}
+
+Status MatchValidator::validateGroup(YieldClauseContext &yieldCtx) const {
+    auto cols = yieldCtx.yieldColumns->columns();
+    DCHECK(!cols.empty());
+    for (auto* col : cols) {
+        auto rewrited = false;
+        auto colOldName = deduceColName(col);
+        if (col->expr()->kind() != Expression::Kind::kAggregate) {
+            // rewritedExpr will dive into Proj PlanNode  (MLC?) (czp)
+            auto* rewritedExpr = col->expr()->clone().release();
+            auto collectAggCol = rewritedExpr->clone();
+            auto aggs = ExpressionUtils::collectAll(collectAggCol.get(),
+                                                    {Expression::Kind::kAggregate});
+            auto size = aggs.size();
+            if (size > 1) {
+                return Status::SemanticError("Aggregate function nesting is not allowed: `%s'",
+                                             collectAggCol->toString().c_str());
+            }
+            if (size == 1) {
+                auto aggExpr = aggs[0]->clone();
+                DCHECK(aggExpr->kind() == Expression::Kind::kAggregate);
+                auto aggColName = aggExpr->toString();
+                col->setExpr(aggExpr.release());
+
+                // rewrite inner aggExpr to variablePropertyExpr
+                RewriteAggExprVisitor rewriteAggVisitor(new std::string(),
+                                                        new std::string(aggColName));
+                rewritedExpr->accept(&rewriteAggVisitor);
+                rewrited = true;
+                yieldCtx.needGenProject_ = true;
+                yieldCtx.projCols_->addColumn(new YieldColumn(rewritedExpr,
+                                              new std::string(colOldName)));
+            }
+        }
+
+        auto colExpr = col->expr();
+        if (colExpr->kind() == Expression::Kind::kAggregate) {
+            auto* aggExpr = static_cast<AggregateExpression*>(colExpr);
+            NG_RETURN_IF_ERROR(ExpressionUtils::checkAggExpr(aggExpr));
+        } else if (!ExpressionUtils::isEvaluableExpr(colExpr)) {
+            yieldCtx.groupKeys_.emplace_back(colExpr);
+        }
+
+        yieldCtx.groupItems_.emplace_back(colExpr);
+        std::string colNewName;
+        if (!rewrited) {
+            colNewName = deduceColName(col);
+            yieldCtx.projCols_->addColumn(new YieldColumn(
+                new VariablePropertyExpression(new std::string(),
+                                           new std::string(colNewName)),
+                new std::string(colOldName)));
+        } else {
+            colNewName = colExpr->toString();
+        }
+        yieldCtx.projOutputColumnNames_.emplace_back(colOldName);
+        yieldCtx.aggOutputColumnNames_.emplace_back(colNewName);
+    }
+
+    return Status::OK();
+}
+
+Status MatchValidator::validateYield(YieldClauseContext &yieldCtx) const {
+    auto cols = yieldCtx.yieldColumns->columns();
+    if (cols.empty()) {
+        return Status::SemanticError("Return yield columns is Empty.");
+    }
+
+    yieldCtx.projCols_ = yieldCtx.qctx->objPool()->add(new YieldColumns());
+    if (!yieldCtx.hasAgg_) {
+        for (auto& col : yieldCtx.yieldColumns->columns()) {
+            yieldCtx.projCols_->addColumn(col->clone().release());
+            if (col->alias() != nullptr) {
+                yieldCtx.projOutputColumnNames_.emplace_back(*col->alias());
+            } else {
+                yieldCtx.projOutputColumnNames_.emplace_back(col->expr()->toString());
+            }
+        }
+        return Status::OK();
+    } else {
+        return validateGroup(yieldCtx);
+    }
 }
 
 Status MatchValidator::buildOutputs(const YieldColumns* yields) {

--- a/src/validator/MatchValidator.h
+++ b/src/validator/MatchValidator.h
@@ -52,6 +52,10 @@ private:
                            const YieldColumns *yieldColumns,
                            OrderByClauseContext &orderByCtx) const;
 
+    Status validateGroup(YieldClauseContext &yieldCtx) const;
+
+    Status validateYield(YieldClauseContext &yieldCtx) const;
+
     StatusOr<Expression*> makeSubFilter(const std::string &alias,
                                         const MapExpression *map,
                                         const std::string &label = "") const;

--- a/src/validator/test/MatchValidatorTest.cpp
+++ b/src/validator/test/MatchValidatorTest.cpp
@@ -76,5 +76,406 @@ TEST_F(MatchValidatorTest, SeekByTagIndex) {
     }
 }
 
+TEST_F(MatchValidatorTest, groupby) {
+    {
+        std::string query = "MATCH(n:person)"
+                            "RETURN id(n) AS id,"
+                                   "count(n) AS count,"
+                                   "sum(floor(n.age)) AS sum,"
+                                   "max(n.age) AS max,"
+                                   "min(n.age) AS min,"
+                                   "avg(distinct n.age) AS age,"
+                                   "labels(n) AS lb;";
+        std::vector<PlanNode::Kind> expected = {PlanNode::Kind::kAggregate,
+                                                PlanNode::Kind::kFilter,
+                                                PlanNode::Kind::kProject,
+                                                PlanNode::Kind::kProject,
+                                                PlanNode::Kind::kFilter,
+                                                PlanNode::Kind::kGetVertices,
+                                                PlanNode::Kind::kDedup,
+                                                PlanNode::Kind::kProject,
+                                                PlanNode::Kind::kIndexScan,
+                                                PlanNode::Kind::kStart};
+        EXPECT_TRUE(checkResult(query, expected));
+    }
+    {
+        std::string query = "MATCH(n:person)"
+                            "RETURN id(n) AS id,"
+                                   "count(*) AS count,"
+                                   "sum(floor(n.age)) AS sum,"
+                                   "max(n.age) AS max,"
+                                   "min(n.age) AS min,"
+                                   "(INT)avg(distinct n.age)+1 AS age,"
+                                   "labels(n) AS lb;";
+        std::vector<PlanNode::Kind> expected = {PlanNode::Kind::kProject,
+                                                PlanNode::Kind::kAggregate,
+                                                PlanNode::Kind::kFilter,
+                                                PlanNode::Kind::kProject,
+                                                PlanNode::Kind::kProject,
+                                                PlanNode::Kind::kFilter,
+                                                PlanNode::Kind::kGetVertices,
+                                                PlanNode::Kind::kDedup,
+                                                PlanNode::Kind::kProject,
+                                                PlanNode::Kind::kIndexScan,
+                                                PlanNode::Kind::kStart};
+        EXPECT_TRUE(checkResult(query, expected));
+    }
+    {
+        std::string query = "MATCH(n:person)"
+                            "RETURN id(n) AS id,"
+                                   "count(n) AS count,"
+                                   "sum(floor(n.age)) AS sum,"
+                                   "max(n.age) AS max,"
+                                   "min(n.age) AS min,"
+                                   "avg(distinct n.age)+1 AS age,"
+                                   "labels(n) AS lb "
+                                   "ORDER BY id;";
+        std::vector<PlanNode::Kind> expected = {PlanNode::Kind::kDataCollect,
+                                                PlanNode::Kind::kSort,
+                                                PlanNode::Kind::kProject,
+                                                PlanNode::Kind::kAggregate,
+                                                PlanNode::Kind::kFilter,
+                                                PlanNode::Kind::kProject,
+                                                PlanNode::Kind::kProject,
+                                                PlanNode::Kind::kFilter,
+                                                PlanNode::Kind::kGetVertices,
+                                                PlanNode::Kind::kDedup,
+                                                PlanNode::Kind::kProject,
+                                                PlanNode::Kind::kIndexScan,
+                                                PlanNode::Kind::kStart};
+        EXPECT_TRUE(checkResult(query, expected));
+    }
+    {
+        std::string query = "MATCH(n:person)"
+                            "RETURN id(n) AS id,"
+                                   "count(n) AS count,"
+                                   "sum(floor(n.age)) AS sum,"
+                                   "max(n.age) AS max,"
+                                   "min(n.age) AS min,"
+                                   "avg(distinct n.age)+1 AS age,"
+                                   "labels(n) AS lb "
+                                "ORDER BY id "
+                                "SKIP 10 LIMIT 20;";
+        std::vector<PlanNode::Kind> expected = {PlanNode::Kind::kDataCollect,
+                                                PlanNode::Kind::kLimit,
+                                                PlanNode::Kind::kSort,
+                                                PlanNode::Kind::kProject,
+                                                PlanNode::Kind::kAggregate,
+                                                PlanNode::Kind::kFilter,
+                                                PlanNode::Kind::kProject,
+                                                PlanNode::Kind::kProject,
+                                                PlanNode::Kind::kFilter,
+                                                PlanNode::Kind::kGetVertices,
+                                                PlanNode::Kind::kDedup,
+                                                PlanNode::Kind::kProject,
+                                                PlanNode::Kind::kIndexScan,
+                                                PlanNode::Kind::kStart};
+        EXPECT_TRUE(checkResult(query, expected));
+    }
+    {
+        std::string query = "MATCH(n:person)-[:like]->(m) "
+                            "RETURN id(n) AS id,"
+                                   "count(n) AS count,"
+                                   "sum(floor(n.age)) AS sum,"
+                                   "max(m.age) AS max,"
+                                   "min(n.age) AS min,"
+                                   "avg(distinct n.age) AS age,"
+                                   "labels(m) AS lb;";
+        std::vector<PlanNode::Kind> expected = {PlanNode::Kind::kAggregate,
+                                                PlanNode::Kind::kFilter,
+                                                PlanNode::Kind::kProject,
+                                                PlanNode::Kind::kDataJoin,
+                                                PlanNode::Kind::kProject,
+                                                PlanNode::Kind::kGetVertices,
+                                                PlanNode::Kind::kDedup,
+                                                PlanNode::Kind::kProject,
+                                                PlanNode::Kind::kFilter,
+                                                PlanNode::Kind::kPassThrough,
+                                                PlanNode::Kind::kProject,
+                                                PlanNode::Kind::kFilter,
+                                                PlanNode::Kind::kGetNeighbors,
+                                                PlanNode::Kind::kDedup,
+                                                PlanNode::Kind::kProject,
+                                                PlanNode::Kind::kIndexScan,
+                                                PlanNode::Kind::kStart};
+        EXPECT_TRUE(checkResult(query, expected));
+    }
+    {
+        std::string query = "MATCH(n:person)-[:like]->(m) "
+                            "RETURN id(n) AS id,"
+                                   "count(n) AS count,"
+                                   "sum(floor(n.age)) AS sum,"
+                                   "max(m.age) AS max,"
+                                   "min(n.age) AS min,"
+                                   "avg(distinct n.age)+1 AS age,"
+                                   "labels(m) AS lb;";
+        std::vector<PlanNode::Kind> expected = {PlanNode::Kind::kProject,
+                                                PlanNode::Kind::kAggregate,
+                                                PlanNode::Kind::kFilter,
+                                                PlanNode::Kind::kProject,
+                                                PlanNode::Kind::kDataJoin,
+                                                PlanNode::Kind::kProject,
+                                                PlanNode::Kind::kGetVertices,
+                                                PlanNode::Kind::kDedup,
+                                                PlanNode::Kind::kProject,
+                                                PlanNode::Kind::kFilter,
+                                                PlanNode::Kind::kPassThrough,
+                                                PlanNode::Kind::kProject,
+                                                PlanNode::Kind::kFilter,
+                                                PlanNode::Kind::kGetNeighbors,
+                                                PlanNode::Kind::kDedup,
+                                                PlanNode::Kind::kProject,
+                                                PlanNode::Kind::kIndexScan,
+                                                PlanNode::Kind::kStart};
+        EXPECT_TRUE(checkResult(query, expected));
+    }
+    {
+        std::string query = "MATCH(n:person)-[:like]->(m) "
+                            "WHERE n.age > 35 "
+                            "RETURN id(n) AS id,"
+                                   "count(n) AS count,"
+                                   "sum(floor(n.age)) AS sum,"
+                                   "max(m.age) AS max,"
+                                   "min(n.age) AS min,"
+                                   "avg(distinct n.age) AS age,"
+                                   "labels(m) AS lb ";
+        std::vector<PlanNode::Kind> expected = {PlanNode::Kind::kAggregate,
+                                                PlanNode::Kind::kFilter,
+                                                PlanNode::Kind::kFilter,
+                                                PlanNode::Kind::kProject,
+                                                PlanNode::Kind::kDataJoin,
+                                                PlanNode::Kind::kProject,
+                                                PlanNode::Kind::kGetVertices,
+                                                PlanNode::Kind::kDedup,
+                                                PlanNode::Kind::kProject,
+                                                PlanNode::Kind::kFilter,
+                                                PlanNode::Kind::kPassThrough,
+                                                PlanNode::Kind::kProject,
+                                                PlanNode::Kind::kFilter,
+                                                PlanNode::Kind::kGetNeighbors,
+                                                PlanNode::Kind::kDedup,
+                                                PlanNode::Kind::kProject,
+                                                PlanNode::Kind::kIndexScan,
+                                                PlanNode::Kind::kStart};
+        EXPECT_TRUE(checkResult(query, expected));
+    }
+    {
+        std::string query = "MATCH(n:person)-[:like]->(m) "
+                            "WHERE n.age > 35 "
+                            "RETURN id(n) AS id,"
+                                   "count(n) AS count,"
+                                   "sum(floor(n.age)) AS sum,"
+                                   "max(m.age) AS max,"
+                                   "min(n.age) AS min,"
+                                   "avg(distinct n.age) AS age,"
+                                   "labels(m) AS lb "
+                                "SKIP 10 LIMIT 20;";
+        std::vector<PlanNode::Kind> expected = {PlanNode::Kind::kDataCollect,
+                                                PlanNode::Kind::kLimit,
+                                                PlanNode::Kind::kAggregate,
+                                                PlanNode::Kind::kFilter,
+                                                PlanNode::Kind::kFilter,
+                                                PlanNode::Kind::kProject,
+                                                PlanNode::Kind::kDataJoin,
+                                                PlanNode::Kind::kProject,
+                                                PlanNode::Kind::kGetVertices,
+                                                PlanNode::Kind::kDedup,
+                                                PlanNode::Kind::kProject,
+                                                PlanNode::Kind::kFilter,
+                                                PlanNode::Kind::kPassThrough,
+                                                PlanNode::Kind::kProject,
+                                                PlanNode::Kind::kFilter,
+                                                PlanNode::Kind::kGetNeighbors,
+                                                PlanNode::Kind::kDedup,
+                                                PlanNode::Kind::kProject,
+                                                PlanNode::Kind::kIndexScan,
+                                                PlanNode::Kind::kStart};
+        EXPECT_TRUE(checkResult(query, expected));
+    }
+    {
+        std::string query = "MATCH(n:person)-[:like]->(m) "
+                            "WHERE n.age > 35 "
+                            "RETURN DISTINCT id(n) AS id,"
+                                   "count(n) AS count,"
+                                   "sum(floor(n.age)) AS sum,"
+                                   "max(m.age) AS max,"
+                                   "min(n.age) AS min,"
+                                   "avg(distinct n.age) AS age,"
+                                   "labels(m) AS lb;";
+        std::vector<PlanNode::Kind> expected = {PlanNode::Kind::kDataCollect,
+                                                PlanNode::Kind::kDedup,
+                                                PlanNode::Kind::kAggregate,
+                                                PlanNode::Kind::kFilter,
+                                                PlanNode::Kind::kFilter,
+                                                PlanNode::Kind::kProject,
+                                                PlanNode::Kind::kDataJoin,
+                                                PlanNode::Kind::kProject,
+                                                PlanNode::Kind::kGetVertices,
+                                                PlanNode::Kind::kDedup,
+                                                PlanNode::Kind::kProject,
+                                                PlanNode::Kind::kFilter,
+                                                PlanNode::Kind::kPassThrough,
+                                                PlanNode::Kind::kProject,
+                                                PlanNode::Kind::kFilter,
+                                                PlanNode::Kind::kGetNeighbors,
+                                                PlanNode::Kind::kDedup,
+                                                PlanNode::Kind::kProject,
+                                                PlanNode::Kind::kIndexScan,
+                                                PlanNode::Kind::kStart};
+        EXPECT_TRUE(checkResult(query, expected));
+    }
+    {
+        std::string query = "MATCH(n:person)-[:like]->(m) "
+                            "WHERE n.age > 35 "
+                            "RETURN id(n) AS id,"
+                                   "count(n) AS count,"
+                                   "sum(floor(n.age)) AS sum,"
+                                   "max(m.age) AS max,"
+                                   "min(n.age) AS min,"
+                                   "avg(distinct n.age)+1 AS age,"
+                                   "labels(m) AS lb "
+                                "SKIP 10 LIMIT 20;";
+        std::vector<PlanNode::Kind> expected = {PlanNode::Kind::kDataCollect,
+                                                PlanNode::Kind::kLimit,
+                                                PlanNode::Kind::kProject,
+                                                PlanNode::Kind::kAggregate,
+                                                PlanNode::Kind::kFilter,
+                                                PlanNode::Kind::kFilter,
+                                                PlanNode::Kind::kProject,
+                                                PlanNode::Kind::kDataJoin,
+                                                PlanNode::Kind::kProject,
+                                                PlanNode::Kind::kGetVertices,
+                                                PlanNode::Kind::kDedup,
+                                                PlanNode::Kind::kProject,
+                                                PlanNode::Kind::kFilter,
+                                                PlanNode::Kind::kPassThrough,
+                                                PlanNode::Kind::kProject,
+                                                PlanNode::Kind::kFilter,
+                                                PlanNode::Kind::kGetNeighbors,
+                                                PlanNode::Kind::kDedup,
+                                                PlanNode::Kind::kProject,
+                                                PlanNode::Kind::kIndexScan,
+                                                PlanNode::Kind::kStart};
+        EXPECT_TRUE(checkResult(query, expected));
+    }
+    {
+        std::string query = "MATCH(n:person)-[:like]->(m) "
+                            "WHERE n.age > 35 "
+                            "RETURN DISTINCT id(n) AS id,"
+                                   "count(n) AS count,"
+                                   "sum(floor(n.age)) AS sum,"
+                                   "max(m.age) AS max,"
+                                   "min(n.age) AS min,"
+                                   "avg(distinct n.age)+1 AS age,"
+                                   "labels(m) AS lb "
+                                "ORDER BY id "
+                                "SKIP 10 LIMIT 20;";
+        std::vector<PlanNode::Kind> expected = {PlanNode::Kind::kDataCollect,
+                                                PlanNode::Kind::kLimit,
+                                                PlanNode::Kind::kSort,
+                                                PlanNode::Kind::kDedup,
+                                                PlanNode::Kind::kProject,
+                                                PlanNode::Kind::kAggregate,
+                                                PlanNode::Kind::kFilter,
+                                                PlanNode::Kind::kFilter,
+                                                PlanNode::Kind::kProject,
+                                                PlanNode::Kind::kDataJoin,
+                                                PlanNode::Kind::kProject,
+                                                PlanNode::Kind::kGetVertices,
+                                                PlanNode::Kind::kDedup,
+                                                PlanNode::Kind::kProject,
+                                                PlanNode::Kind::kFilter,
+                                                PlanNode::Kind::kPassThrough,
+                                                PlanNode::Kind::kProject,
+                                                PlanNode::Kind::kFilter,
+                                                PlanNode::Kind::kGetNeighbors,
+                                                PlanNode::Kind::kDedup,
+                                                PlanNode::Kind::kProject,
+                                                PlanNode::Kind::kIndexScan,
+                                                PlanNode::Kind::kStart};
+        EXPECT_TRUE(checkResult(query, expected));
+    }
+    {
+        std::string query = "MATCH(n:person)-[:like]->(m) "
+                            "WHERE n.age > 35 "
+                            "RETURN DISTINCT id(n) AS id,"
+                                   "count(n) AS count,"
+                                   "sum(floor(n.age)) AS sum,"
+                                   "max(m.age) AS max,"
+                                   "min(n.age) AS min,"
+                                   "avg(distinct n.age) AS age,"
+                                   "labels(m) AS lb "
+                                "ORDER BY id "
+                                "SKIP 10 LIMIT 20;";
+        std::vector<PlanNode::Kind> expected = {PlanNode::Kind::kDataCollect,
+                                                PlanNode::Kind::kLimit,
+                                                PlanNode::Kind::kSort,
+                                                PlanNode::Kind::kDedup,
+                                                PlanNode::Kind::kAggregate,
+                                                PlanNode::Kind::kFilter,
+                                                PlanNode::Kind::kFilter,
+                                                PlanNode::Kind::kProject,
+                                                PlanNode::Kind::kDataJoin,
+                                                PlanNode::Kind::kProject,
+                                                PlanNode::Kind::kGetVertices,
+                                                PlanNode::Kind::kDedup,
+                                                PlanNode::Kind::kProject,
+                                                PlanNode::Kind::kFilter,
+                                                PlanNode::Kind::kPassThrough,
+                                                PlanNode::Kind::kProject,
+                                                PlanNode::Kind::kFilter,
+                                                PlanNode::Kind::kGetNeighbors,
+                                                PlanNode::Kind::kDedup,
+                                                PlanNode::Kind::kProject,
+                                                PlanNode::Kind::kIndexScan,
+                                                PlanNode::Kind::kStart};
+        EXPECT_TRUE(checkResult(query, expected));
+    }
+    {
+        std::string query = "MATCH(n:person)-[:like]->(m)-[:serve]-() "
+                            "WHERE n.age > 35 "
+                            "RETURN DISTINCT id(n) AS id,"
+                                   "count(n) AS count,"
+                                   "sum(floor(n.age)) AS sum,"
+                                   "max(m.age) AS max,"
+                                   "min(n.age) AS min,"
+                                   "(INT)avg(distinct n.age)+1 AS age,"
+                                   "labels(m) AS lb "
+                                "ORDER BY id "
+                                "SKIP 10 LIMIT 20;";
+        std::vector<PlanNode::Kind> expected = {PlanNode::Kind::kDataCollect,
+                                                PlanNode::Kind::kLimit,
+                                                PlanNode::Kind::kSort,
+                                                PlanNode::Kind::kDedup,
+                                                PlanNode::Kind::kProject,
+                                                PlanNode::Kind::kAggregate,
+                                                PlanNode::Kind::kFilter,
+                                                PlanNode::Kind::kFilter,
+                                                PlanNode::Kind::kProject,
+                                                PlanNode::Kind::kDataJoin,
+                                                PlanNode::Kind::kProject,
+                                                PlanNode::Kind::kGetVertices,
+                                                PlanNode::Kind::kDedup,
+                                                PlanNode::Kind::kProject,
+                                                PlanNode::Kind::kDataJoin,
+                                                PlanNode::Kind::kFilter,
+                                                PlanNode::Kind::kPassThrough,
+                                                PlanNode::Kind::kProject,
+                                                PlanNode::Kind::kGetNeighbors,
+                                                PlanNode::Kind::kDedup,
+                                                PlanNode::Kind::kProject,
+                                                PlanNode::Kind::kFilter,
+                                                PlanNode::Kind::kPassThrough,
+                                                PlanNode::Kind::kProject,
+                                                PlanNode::Kind::kFilter,
+                                                PlanNode::Kind::kGetNeighbors,
+                                                PlanNode::Kind::kDedup,
+                                                PlanNode::Kind::kProject,
+                                                PlanNode::Kind::kIndexScan,
+                                                PlanNode::Kind::kStart};
+        EXPECT_TRUE(checkResult(query, expected));
+    }
+}
+
 }   // namespace graph
 }   // namespace nebula

--- a/src/visitor/RewriteMatchLabelVisitor.cpp
+++ b/src/visitor/RewriteMatchLabelVisitor.cpp
@@ -37,6 +37,14 @@ void RewriteMatchLabelVisitor::visit(FunctionCallExpression *expr) {
     }
 }
 
+void RewriteMatchLabelVisitor::visit(AggregateExpression *expr) {
+    auto arg = expr->arg();
+    if (isLabel(arg)) {
+        expr->setArg(rewriter_(arg));
+    } else {
+        arg->accept(this);
+    }
+}
 
 void RewriteMatchLabelVisitor::visit(AttributeExpression *expr) {
     if (isLabel(expr->left())) {

--- a/src/visitor/RewriteMatchLabelVisitor.h
+++ b/src/visitor/RewriteMatchLabelVisitor.h
@@ -36,6 +36,7 @@ private:
     void visit(TypeCastingExpression*) override;
     void visit(UnaryExpression*) override;
     void visit(FunctionCallExpression*) override;
+    void visit(AggregateExpression*) override;
     void visit(ListExpression*) override;
     void visit(SetExpression*) override;
     void visit(MapExpression*) override;

--- a/tests/tck/features/expression/predicate.feature
+++ b/tests/tck/features/expression/predicate.feature
@@ -2,7 +2,6 @@
 #
 # This source code is licensed under Apache 2.0 License,
 # attached with Common Clause Condition 1.0, found in the LICENSES directory.
-@jie
 Feature: Predicate
 
   Scenario: yield a predicate

--- a/tests/tck/features/index/Index.IntVid.feature
+++ b/tests/tck/features/index/Index.IntVid.feature
@@ -550,7 +550,6 @@ Feature: IndexTest_Vid_Int
       | 100      | true       | 5          |
     Then drop the used space
 
-  @test3
   Scenario: IndexTest IntVid RebuildTagIndexStatusInfo
     Given an empty graph
     And create a space with following options:

--- a/tests/tck/features/match/MatchGroupBy.feature
+++ b/tests/tck/features/match/MatchGroupBy.feature
@@ -1,0 +1,189 @@
+# Copyright (c) 2020 vesoft inc. All rights reserved.
+#
+# This source code is licensed under Apache 2.0 License,
+# attached with Common Clause Condition 1.0, found in the LICENSES directory.
+Feature: Match GroupBy
+
+  Background:
+    Given a graph with space named "nba"
+
+  Scenario: Basic groupby
+    When executing query:
+      """
+      MATCH(n:player)
+        RETURN id(n) AS id,
+               count(n) AS count,
+               sum(floor(n.age)) AS sum,
+               max(n.age) AS max,
+               min(n.age) AS min,
+               avg(distinct n.age) AS age,
+               labels(n) AS lb
+          ORDER BY id, count, max, min
+          SKIP 10 LIMIT 8;
+      """
+    Then the result should be, in order, with relax comparison:
+      | id                      | count | sum  | max | min | age  | lb         |
+      | "David West"            | 1     | 38.0 | 38  | 38  | 38.0 | ["player"] |
+      | "DeAndre Jordan"        | 1     | 30.0 | 30  | 30  | 30.0 | ["player"] |
+      | "Dejounte Murray"       | 1     | 29.0 | 29  | 29  | 29.0 | ["player"] |
+      | "Dirk Nowitzki"         | 1     | 40.0 | 40  | 40  | 40.0 | ["player"] |
+      | "Dwight Howard"         | 1     | 33.0 | 33  | 33  | 33.0 | ["player"] |
+      | "Dwyane Wade"           | 1     | 37.0 | 37  | 37  | 37.0 | ["player"] |
+      | "Giannis Antetokounmpo" | 1     | 24.0 | 24  | 24  | 24.0 | ["player"] |
+      | "Grant Hill"            | 1     | 46.0 | 46  | 46  | 46.0 | ["player"] |
+    When executing query:
+      """
+      MATCH(n:player)
+        RETURN id(n) AS id,
+               count(n) AS count,
+               sum(floor(n.age)) AS sum,
+               max(n.age) AS max,
+               min(n.age) AS min,
+               avg(distinct n.age)+1 AS age,
+               labels(n) AS lb
+          ORDER BY id, count, max, min
+          SKIP 10 LIMIT 8;
+      """
+    Then the result should be, in order, with relax comparison:
+      | id                      | count | sum  | max | min | age  | lb         |
+      | "David West"            | 1     | 38.0 | 38  | 38  | 39.0 | ["player"] |
+      | "DeAndre Jordan"        | 1     | 30.0 | 30  | 30  | 31.0 | ["player"] |
+      | "Dejounte Murray"       | 1     | 29.0 | 29  | 29  | 30.0 | ["player"] |
+      | "Dirk Nowitzki"         | 1     | 40.0 | 40  | 40  | 41.0 | ["player"] |
+      | "Dwight Howard"         | 1     | 33.0 | 33  | 33  | 34.0 | ["player"] |
+      | "Dwyane Wade"           | 1     | 37.0 | 37  | 37  | 38.0 | ["player"] |
+      | "Giannis Antetokounmpo" | 1     | 24.0 | 24  | 24  | 25.0 | ["player"] |
+      | "Grant Hill"            | 1     | 46.0 | 46  | 46  | 47.0 | ["player"] |
+    When executing query:
+      """
+      MATCH(n:player)
+        RETURN id(n) AS id,
+               count(n) AS count,
+               sum(floor(n.age)) AS sum,
+               max(n.age) AS max,
+               min(n.age) AS min,
+               (INT)avg(distinct n.age)+1 AS age,
+               labels(n) AS lb
+          ORDER BY id, count, max, min
+          SKIP 10 LIMIT 8;
+      """
+    Then the result should be, in order, with relax comparison:
+      | id                      | count | sum  | max | min | age | lb         |
+      | "David West"            | 1     | 38.0 | 38  | 38  | 39  | ["player"] |
+      | "DeAndre Jordan"        | 1     | 30.0 | 30  | 30  | 31  | ["player"] |
+      | "Dejounte Murray"       | 1     | 29.0 | 29  | 29  | 30  | ["player"] |
+      | "Dirk Nowitzki"         | 1     | 40.0 | 40  | 40  | 41  | ["player"] |
+      | "Dwight Howard"         | 1     | 33.0 | 33  | 33  | 34  | ["player"] |
+      | "Dwyane Wade"           | 1     | 37.0 | 37  | 37  | 38  | ["player"] |
+      | "Giannis Antetokounmpo" | 1     | 24.0 | 24  | 24  | 25  | ["player"] |
+      | "Grant Hill"            | 1     | 46.0 | 46  | 46  | 47  | ["player"] |
+    When executing query:
+      """
+      MATCH(n:player)
+        WHERE n.age > 35
+        RETURN DISTINCT id(n) AS id,
+                        count(n) AS count,
+                        sum(floor(n.age)) AS sum,
+                        max(n.age) AS max,
+                        min(n.age) AS min,
+                        avg(distinct n.age)+1 AS age,
+                        labels(n) AS lb
+              ORDER BY id, count, max, min
+              SKIP 10 LIMIT 6;
+      """
+    Then the result should be, in order, with relax comparison:
+      | id                | count | sum  | max | min | age  | lb                     |
+      | "Ray Allen"       | 1     | 43.0 | 43  | 43  | 44.0 | ["player"]             |
+      | "Shaquile O'Neal" | 1     | 47.0 | 47  | 47  | 48.0 | ["player"]             |
+      | "Steve Nash"      | 1     | 45.0 | 45  | 45  | 46.0 | ["player"]             |
+      | "Tim Duncan"      | 1     | 42.0 | 42  | 42  | 43.0 | ["bachelor", "player"] |
+      | "Tony Parker"     | 1     | 36.0 | 36  | 36  | 37.0 | ["player"]             |
+      | "Tracy McGrady"   | 1     | 39.0 | 39  | 39  | 40.0 | ["player"]             |
+    When executing query:
+      """
+      MATCH(n:player)-[:like]->(m)
+        WHERE n.age > 35
+        RETURN DISTINCT id(n) AS id,
+                        count(n) AS count,
+                        sum(floor(n.age)) AS sum,
+                        max(m.age) AS max,
+                        min(n.age) AS min,
+                        avg(distinct n.age)+1 AS age,
+                        labels(m) AS lb
+              ORDER BY id, count, max, min
+              SKIP 10 LIMIT 20;
+      """
+    Then the result should be, in order, with relax comparison:
+      | id                | count | sum   | max | min | age  | lb                     |
+      | "Shaquile O'Neal" | 1     | 47.0  | 31  | 47  | 48.0 | ["player"]             |
+      | "Shaquile O'Neal" | 1     | 47.0  | 42  | 47  | 48.0 | ["bachelor", "player"] |
+      | "Steve Nash"      | 4     | 180.0 | 45  | 45  | 46.0 | ["player"]             |
+      | "Tim Duncan"      | 2     | 84.0  | 41  | 42  | 43.0 | ["player"]             |
+      | "Tony Parker"     | 1     | 36.0  | 42  | 36  | 37.0 | ["bachelor", "player"] |
+      | "Tony Parker"     | 2     | 72.0  | 41  | 36  | 37.0 | ["player"]             |
+      | "Tracy McGrady"   | 3     | 117.0 | 46  | 39  | 40.0 | ["player"]             |
+      | "Vince Carter"    | 2     | 84.0  | 45  | 42  | 43.0 | ["player"]             |
+      | "Yao Ming"        | 2     | 76.0  | 47  | 38  | 39.0 | ["player"]             |
+    When executing query:
+      """
+      MATCH(n:player)-[:like*2]->(m)-[:serve]->()
+        WHERE n.age > 35
+        RETURN DISTINCT id(n) AS id,
+                        count(n) AS count,
+                        sum(floor(n.age)) AS sum,
+                        max(m.age) AS max,
+                        min(n.age) AS min,
+                        avg(distinct n.age)+1 AS age,
+                        labels(m) AS lb
+              ORDER BY id, count, max, min
+        | YIELD count(*) AS count;
+      """
+    Then the result should be, in order, with relax comparison:
+      | count |
+      | 20    |
+    When executing query:
+      """
+      MATCH(n:player)-[:like*2]->(m)-[:serve]->()
+        WHERE n.age > 35
+        RETURN DISTINCT id(n) AS id,
+                        count(n) AS count,
+                        sum(floor(n.age)) AS sum,
+                        max(m.age) AS max,
+                        min(n.age) AS min,
+                        avg(distinct n.age)+1 AS age,
+                        labels(m) AS lb
+              ORDER BY id, count, max, min
+        | YIELD DISTINCT $-.min AS min, (INT)count(*) AS count;
+      """
+    Then the result should be, in any order, with relax comparison:
+      | min | count |
+      | 39  | 1     |
+      | 42  | 3     |
+      | 47  | 1     |
+      | 43  | 1     |
+      | 38  | 3     |
+      | 40  | 1     |
+      | 36  | 5     |
+      | 37  | 1     |
+      | 46  | 1     |
+      | 45  | 2     |
+      | 41  | 1     |
+    When executing query:
+      """
+      MATCH p = (a:player)-[:like]->(other:player)
+          WHERE other <> a
+        WITH a AS a, other AS other, length(p) AS len
+        RETURN a.name AS name, (INT)avg(other.age) AS age, len
+          ORDER BY name, age
+          SKIP 3 LIMIT 8
+      """
+    Then the result should be, in order, with relax comparison:
+      | name              | age | len |
+      | "Blake Griffin"   | 33  | 1   |
+      | "Boris Diaw"      | 39  | 1   |
+      | "Carmelo Anthony" | 34  | 1   |
+      | "Chris Paul"      | 35  | 1   |
+      | "Damian Lillard"  | 33  | 1   |
+      | "Danny Green"     | 36  | 1   |
+      | "Dejounte Murray" | 33  | 1   |
+      | "Dirk Nowitzki"   | 42  | 1   |

--- a/tests/tck/features/schema/Schema.feature
+++ b/tests/tck/features/schema/Schema.feature
@@ -2,7 +2,6 @@
 #
 # This source code is licensed under Apache 2.0 License,
 # attached with Common Clause Condition 1.0, found in the LICENSES directory.
-@schema
 Feature: Insert string vid of vertex and edge
 
   Scenario: insert vertex and edge test


### PR DESCRIPTION
This PR adds the following feature:
 - match groupby (eg.`match (n:player) return n, n.age, avg(n.age)+1`)

fixes #594 