### PR TITLE
Fix download core problem

### DIFF
--- a/src/parser/MutateSentences.h
+++ b/src/parser/MutateSentences.h
@@ -601,7 +601,6 @@ public:
         static std::string hdfsPrefix = "hdfs://";
         if (url->find(hdfsPrefix) != 0) {
             LOG(ERROR) << "URL should start with " << hdfsPrefix;
-            delete url;
             return;
         }
 
@@ -616,6 +615,7 @@ public:
                     port_ = folly::to<int32_t>(tokens[1].toString().substr(0, position).c_str());
                 } catch (const std::exception& ex) {
                     LOG(ERROR) << "URL's port parse failed: " << *url;
+                    return;
                 }
                 path_ = std::make_unique<std::string>(
                             tokens[1].toString().substr(position, tokens[1].size()));
@@ -625,7 +625,6 @@ public:
         } else {
             LOG(ERROR) << "URL Parse Failed: " << *url;
         }
-        delete url;
     }
 
     std::string toString() const override;

--- a/src/validator/DownloadValidator.cpp
+++ b/src/validator/DownloadValidator.cpp
@@ -15,6 +15,12 @@ namespace graph {
 
 Status DownloadValidator::toPlan() {
     auto sentence = static_cast<DownloadSentence*>(sentence_);
+    if (sentence->host() == nullptr ||
+        sentence->port() == 0 ||
+        sentence->path() == nullptr) {
+        return Status::SemanticError("HDFS path illegal."
+                                     "Should be HDFS://${HDFS_HOST}:${HDFS_PORT}/${HDFS_PATH}");
+    }
     auto *doNode = Download::make(qctx_,
                                   nullptr,
                                   *sentence->host(),


### PR DESCRIPTION
```
(root@nebula) [t]> DOWNLOAD HDFS "192.168.8.94:9000:/"
[ERROR (-12)]: SemanticError: HDFS path illegal.Should be HDFS://${HDFS_HOST}:${HDFS_PORT}/${HDFS_PATH}

Mon, 22 Feb 2021 18:34:41 CST

(root@nebula) [t]> DOWNLOAD HDFS "hdfs://192.168.8.94:"
[ERROR (-12)]: SemanticError: HDFS path illegal.Should be HDFS://${HDFS_HOST}:${HDFS_PORT}/${HDFS_PATH}

Mon, 22 Feb 2021 18:36:17 CST

(root@nebula) [t]> DOWNLOAD HDFS "hdfs://192.168.8.94:9090"
[ERROR (-12)]: SemanticError: HDFS path illegal.Should be HDFS://${HDFS_HOST}:${HDFS_PORT}/${HDFS_PATH}

Mon, 22 Feb 2021 18:36:21 CST
```