### PR TITLE
Introduce weak dependency for plan node

### DIFF
--- a/src/executor/Executor.cpp
+++ b/src/executor/Executor.cpp
@@ -129,7 +129,10 @@ Executor *Executor::makeExecutor(const PlanNode *node,
     }
 
     for (size_t i = 0; i < node->numDeps(); ++i) {
-        exec->dependsOn(makeExecutor(node->dep(i), qctx, visited));
+        const auto &dep = node->dependency(i);
+        if (!dep.weak) {
+            exec->dependsOn(makeExecutor(dep.node, qctx, visited));
+        }
     }
 
     visited->insert({node->id(), exec});

--- a/src/executor/query/JoinExecutor.cpp
+++ b/src/executor/query/JoinExecutor.cpp
@@ -15,18 +15,19 @@ namespace graph {
 
 Status JoinExecutor::checkInputDataSets() {
     auto* join = asNode<Join>(node());
-    lhsIter_ = ectx_->getVersionedResult(join->leftVar().first, join->leftVar().second).iter();
+    auto leftVar = join->left()->outputVar();
+    lhsIter_ = ectx_->getVersionedResult(leftVar, join->leftVarVersion()).iter();
     DCHECK(!!lhsIter_);
-    VLOG(1) << "lhs: " << join->leftVar().first << " " << lhsIter_->size();
+    VLOG(1) << "lhs: " << leftVar << " " << lhsIter_->size();
     if (lhsIter_->isGetNeighborsIter() || lhsIter_->isDefaultIter()) {
         std::stringstream ss;
         ss << "Join executor does not support " << lhsIter_->kind();
         return Status::Error(ss.str());
     }
-    rhsIter_ =
-        ectx_->getVersionedResult(join->rightVar().first, join->rightVar().second).iter();
+    auto rightVar = join->right()->outputVar();
+    rhsIter_ = ectx_->getVersionedResult(rightVar, join->rightVarVersion()).iter();
     DCHECK(!!rhsIter_);
-    VLOG(1) << "rhs: " << join->rightVar().first << " " << rhsIter_->size();
+    VLOG(1) << "rhs: " << rightVar << " " << rhsIter_->size();
     if (rhsIter_->isGetNeighborsIter() || rhsIter_->isDefaultIter()) {
         std::stringstream ss;
         ss << "Join executor does not support " << rhsIter_->kind();

--- a/src/executor/query/LeftJoinExecutor.cpp
+++ b/src/executor/query/LeftJoinExecutor.cpp
@@ -25,7 +25,8 @@ Status LeftJoinExecutor::close() {
 
 folly::Future<Status> LeftJoinExecutor::join() {
     auto* join = asNode<Join>(node());
-    auto& rhsResult = ectx_->getVersionedResult(join->rightVar().first, join->rightVar().second);
+    auto rightVar = join->right()->outputVar();
+    auto& rhsResult = ectx_->getVersionedResult(rightVar, join->rightVarVersion());
     rightColSize_ = rhsResult.valuePtr()->getDataSet().colNames.size();
 
     auto& hashKeys = join->hashKeys();

--- a/src/planner/Planner.h
+++ b/src/planner/Planner.h
@@ -21,6 +21,8 @@ struct SubPlan {
     // root and tail of a subplan.
     PlanNode*   root{nullptr};
     PlanNode*   tail{nullptr};
+
+    explicit SubPlan(PlanNode* root = nullptr, PlanNode* tail = nullptr) : root(root), tail(tail) {}
 };
 
 std::ostream& operator<<(std::ostream& os, const SubPlan& subplan);

--- a/src/planner/match/AddDependencyStrategy.cpp
+++ b/src/planner/match/AddDependencyStrategy.cpp
@@ -8,10 +8,11 @@
 
 namespace nebula {
 namespace graph {
-PlanNode* AddDependencyStrategy::connect(const PlanNode* left, const PlanNode* right) {
-    auto* mutableLeft = const_cast<PlanNode*>(left);
+PlanNode* AddDependencyStrategy::connect(const PlanNode::Dependency& left,
+                                         const PlanNode::Dependency& right) {
+    auto* mutableLeft = const_cast<PlanNode*>(left.node);
     auto* siLeft = static_cast<SingleDependencyNode*>(mutableLeft);
-    siLeft->dependsOn(const_cast<PlanNode*>(right));
+    siLeft->dependsOn(const_cast<PlanNode*>(right.node));
     // siLeft->setColNames(right->colNames());
     return nullptr;
 }

--- a/src/planner/match/AddDependencyStrategy.h
+++ b/src/planner/match/AddDependencyStrategy.h
@@ -19,7 +19,7 @@ class AddDependencyStrategy final : public SegmentsConnectStrategy {
 public:
     AddDependencyStrategy() : SegmentsConnectStrategy(nullptr) {}
 
-    PlanNode* connect(const PlanNode* left, const PlanNode* right) override;
+    PlanNode* connect(const PlanNode::Dependency& left, const PlanNode::Dependency& right) override;
 };
 }   // namespace graph
 }   // namespace nebula

--- a/src/planner/match/AddInputStrategy.cpp
+++ b/src/planner/match/AddInputStrategy.cpp
@@ -8,14 +8,15 @@
 
 namespace nebula {
 namespace graph {
-PlanNode* AddInputStrategy::connect(const PlanNode* left, const PlanNode* right) {
-    DCHECK(left->isSingleInput());
-    auto* mutableLeft = const_cast<PlanNode*>(left);
+PlanNode* AddInputStrategy::connect(const PlanNode::Dependency& left,
+                                    const PlanNode::Dependency& right) {
+    DCHECK(left.node->isSingleInput());
+    auto* mutableLeft = const_cast<PlanNode*>(left.node);
     auto* siLeft = static_cast<SingleInputNode*>(mutableLeft);
-    siLeft->dependsOn(const_cast<PlanNode*>(right));
-    siLeft->setInputVar(right->outputVar());
+    siLeft->dependsOn(const_cast<PlanNode*>(right.node));
+    siLeft->setInputVar(right.node->outputVar());
     if (copyColNames_) {
-        siLeft->setColNames(right->colNames());
+        siLeft->setColNames(right.node->colNames());
     }
     return nullptr;
 }

--- a/src/planner/match/AddInputStrategy.h
+++ b/src/planner/match/AddInputStrategy.h
@@ -20,7 +20,7 @@ public:
     explicit AddInputStrategy(bool copyColNames)
         : SegmentsConnectStrategy(nullptr), copyColNames_(copyColNames) {}
 
-    PlanNode* connect(const PlanNode* left, const PlanNode* right) override;
+    PlanNode* connect(const PlanNode::Dependency& left, const PlanNode::Dependency& right) override;
 
 private:
     bool copyColNames_{false};

--- a/src/planner/match/CartesianProductStrategy.cpp
+++ b/src/planner/match/CartesianProductStrategy.cpp
@@ -6,25 +6,29 @@
 
 #include "planner/match/CartesianProductStrategy.h"
 
-#include "planner/Query.h"
-#include "util/ExpressionUtils.h"
-#include "planner/match/MatchSolver.h"
 #include "planner/Algo.h"
+#include "planner/Query.h"
+#include "planner/match/MatchSolver.h"
+#include "util/ExpressionUtils.h"
 
 namespace nebula {
 namespace graph {
-PlanNode* CartesianProductStrategy::connect(const PlanNode* left, const PlanNode* right) {
+
+PlanNode* CartesianProductStrategy::connect(const PlanNode::Dependency& left,
+                                            const PlanNode::Dependency& right) {
     return joinDataSet(left, right);
 }
 
-PlanNode* CartesianProductStrategy::joinDataSet(const PlanNode* left, const PlanNode* right) {
-    DCHECK(left->outputVar() != right->outputVar());
+PlanNode* CartesianProductStrategy::joinDataSet(const PlanNode::Dependency& left,
+                                                const PlanNode::Dependency& right) {
+    DCHECK_NE(left.node->outputVar(), right.node->outputVar());
 
     auto* cartesianProduct = CartesianProduct::make(qctx_, nullptr);
-    cartesianProduct->addVar(left->outputVar());
-    cartesianProduct->addVar(right->outputVar());
+    cartesianProduct->addVar(left.node->outputVar());
+    cartesianProduct->addVar(right.node->outputVar());
 
     return cartesianProduct;
 }
-}  // namespace graph
-}  // namespace nebula
+
+}   // namespace graph
+}   // namespace nebula

--- a/src/planner/match/CartesianProductStrategy.h
+++ b/src/planner/match/CartesianProductStrategy.h
@@ -8,7 +8,6 @@
 #define PLANNER_MATCH_CARTESIANPRODUCTSTRATEGY_H_
 
 #include "planner/match/SegmentsConnector.h"
-#include "planner/PlanNode.h"
 
 namespace nebula {
 namespace graph {
@@ -21,10 +20,10 @@ class CartesianProductStrategy final : public SegmentsConnectStrategy {
 public:
     explicit CartesianProductStrategy(QueryContext* qctx) : SegmentsConnectStrategy(qctx) {}
 
-    PlanNode* connect(const PlanNode* left, const PlanNode* right) override;
+    PlanNode* connect(const PlanNode::Dependency& left, const PlanNode::Dependency& right) override;
 
 private:
-    PlanNode* joinDataSet(const PlanNode* left, const PlanNode* right);
+    PlanNode* joinDataSet(const PlanNode::Dependency& left, const PlanNode::Dependency& right);
 };
 }  // namespace graph
 }  // namespace nebula

--- a/src/planner/match/InnerJoinStrategy.h
+++ b/src/planner/match/InnerJoinStrategy.h
@@ -7,7 +7,6 @@
 #ifndef PLANNER_PLANNERS_MATCH_INNERJOINSTRATEGY_H_
 #define PLANNER_PLANNERS_MATCH_INNERJOINSTRATEGY_H_
 
-#include "planner/PlanNode.h"
 #include "planner/match/SegmentsConnectStrategy.h"
 
 namespace nebula {
@@ -34,10 +33,10 @@ public:
         return this;
     }
 
-    PlanNode* connect(const PlanNode* left, const PlanNode* right) override;
+    PlanNode* connect(const PlanNode::Dependency& left, const PlanNode::Dependency& right) override;
 
 private:
-    PlanNode* joinDataSet(const PlanNode* left, const PlanNode* right);
+    PlanNode* joinDataSet(const PlanNode::Dependency& left, const PlanNode::Dependency& right);
 
     JoinPos     leftPos_{JoinPos::kEnd};
     JoinPos     rightPos_{JoinPos::kStart};

--- a/src/planner/match/SegmentsConnectStrategy.h
+++ b/src/planner/match/SegmentsConnectStrategy.h
@@ -7,6 +7,8 @@
 #ifndef PLANNER_MATCH_SEGMENTSCONNECTSTRATEGY_H_
 #define PLANNER_MATCH_SEGMENTSCONNECTSTRATEGY_H_
 
+#include "planner/PlanNode.h"
+
 namespace nebula {
 namespace graph {
 
@@ -16,11 +18,14 @@ public:
 
     virtual ~SegmentsConnectStrategy() = default;
 
-    virtual PlanNode* connect(const PlanNode* left, const PlanNode* right) = 0;
+    virtual PlanNode* connect(const PlanNode::Dependency& left,
+                              const PlanNode::Dependency& right) = 0;
 
 protected:
-    QueryContext*   qctx_;
+    QueryContext* qctx_;
 };
-}  // namespace graph
-}  // namespace nebula
-#endif  // PLANNER_MATCH_SEGMENTSCONNECTSTRATEGY_H_
+
+}   // namespace graph
+}   // namespace nebula
+
+#endif   // PLANNER_MATCH_SEGMENTSCONNECTSTRATEGY_H_

--- a/src/planner/match/SegmentsConnector.cpp
+++ b/src/planner/match/SegmentsConnector.cpp
@@ -31,8 +31,8 @@ StatusOr<SubPlan> SegmentsConnector::connectSegments(CypherClauseContextBase* le
 }
 
 PlanNode* SegmentsConnector::innerJoinSegments(QueryContext* qctx,
-                                               const PlanNode* left,
-                                               const PlanNode* right,
+                                               const PlanNode::Dependency& left,
+                                               const PlanNode::Dependency& right,
                                                InnerJoinStrategy::JoinPos leftPos,
                                                InnerJoinStrategy::JoinPos rightPos) {
     return std::make_unique<InnerJoinStrategy>(qctx)
@@ -42,8 +42,8 @@ PlanNode* SegmentsConnector::innerJoinSegments(QueryContext* qctx,
 }
 
 PlanNode* SegmentsConnector::cartesianProductSegments(QueryContext* qctx,
-                                                      const PlanNode* left,
-                                                      const PlanNode* right) {
+                                                      const PlanNode::Dependency& left,
+                                                      const PlanNode::Dependency& right) {
     return std::make_unique<CartesianProductStrategy>(qctx)->connect(left, right);
 }
 

--- a/src/planner/match/SegmentsConnector.h
+++ b/src/planner/match/SegmentsConnector.h
@@ -39,14 +39,14 @@ public:
 
     static PlanNode* innerJoinSegments(
         QueryContext* qctx,
-        const PlanNode* left,
-        const PlanNode* right,
+        const PlanNode::Dependency& left,
+        const PlanNode::Dependency& right,
         InnerJoinStrategy::JoinPos leftPos = InnerJoinStrategy::JoinPos::kEnd,
         InnerJoinStrategy::JoinPos rightPos = InnerJoinStrategy::JoinPos::kStart);
 
     static PlanNode* cartesianProductSegments(QueryContext* qctx,
-                                              const PlanNode* left,
-                                              const PlanNode* right);
+                                              const PlanNode::Dependency& left,
+                                              const PlanNode::Dependency& right);
 
     static void addDependency(const PlanNode* left, const PlanNode* right);
 


### PR DESCRIPTION
Scheduler will use the weak dependency to solve the following plan execution issue:

```
A -----> B -----> C
  \               ^
   \______________|
```

A depends on B and C, B depends on C, And we should not execute C twice.