### PR TITLE
Fix indexScan rule when compare INT with Double

### DIFF
--- a/src/optimizer/OptimizerUtils.cpp
+++ b/src/optimizer/OptimizerUtils.cpp
@@ -239,13 +239,6 @@ Value OptimizerUtils::boundValueWithLT(const meta::cpp2::ColumnDef& col, const V
             }
             std::vector<unsigned char> bytes(v.getStr().begin(), v.getStr().end());
             bytes.resize(*col.get_type().get_type_length());
-            // for (size_t i = bytes.size();; i--) {
-            //     if (i > 0) {
-            //         if (bytes[i-1]-- != 0) break;
-            //     } else {
-            //         return Value(std::string(*col.get_type().get_type_length(), '\0'));
-            //     }
-            // }
             return Value(std::string(bytes.begin(), bytes.end()));
         }
         case Value::Type::DATE : {

--- a/src/optimizer/OptimizerUtils.cpp
+++ b/src/optimizer/OptimizerUtils.cpp
@@ -215,11 +215,6 @@ Value OptimizerUtils::boundValueWithLT(const meta::cpp2::ColumnDef& col, const V
                 boundVar = v.getInt();
             }
             return Value(boundVar);
-            // if (boundVar == std::numeric_limits<int64_t>::min()) {
-            //     return Value(boundVar);
-            // } else {
-            //     return Value(boundVar - 1);
-            // }
         }
         case Value::Type::FLOAT : {
             double_t boundVar;
@@ -239,18 +234,6 @@ Value OptimizerUtils::boundValueWithLT(const meta::cpp2::ColumnDef& col, const V
                 return Value(-std::numeric_limits<double_t>::min());
             }
             return Value(boundVar - kEpsilon);
-
-
-            // if (v.getFloat() < 0.0) {
-            //     if (v.getFloat() == -std::numeric_limits<double_t>::max()) {
-            //         return v;
-            //     } else if (v.getFloat() == -std::numeric_limits<double_t>::min()) {
-            //         return Value(0.0);
-            //     }
-            // } else if (v.getFloat() == 0.0) {
-            //     return Value(-std::numeric_limits<double_t>::min());
-            // }
-            // return v.getFloat() - kEpsilon;
         }
         case Value::Type::STRING : {
             if (!col.type.__isset.type_length || col.get_type().get_type_length() == nullptr) {

--- a/src/optimizer/OptimizerUtils.cpp
+++ b/src/optimizer/OptimizerUtils.cpp
@@ -36,14 +36,15 @@ Value OptimizerUtils::boundValueWithGT(const meta::cpp2::ColumnDef& col, const V
             int64_t boundVar;
             if (v.isFloat()) {
                 // Check if the float value can be cast
-                if (!const_cast<Value&>(v).toFloat().second) {
+                if (!const_cast<Value&>(v).toInt().second) {
                     DLOG(FATAL) << "Float value is out of the limit of Int type ";
                     return Value::kNullBadType;
                 }
-                boundVar = floor(const_cast<Value&>(v).toFloat().first);
+                boundVar = const_cast<Value&>(v).toInt().first;
             } else {
                 boundVar = v.getInt();
             }
+
             if (boundVar == std::numeric_limits<int64_t>::max()) {
                 return Value(boundVar);
             } else {
@@ -51,7 +52,7 @@ Value OptimizerUtils::boundValueWithGT(const meta::cpp2::ColumnDef& col, const V
             }
         }
         case Value::Type::FLOAT: {
-            int64_t boundVar;
+            double_t boundVar;
             if (v.isInt()) {
                 boundVar = const_cast<Value&>(v).toFloat().first;
             } else {
@@ -202,22 +203,26 @@ Value OptimizerUtils::boundValueWithLT(const meta::cpp2::ColumnDef& col, const V
             int64_t boundVar;
             if (v.isFloat()) {
                 // Check if the float value can be cast
-                if (!const_cast<Value&>(v).toFloat().second) {
+                if (!const_cast<Value&>(v).toInt().second) {
                     DLOG(FATAL) << "Float value is out of the limit of Int type ";
                     return Value::kNullBadType;
                 }
-                boundVar = floor(const_cast<Value&>(v).toFloat().first);
+                boundVar = const_cast<Value&>(v).toInt().first;
+                if (boundVar != std::numeric_limits<int64_t>::max()) {
+                    boundVar += 1;
+                }
             } else {
                 boundVar = v.getInt();
             }
-            if (boundVar == std::numeric_limits<int64_t>::min()) {
-                return Value(boundVar);
-            } else {
-                return Value(boundVar - 1);
-            }
+            return Value(boundVar);
+            // if (boundVar == std::numeric_limits<int64_t>::min()) {
+            //     return Value(boundVar);
+            // } else {
+            //     return Value(boundVar - 1);
+            // }
         }
         case Value::Type::FLOAT : {
-            int64_t boundVar;
+            double_t boundVar;
             if (v.isInt()) {
                 boundVar = const_cast<Value&>(v).toFloat().first;
             } else {

--- a/src/optimizer/OptimizerUtils.cpp
+++ b/src/optimizer/OptimizerUtils.cpp
@@ -37,7 +37,6 @@ Value OptimizerUtils::boundValueWithGT(const meta::cpp2::ColumnDef& col, const V
             if (v.isFloat()) {
                 // Check if the float value can be cast
                 if (!const_cast<Value&>(v).toInt().second) {
-                    DLOG(FATAL) << "Float value is out of the limit of Int type ";
                     return Value::kNullBadType;
                 }
                 boundVar = const_cast<Value&>(v).toInt().first;
@@ -204,7 +203,6 @@ Value OptimizerUtils::boundValueWithLT(const meta::cpp2::ColumnDef& col, const V
             if (v.isFloat()) {
                 // Check if the float value can be cast
                 if (!const_cast<Value&>(v).toInt().second) {
-                    DLOG(FATAL) << "Float value is out of the limit of Int type ";
                     return Value::kNullBadType;
                 }
                 boundVar = const_cast<Value&>(v).toInt().first;
@@ -241,13 +239,13 @@ Value OptimizerUtils::boundValueWithLT(const meta::cpp2::ColumnDef& col, const V
             }
             std::vector<unsigned char> bytes(v.getStr().begin(), v.getStr().end());
             bytes.resize(*col.get_type().get_type_length());
-            for (size_t i = bytes.size();; i--) {
-                if (i > 0) {
-                    if (bytes[i-1]-- != 0) break;
-                } else {
-                    return Value(std::string(*col.get_type().get_type_length(), '\0'));
-                }
-            }
+            // for (size_t i = bytes.size();; i--) {
+            //     if (i > 0) {
+            //         if (bytes[i-1]-- != 0) break;
+            //     } else {
+            //         return Value(std::string(*col.get_type().get_type_length(), '\0'));
+            //     }
+            // }
             return Value(std::string(bytes.begin(), bytes.end()));
         }
         case Value::Type::DATE : {

--- a/src/optimizer/rule/IndexScanRule.cpp
+++ b/src/optimizer/rule/IndexScanRule.cpp
@@ -238,8 +238,8 @@ Status IndexScanRule::boundValue(const FilterItem& item,
     }
     switch (item.relOP_) {
         case Expression::Kind::kRelLE: {
-            // if c1 <= int(5) , the range pair should be (min, 6)
-            // if c1 < int(5), the range pair should be (min, 5)
+            // if c1 <= int(5) , the range pair should be [min, 6)
+            // if c1 < int(5), the range pair should be [min, 5)
             auto v = OptimizerUtils::boundValue(col, BVO::GREATER_THAN, val);
             CHECK_BOUND_VALUE(v, col.get_name());
             // where c <= 1 and c <= 2 , 1 should be valid.
@@ -273,8 +273,8 @@ Status IndexScanRule::boundValue(const FilterItem& item,
             break;
         }
         case Expression::Kind::kRelGT: {
-            // if c >= 5, the range pair should be (5, max)
-            // if c > 5, the range pair should be (6, max)
+            // if c >= 5, the range pair should be [5, max)
+            // if c > 5, the range pair should be [6, max)
             auto v = OptimizerUtils::boundValue(col, BVO::GREATER_THAN, val);
             CHECK_BOUND_VALUE(v, col.get_name());
             // where c > 1 and c > 2 , 2 should be valid.

--- a/src/optimizer/test/IndexBoundValueTest.cpp
+++ b/src/optimizer/test/IndexBoundValueTest.cpp
@@ -36,7 +36,7 @@ TEST(IndexBoundValueTest, StringTest) {
     EXPECT_EQ(maxStr, OptimizerUtils::boundValue(col, OP::GREATER_THAN, Value(maxStr)).getStr());
 
     retVal = OptimizerUtils::boundValue(col, OP::LESS_THAN, Value("aa")).getStr();
-    expected = {'a', '`', 255, 255, 255, 255, 255, 255};
+    expected = {'a', 'a', '\0', '\0', '\0', '\0', '\0', '\0'};
     EXPECT_EQ(std::string(expected.begin(), expected.end()), retVal);
 
     retVal = OptimizerUtils::boundValue(col, OP::LESS_THAN, Value("")).getStr();
@@ -48,7 +48,7 @@ TEST(IndexBoundValueTest, StringTest) {
     {
         auto actual = "ABCDEFGHIJKLMN";
         auto expectGT = "ABCDEFGI";
-        auto expectLT = "ABCDEFGG";
+        auto expectLT = "ABCDEFGH";
         EXPECT_EQ(expectGT,
                   OptimizerUtils::boundValue(col, OP::GREATER_THAN, Value(actual)).getStr());
         EXPECT_EQ(expectLT,
@@ -64,7 +64,7 @@ TEST(IndexBoundValueTest, StringTest) {
     }
     {
         std::vector<unsigned char> act = {255, 255, 255, 0, 0, 0, 0, 0};
-        std::vector<unsigned char> exp = {255, 255, 254, 255, 255, 255, 255, 255};
+        std::vector<unsigned char> exp = {255, 255, 255, 0, 0, 0, 0, 0};
         auto actStr = std::string(act.begin(), act.end());
         auto expStr = std::string(exp.begin(), exp.end());
         EXPECT_EQ(expStr, OptimizerUtils::boundValue(col, OP::LESS_THAN, Value(actStr)).getStr());

--- a/src/optimizer/test/IndexBoundValueTest.cpp
+++ b/src/optimizer/test/IndexBoundValueTest.cpp
@@ -80,6 +80,8 @@ TEST(IndexBoundValueTest, IntTest) {
     }
     auto maxInt = std::numeric_limits<int64_t>::max();
     auto minInt = std::numeric_limits<int64_t>::min();
+    auto testDouble = 35.5;
+
     EXPECT_EQ(maxInt, OptimizerUtils::boundValue(col, OP::MAX, Value(maxInt)).getInt());
     EXPECT_EQ(maxInt, OptimizerUtils::boundValue(col, OP::MAX, Value(1L)).getInt());
     EXPECT_EQ(minInt, OptimizerUtils::boundValue(col, OP::MIN, Value(minInt)).getInt());
@@ -89,14 +91,18 @@ TEST(IndexBoundValueTest, IntTest) {
     EXPECT_EQ(maxInt, OptimizerUtils::boundValue(col, OP::GREATER_THAN, Value(maxInt)).getInt());
     EXPECT_EQ(minInt + 1,
               OptimizerUtils::boundValue(col, OP::GREATER_THAN, Value(minInt)).getInt());
-    EXPECT_EQ(maxInt - 1,
+    EXPECT_EQ(maxInt,
               OptimizerUtils::boundValue(col, OP::LESS_THAN, Value(maxInt)).getInt());
 
     EXPECT_EQ(1, OptimizerUtils::boundValue(col, OP::GREATER_THAN, Value(0L)).getInt());
-    EXPECT_EQ(-1, OptimizerUtils::boundValue(col, OP::LESS_THAN, Value(0L)).getInt());
+    EXPECT_EQ(0, OptimizerUtils::boundValue(col, OP::LESS_THAN, Value(0L)).getInt());
 
     EXPECT_EQ(6, OptimizerUtils::boundValue(col, OP::GREATER_THAN, Value(5L)).getInt());
-    EXPECT_EQ(4, OptimizerUtils::boundValue(col, OP::LESS_THAN, Value(5L)).getInt());
+    EXPECT_EQ(5, OptimizerUtils::boundValue(col, OP::LESS_THAN, Value(5L)).getInt());
+
+    // compare int and double
+    EXPECT_EQ(36, OptimizerUtils::boundValue(col, OP::GREATER_THAN, Value(testDouble)).getInt());
+    EXPECT_EQ(36, OptimizerUtils::boundValue(col, OP::LESS_THAN, Value(testDouble)).getInt());
 }
 
 TEST(IndexBoundValueTest, DoubleTest) {
@@ -108,6 +114,7 @@ TEST(IndexBoundValueTest, DoubleTest) {
     }
     auto maxDouble = std::numeric_limits<double_t>::max();
     auto minDouble = std::numeric_limits<double_t>::min();
+
     EXPECT_EQ(maxDouble, OptimizerUtils::boundValue(col, OP::MAX, Value(maxDouble)).getFloat());
     EXPECT_EQ(maxDouble, OptimizerUtils::boundValue(col, OP::MAX, Value(1.1)).getFloat());
     EXPECT_EQ(-maxDouble, OptimizerUtils::boundValue(col, OP::MIN, Value(minDouble)).getFloat());
@@ -121,7 +128,6 @@ TEST(IndexBoundValueTest, DoubleTest) {
 
     EXPECT_EQ(5.1 - 0.0000000000000001,
               OptimizerUtils::boundValue(col, OP::LESS_THAN, Value(5.1)));
-
     EXPECT_EQ(-(5.1 + 0.0000000000000001),
               OptimizerUtils::boundValue(col, OP::LESS_THAN, Value(-5.1)));
 
@@ -134,9 +140,18 @@ TEST(IndexBoundValueTest, DoubleTest) {
 
     EXPECT_EQ(5.1 + 0.0000000000000001,
               OptimizerUtils::boundValue(col, OP::GREATER_THAN, Value(5.1)).getFloat());
-
     EXPECT_EQ(-(5.1 - 0.0000000000000001),
               OptimizerUtils::boundValue(col, OP::GREATER_THAN, Value(-5.1)).getFloat());
+
+    // compare int and double
+    EXPECT_EQ(50 + 0.0000000000000001,
+              OptimizerUtils::boundValue(col, OP::GREATER_THAN, Value(50)).getFloat());
+    EXPECT_EQ(-(50 - 0.0000000000000001),
+              OptimizerUtils::boundValue(col, OP::GREATER_THAN, Value(-50)).getFloat());
+    EXPECT_EQ(50 - 0.0000000000000001,
+              OptimizerUtils::boundValue(col, OP::LESS_THAN, Value(50)).getFloat());
+    EXPECT_EQ(-(50 + 0.0000000000000001),
+              OptimizerUtils::boundValue(col, OP::LESS_THAN, Value(-50)).getFloat());
 }
 
 TEST(IndexBoundValueTest, DateTest) {

--- a/src/optimizer/test/IndexScanRuleTest.cpp
+++ b/src/optimizer/test/IndexScanRuleTest.cpp
@@ -424,7 +424,8 @@ TEST(IndexScanRuleTest, BoundValueRangeTest) {
             EXPECT_EQ("col_str", hint.column_name);
             EXPECT_EQ(storage::cpp2::ScanType::RANGE, hint.scan_type);
             EXPECT_EQ(std::string(len, '\0'), hint.begin_value);
-            EXPECT_EQ("ccc", hint.end_value);
+            std::string end = std::string(3, 'c').append(7, 0x00);
+            EXPECT_EQ(end, hint.end_value);
         }
         {
             std::vector<storage::cpp2::IndexColumnHint> hints;
@@ -455,7 +456,7 @@ TEST(IndexScanRuleTest, BoundValueRangeTest) {
             EXPECT_EQ("col_str", hint.column_name);
             EXPECT_EQ(storage::cpp2::ScanType::RANGE, hint.scan_type);
             std::string begin = std::string(3, 'a').append(6, 0x00).append(1, 0x01);
-            std::string end = "ccc";
+            std::string end = std::string(3, 'c').append(7, 0x00);
             EXPECT_EQ(begin, hint.begin_value);
             EXPECT_EQ(end, hint.end_value);
         }
@@ -471,7 +472,7 @@ TEST(IndexScanRuleTest, BoundValueRangeTest) {
             const auto& hint = hints[0];
             EXPECT_EQ("col_str", hint.column_name);
             EXPECT_EQ(storage::cpp2::ScanType::RANGE, hint.scan_type);
-            std::string begin = "aaa";
+            std::string begin = std::string(3, 'a').append(7, 0x00);
             std::string end = std::string(3, 'c').append(6, 0x00).append(1, 0x01);
             EXPECT_EQ(begin, hint.begin_value);
             EXPECT_EQ(end, hint.end_value);
@@ -488,8 +489,10 @@ TEST(IndexScanRuleTest, BoundValueRangeTest) {
             const auto& hint = hints[0];
             EXPECT_EQ("col_str", hint.column_name);
             EXPECT_EQ(storage::cpp2::ScanType::RANGE, hint.scan_type);
-            EXPECT_EQ("aaa", hint.begin_value);
-            EXPECT_EQ("ccc", hint.end_value);
+            std::string begin = std::string(3, 'a').append(7, 0x00);
+            std::string end = std::string(3, 'c').append(7, 0x00);
+            EXPECT_EQ(begin, hint.begin_value);
+            EXPECT_EQ(end, hint.end_value);
         }
     }
 }

--- a/src/validator/LookupValidator.cpp
+++ b/src/validator/LookupValidator.cpp
@@ -397,7 +397,12 @@ StatusOr<Value> LookupValidator::checkConstExpr(Expression* expr, const std::str
     auto type = schema->getFieldType(prop);
     QueryExpressionContext dummy(nullptr);
     auto v = Expression::eval(expr, dummy);
-    if (v.type() != SchemaUtil::propTypeToValueType(type)) {
+
+    // Allow different numeric type to compare
+    if (v.isNumeric() && (graph::SchemaUtil::propTypeToValueType(type) == Value::Type::INT ||
+                          graph::SchemaUtil::propTypeToValueType(type) == Value::Type::FLOAT)) {
+        // skip the check
+    } else if (v.type() != SchemaUtil::propTypeToValueType(type)) {
         return Status::SemanticError("Column type error : %s", prop.c_str());
     }
     return v;

--- a/tests/tck/features/lookup/ByIndex.feature
+++ b/tests/tck/features/lookup/ByIndex.feature
@@ -1,7 +1,9 @@
 Feature: Lookup by index itself
 
   Background:
-    Given a graph with space named "nba"
+    Given an empty graph
+    And load "nba" csv data to a new space
+    And wait 3 seconds
 
   Scenario: [1] tag index
     When executing query:

--- a/tests/tck/features/lookup/ByIndex.feature
+++ b/tests/tck/features/lookup/ByIndex.feature
@@ -438,3 +438,160 @@ Feature: Lookup by index itself
       LOOKUP ON serve WHERE serve.start_year == serve.end_year YIELD serve.start_year AS startYear
       """
     Then a SemanticError should be raised at runtime:
+
+  Scenario: [1] Compare INT and FLOAT during IndexScan
+    When executing query:
+      """
+      LOOKUP ON player WHERE player.age == 40 YIELD player.age AS Age
+      """
+    Then the result should be, in any order:
+      | VertexID        | Age |
+      | "Dirk Nowitzki" | 40  |
+      | "Kobe Bryant"   | 40  |
+    When executing query:
+      """
+      LOOKUP ON player WHERE player.age > 40 YIELD player.age AS Age
+      """
+    Then the result should be, in any order:
+      | VertexID          | Age |
+      | "Grant Hill"      | 46  |
+      | "Jason Kidd"      | 45  |
+      | "Manu Ginobili"   | 41  |
+      | "Ray Allen"       | 43  |
+      | "Shaquile O'Neal" | 47  |
+      | "Steve Nash"      | 45  |
+      | "Tim Duncan"      | 42  |
+      | "Vince Carter"    | 42  |
+    When executing query:
+      """
+      LOOKUP ON player WHERE player.age > 40.5 YIELD player.age AS Age
+      """
+    Then the result should be, in any order:
+      | VertexID          | Age |
+      | "Grant Hill"      | 46  |
+      | "Jason Kidd"      | 45  |
+      | "Manu Ginobili"   | 41  |
+      | "Ray Allen"       | 43  |
+      | "Shaquile O'Neal" | 47  |
+      | "Steve Nash"      | 45  |
+      | "Tim Duncan"      | 42  |
+      | "Vince Carter"    | 42  |
+    When executing query:
+      """
+      LOOKUP ON player WHERE player.age >= 40.5 YIELD player.age AS Age
+      """
+    Then the result should be, in any order:
+      | VertexID          | Age |
+      | "Grant Hill"      | 46  |
+      | "Jason Kidd"      | 45  |
+      | "Manu Ginobili"   | 41  |
+      | "Ray Allen"       | 43  |
+      | "Shaquile O'Neal" | 47  |
+      | "Steve Nash"      | 45  |
+      | "Tim Duncan"      | 42  |
+      | "Vince Carter"    | 42  |
+    When executing query:
+      """
+      LOOKUP ON player WHERE player.age < 40
+      YIELD player.age AS Age, player.name AS Name | order by Age DESC, Name| limit 10
+      """
+    Then the result should be, in order, with relax comparison:
+      | VertexID            | Age | Name                |
+      | "Tracy McGrady"     | 39  | "Tracy McGrady"     |
+      | "David West"        | 38  | "David West"        |
+      | "Paul Gasol"        | 38  | "Paul Gasol"        |
+      | "Yao Ming"          | 38  | "Yao Ming"          |
+      | "Dwyane Wade"       | 37  | "Dwyane Wade"       |
+      | "Amar'e Stoudemire" | 36  | "Amar'e Stoudemire" |
+      | "Boris Diaw"        | 36  | "Boris Diaw"        |
+      | "Tony Parker"       | 36  | "Tony Parker"       |
+      | "Carmelo Anthony"   | 34  | "Carmelo Anthony"   |
+      | "LeBron James"      | 34  | "LeBron James"      |
+    When executing query:
+      """
+      LOOKUP ON player WHERE player.age <= 40
+      YIELD player.age AS Age, player.name AS Name | order by Age DESC, Name| limit 10
+      """
+    Then the result should be, in order, with relax comparison:
+      | VertexID            | Age | Name                |
+      | "Dirk Nowitzki"     | 40  | "Dirk Nowitzki"     |
+      | "Kobe Bryant"       | 40  | "Kobe Bryant"       |
+      | "Tracy McGrady"     | 39  | "Tracy McGrady"     |
+      | "David West"        | 38  | "David West"        |
+      | "Paul Gasol"        | 38  | "Paul Gasol"        |
+      | "Yao Ming"          | 38  | "Yao Ming"          |
+      | "Dwyane Wade"       | 37  | "Dwyane Wade"       |
+      | "Amar'e Stoudemire" | 36  | "Amar'e Stoudemire" |
+      | "Boris Diaw"        | 36  | "Boris Diaw"        |
+      | "Tony Parker"       | 36  | "Tony Parker"       |
+
+  Scenario: [2] Compare INT and FLOAT during IndexScan
+    Given having executed:
+      """
+      CREATE TAG weight (WEIGHT double)
+      """
+    And having executed:
+      """
+      CREATE TAG INDEX weight_index
+      ON weight(WEIGHT)
+      """
+    And wait 6 seconds
+    When executing query:
+      """
+      INSERT VERTEX weight(WEIGHT)
+      VALUES "Tim Duncan" : (70.5)
+      """
+    Then the execution should be successful
+    When executing query:
+      """
+      INSERT VERTEX weight(WEIGHT)
+      VALUES "Tony Parker" : (80.0)
+      """
+    Then the execution should be successful
+    When executing query:
+      """
+      LOOKUP ON weight
+      WHERE weight.WEIGHT > 70;
+      """
+    Then the result should be, in any order:
+      | VertexID      |
+      | "Tim Duncan"  |
+      | "Tony Parker" |
+    When executing query:
+      """
+      LOOKUP ON weight
+      WHERE weight.WEIGHT > 70.4;
+      """
+    Then the result should be, in any order:
+      | VertexID      |
+      | "Tim Duncan"  |
+      | "Tony Parker" |
+    When executing query:
+      """
+      LOOKUP ON weight
+      WHERE weight.WEIGHT >= 70.5;
+      """
+    Then the result should be, in any order:
+      | VertexID      |
+      | "Tim Duncan"  |
+      | "Tony Parker" |
+    Then drop the used space
+
+# (TODO) Unsupported cases due to the lack of float precision
+# When executing query:
+# """
+# LOOKUP ON weight
+# WHERE weight.WEIGHT > 70.5;
+# """
+# Then the result should be, in any order:
+# | VertexID      |
+# | "Tony Parker" |
+# When executing query:
+# """
+# LOOKUP ON weight
+# WHERE weight.WEIGHT <= 80.0;
+# """
+# Then the result should be, in any order:
+# | VertexID      |
+# | "Tim Duncan"  |
+# | "Tony Parker" |

--- a/tests/tck/features/lookup/ByIndex.intVid.feature
+++ b/tests/tck/features/lookup/ByIndex.intVid.feature
@@ -1,3 +1,4 @@
+@test
 Feature: Lookup by index itself in integer vid
 
   Background:
@@ -438,3 +439,160 @@ Feature: Lookup by index itself in integer vid
       LOOKUP ON serve WHERE serve.start_year == serve.end_year YIELD serve.start_year AS startYear
       """
     Then a SemanticError should be raised at runtime:
+
+  Scenario: [1] Compare INT and FLOAT during IndexScan
+    When executing query:
+      """
+      LOOKUP ON player WHERE player.age == 40 YIELD player.age AS Age
+      """
+    Then the result should be, in any order, and the columns 0 should be hashed:
+      | VertexID        | Age |
+      | "Dirk Nowitzki" | 40  |
+      | "Kobe Bryant"   | 40  |
+    When executing query:
+      """
+      LOOKUP ON player WHERE player.age > 40 YIELD player.age AS Age
+      """
+    Then the result should be, in any order, and the columns 0 should be hashed:
+      | VertexID          | Age |
+      | "Grant Hill"      | 46  |
+      | "Jason Kidd"      | 45  |
+      | "Manu Ginobili"   | 41  |
+      | "Ray Allen"       | 43  |
+      | "Shaquile O'Neal" | 47  |
+      | "Steve Nash"      | 45  |
+      | "Tim Duncan"      | 42  |
+      | "Vince Carter"    | 42  |
+    When executing query:
+      """
+      LOOKUP ON player WHERE player.age > 40.5 YIELD player.age AS Age
+      """
+    Then the result should be, in any order, and the columns 0 should be hashed:
+      | VertexID          | Age |
+      | "Grant Hill"      | 46  |
+      | "Jason Kidd"      | 45  |
+      | "Manu Ginobili"   | 41  |
+      | "Ray Allen"       | 43  |
+      | "Shaquile O'Neal" | 47  |
+      | "Steve Nash"      | 45  |
+      | "Tim Duncan"      | 42  |
+      | "Vince Carter"    | 42  |
+    When executing query:
+      """
+      LOOKUP ON player WHERE player.age >= 40.5 YIELD player.age AS Age
+      """
+    Then the result should be, in any order, and the columns 0 should be hashed:
+      | VertexID          | Age |
+      | "Grant Hill"      | 46  |
+      | "Jason Kidd"      | 45  |
+      | "Manu Ginobili"   | 41  |
+      | "Ray Allen"       | 43  |
+      | "Shaquile O'Neal" | 47  |
+      | "Steve Nash"      | 45  |
+      | "Tim Duncan"      | 42  |
+      | "Vince Carter"    | 42  |
+    When executing query:
+      """
+      LOOKUP ON player WHERE player.age < 40
+      YIELD player.age AS Age, player.name AS Name | order by Age DESC, Name| limit 10
+      """
+    Then the result should be, in order, with relax comparison, and the columns 0 should be hashed:
+      | VertexID            | Age | Name                |
+      | "Tracy McGrady"     | 39  | "Tracy McGrady"     |
+      | "David West"        | 38  | "David West"        |
+      | "Paul Gasol"        | 38  | "Paul Gasol"        |
+      | "Yao Ming"          | 38  | "Yao Ming"          |
+      | "Dwyane Wade"       | 37  | "Dwyane Wade"       |
+      | "Amar'e Stoudemire" | 36  | "Amar'e Stoudemire" |
+      | "Boris Diaw"        | 36  | "Boris Diaw"        |
+      | "Tony Parker"       | 36  | "Tony Parker"       |
+      | "Carmelo Anthony"   | 34  | "Carmelo Anthony"   |
+      | "LeBron James"      | 34  | "LeBron James"      |
+    When executing query:
+      """
+      LOOKUP ON player WHERE player.age <= 40
+      YIELD player.age AS Age, player.name AS Name | order by Age DESC, Name| limit 10
+      """
+    Then the result should be, in order, with relax comparison, and the columns 0 should be hashed:
+      | VertexID            | Age | Name                |
+      | "Dirk Nowitzki"     | 40  | "Dirk Nowitzki"     |
+      | "Kobe Bryant"       | 40  | "Kobe Bryant"       |
+      | "Tracy McGrady"     | 39  | "Tracy McGrady"     |
+      | "David West"        | 38  | "David West"        |
+      | "Paul Gasol"        | 38  | "Paul Gasol"        |
+      | "Yao Ming"          | 38  | "Yao Ming"          |
+      | "Dwyane Wade"       | 37  | "Dwyane Wade"       |
+      | "Amar'e Stoudemire" | 36  | "Amar'e Stoudemire" |
+      | "Boris Diaw"        | 36  | "Boris Diaw"        |
+      | "Tony Parker"       | 36  | "Tony Parker"       |
+
+  Scenario: [2] Compare INT and FLOAT during IndexScan
+    Given having executed:
+      """
+      CREATE TAG weight (WEIGHT double)
+      """
+    And having executed:
+      """
+      CREATE TAG INDEX weight_index
+      ON weight(WEIGHT)
+      """
+    And wait 6 seconds
+    When executing query:
+      """
+      INSERT VERTEX weight(WEIGHT)
+      VALUES hash("Tim Duncan") : (70.5)
+      """
+    Then the execution should be successful
+    When executing query:
+      """
+      INSERT VERTEX weight(WEIGHT)
+      VALUES hash("Tony Parker") : (80.0)
+      """
+    Then the execution should be successful
+    When executing query:
+      """
+      LOOKUP ON weight
+      WHERE weight.WEIGHT > 70;
+      """
+    Then the result should be, in any order, and the columns 0 should be hashed:
+      | VertexID      |
+      | "Tim Duncan"  |
+      | "Tony Parker" |
+    When executing query:
+      """
+      LOOKUP ON weight
+      WHERE weight.WEIGHT > 70.4;
+      """
+    Then the result should be, in any order, and the columns 0 should be hashed:
+      | VertexID      |
+      | "Tim Duncan"  |
+      | "Tony Parker" |
+    When executing query:
+      """
+      LOOKUP ON weight
+      WHERE weight.WEIGHT >= 70.5;
+      """
+    Then the result should be, in any order, and the columns 0 should be hashed:
+      | VertexID      |
+      | "Tim Duncan"  |
+      | "Tony Parker" |
+    Then drop the used space
+
+# (TODO) Unsupported cases due to the lack of float precision
+# When executing query:
+# """
+# LOOKUP ON weight
+# WHERE weight.WEIGHT > 70.5;
+# """
+# Then the result should be, in any order, and the columns 0 should be hashed:
+# | VertexID      |
+# | "Tony Parker" |
+# When executing query:
+# """
+# LOOKUP ON weight
+# WHERE weight.WEIGHT <= 80.0;
+# """
+# Then the result should be, in any order, and the columns 0 should be hashed:
+# | VertexID      |
+# | "Tim Duncan"  |
+# | "Tony Parker" |

--- a/tests/tck/features/lookup/ByIndex.intVid.feature
+++ b/tests/tck/features/lookup/ByIndex.intVid.feature
@@ -1,8 +1,9 @@
-@test
 Feature: Lookup by index itself in integer vid
 
   Background:
-    Given a graph with space named "nba_int_vid"
+    Given an empty graph
+    And load "nba_int_vid" csv data to a new space
+    And wait 3 seconds
 
   Scenario: [1] tag index
     When executing query:

--- a/tests/tck/features/match/VariableLengthPattern.intVid.feature
+++ b/tests/tck/features/match/VariableLengthPattern.intVid.feature
@@ -7,7 +7,7 @@ Feature: Integer Vid Variable length Pattern match (m to n)
   Background:
     Given a graph with space named "nba_int_vid"
 
-  Scenario: Integer Vid  single both direction edge with properties
+  Scenario: Integer Vid single both direction edge with properties
     When executing query:
       """
       MATCH (:player{name:"Tim Duncan"})-[e:serve*2..3{start_year: 2000}]-(v)
@@ -24,7 +24,7 @@ Feature: Integer Vid Variable length Pattern match (m to n)
       | e                                                                                  | v                  |
       | [[:like "Tim Duncan"<-"Manu Ginobili"], [:like "Manu Ginobili"<-"Tiago Splitter"]] | ("Tiago Splitter") |
 
-  Scenario: Integer Vid  single direction edge with properties
+  Scenario: Integer Vid single direction edge with properties
     When executing query:
       """
       MATCH (:player{name:"Tim Duncan"})-[e:serve*2..3{start_year: 2000}]->(v)
@@ -48,7 +48,7 @@ Feature: Integer Vid Variable length Pattern match (m to n)
       | e                                                                                  | v                  |
       | [[:like "Tim Duncan"<-"Manu Ginobili"], [:like "Manu Ginobili"<-"Tiago Splitter"]] | ("Tiago Splitter") |
 
-  Scenario: Integer Vid  single both direction edge without properties
+  Scenario: Integer Vid single both direction edge without properties
     When executing query:
       """
       MATCH (:player{name:"Tim Duncan"})-[e:serve*2..3]-(v)
@@ -122,7 +122,7 @@ Feature: Integer Vid Variable length Pattern match (m to n)
       | [[:serve "Tim Duncan"->"Spurs"], [:serve "Spurs"<-"Boris Diaw"], [:serve "Boris Diaw"->"Hawks"]]                       | ("Hawks")             |
       | [[:serve "Tim Duncan"->"Spurs"], [:serve "Spurs"<-"Boris Diaw"], [:serve "Boris Diaw"->"Hornets"]]                     | ("Hornets")           |
 
-  Scenario: Integer Vid  single both direction edge without properties
+  Scenario: Integer Vid single both direction edge without properties
     When executing query:
       """
       MATCH (:player{name: "Tim Duncan"})-[e:like*2..3]-(v)
@@ -133,7 +133,7 @@ Feature: Integer Vid Variable length Pattern match (m to n)
       | COUNT(*) |
       | 292      |
 
-  Scenario: Integer Vid  single direction edge without properties
+  Scenario: Integer Vid single direction edge without properties
     When executing query:
       """
       MATCH (:player{name:"Tim Duncan"})-[e:serve*2..3]->(v)
@@ -158,7 +158,7 @@ Feature: Integer Vid Variable length Pattern match (m to n)
       | [[:like "Tim Duncan"->"Manu Ginobili"], [:like "Manu Ginobili"->"Tim Duncan"]]                                                | ("Tim Duncan")        |
       | [[:like "Tim Duncan"->"Manu Ginobili"], [:like "Manu Ginobili"->"Tim Duncan"], [:like "Tim Duncan"->"Tony Parker"]]           | ("Tony Parker")       |
 
-  Scenario: Integer Vid  multiple both direction edge with properties
+  Scenario: Integer Vid multiple both direction edge with properties
     When executing query:
       """
       MATCH (:player{name: "Tim Duncan"})-[e:serve|like*2..3{likeness: 90}]-(v)
@@ -175,7 +175,7 @@ Feature: Integer Vid Variable length Pattern match (m to n)
     Then the result should be, in any order:
       | e | v |
 
-  Scenario: Integer Vid  multiple direction edge with properties
+  Scenario: Integer Vid multiple direction edge with properties
     When executing query:
       """
       MATCH (:player{name:"Tim Duncan"})-[e:serve|like*2..3{likeness: 90}]->(v)
@@ -192,7 +192,7 @@ Feature: Integer Vid Variable length Pattern match (m to n)
       | e                                                                                  | v                  |
       | [[:like "Tim Duncan"<-"Manu Ginobili"], [:like "Manu Ginobili"<-"Tiago Splitter"]] | ("Tiago Splitter") |
 
-  Scenario: Integer Vid  multiple both direction edge without properties
+  Scenario: Integer Vid multiple both direction edge without properties
     When executing query:
       """
       MATCH (:player{name:"Tim Duncan"})-[e:serve|like*2..3]-(v)
@@ -203,7 +203,7 @@ Feature: Integer Vid Variable length Pattern match (m to n)
       | COUNT(*) |
       | 927      |
 
-  Scenario: Integer Vid  multiple direction edge without properties
+  Scenario: Integer Vid multiple direction edge without properties
     When executing query:
       """
       MATCH (:player{name: "Tim Duncan"})-[e:serve|like*2..3]->(v)
@@ -229,7 +229,7 @@ Feature: Integer Vid Variable length Pattern match (m to n)
       | [[:like "Tim Duncan"->"Manu Ginobili"], [:like "Manu Ginobili"->"Tim Duncan"], [:serve "Tim Duncan"->"Spurs"]]                   | ("Spurs")             |
       | [[:like "Tim Duncan"->"Manu Ginobili"], [:serve "Manu Ginobili"->"Spurs"]]                                                       | ("Spurs")             |
 
-  Scenario: Integer Vid  return all
+  Scenario: Integer Vid return all
     When executing query:
       """
       MATCH (:player{name:"Tim Duncan"})-[e:like*2..3]->()
@@ -247,7 +247,7 @@ Feature: Integer Vid Variable length Pattern match (m to n)
       | [[:like "Tim Duncan"->"Manu Ginobili"], [:like "Manu Ginobili"->"Tim Duncan"]]                                                |
       | [[:like "Tim Duncan"->"Manu Ginobili"], [:like "Manu Ginobili"->"Tim Duncan"], [:like "Tim Duncan"->"Tony Parker"]]           |
 
-  Scenario: Integer Vid  from one step
+  Scenario: Integer Vid from one step
     When executing query:
       """
       MATCH (v:player{name: 'Tim Duncan'})-[e:like*1]-()
@@ -268,7 +268,7 @@ Feature: Integer Vid Variable length Pattern match (m to n)
       | [[:like "Tim Duncan"<-"Tony Parker"]]       |
       | [[:like "Tim Duncan"<-"LaMarcus Aldridge"]] |
 
-  Scenario: Integer Vid  from one step to one step
+  Scenario: Integer Vid from one step to one step
     When executing query:
       """
       MATCH (v:player{name: 'Tim Duncan'})-[e:like*1..1]-()
@@ -289,7 +289,7 @@ Feature: Integer Vid Variable length Pattern match (m to n)
       | [[:like "Tim Duncan"<-"Tony Parker"]]       |
       | [[:like "Tim Duncan"<-"LaMarcus Aldridge"]] |
 
-  Scenario: Integer Vid  filter by edges
+  Scenario: Integer Vid filter by edges
     When executing query:
       """
       MATCH (v:player{name: 'Tim Duncan'})-[e:like*2..3]-()
@@ -310,7 +310,7 @@ Feature: Integer Vid Variable length Pattern match (m to n)
       | v2                                                                                                          |
       | ("Tim Duncan" :bachelor{name: "Tim Duncan", speciality: "psychology"} :player{age: 42, name: "Tim Duncan"}) |
 
-  Scenario: Integer Vid  multi-steps and filter by node properties
+  Scenario: Integer Vid multi-steps and filter by node properties
     When executing query:
       """
       MATCH (v:player{name: 'Tim Duncan'})-[e1:like*1..2]-(v2{name: 'Tony Parker'})-[e2:serve]-(v3{name: 'Spurs'})


### PR DESCRIPTION
1. Fix crash caused by comparing different numerical types in the index scan. Issue: fixes https://github.com/vesoft-inc/nebula-graph/issues/721

TODO:
Fix edges cases failure due to the float precision.