### PR TITLE
Release unused symbols for plan node when optimizing

### DIFF
--- a/src/optimizer/OptGroup.cpp
+++ b/src/optimizer/OptGroup.cpp
@@ -70,6 +70,9 @@ Status OptGroup::explore(const OptRule *rule) {
         NG_RETURN_IF_ERROR(resStatus);
         auto result = std::move(resStatus).value();
         if (result.eraseAll) {
+            for (auto gnode : groupNodes_) {
+                gnode->node()->releaseSymbols();
+            }
             groupNodes_.clear();
             for (auto ngn : result.newGroupNodes) {
                 addGroupNode(ngn);
@@ -86,6 +89,7 @@ Status OptGroup::explore(const OptRule *rule) {
         }
 
         if (result.eraseCurr) {
+            (*iter)->node()->releaseSymbols();
             iter = groupNodes_.erase(iter);
         } else {
             ++iter;

--- a/src/optimizer/OptGroup.h
+++ b/src/optimizer/OptGroup.h
@@ -100,7 +100,7 @@ public:
         return group_;
     }
 
-    const graph::PlanNode *node() const {
+    graph::PlanNode *node() const {
         return node_;
     }
 

--- a/src/planner/PlanNode.cpp
+++ b/src/planner/PlanNode.cpp
@@ -323,6 +323,16 @@ std::unique_ptr<PlanNodeDescription> PlanNode::explain() const {
     return desc;
 }
 
+void PlanNode::releaseSymbols() {
+    auto symTbl = qctx_->symTable();
+    for (auto in : inputVars_) {
+        in && symTbl->deleteReadBy(in->name, this);
+    }
+    for (auto out : outputVars_) {
+        out && symTbl->deleteWrittenBy(out->name, this);
+    }
+}
+
 std::ostream& operator<<(std::ostream& os, PlanNode::Kind kind) {
     os << PlanNode::toString(kind);
     return os;

--- a/src/planner/PlanNode.h
+++ b/src/planner/PlanNode.h
@@ -234,6 +234,8 @@ public:
         return inputVars_;
     }
 
+    void releaseSymbols();
+
     static const char* toString(Kind kind);
     std::string toString() const;
 


### PR DESCRIPTION
Release unused symbols will decrease the number of symbols when applying the new rule.