### PR TITLE
Generate log directory, if it does not exist

### DIFF
--- a/conf/nebula-graphd.conf.default
+++ b/conf/nebula-graphd.conf.default
@@ -7,7 +7,7 @@
 --enable_optimizer=true
 
 ########## logging ##########
-# The directory to host logging files, which must already exists
+# The directory to host logging files
 --log_dir=logs
 # Log level, 0, 1, 2, 3 for INFO, WARNING, ERROR, FATAL respectively
 --minloglevel=0

--- a/conf/nebula-graphd.conf.production
+++ b/conf/nebula-graphd.conf.production
@@ -7,7 +7,7 @@
 --enable_optimizer=true
 
 ########## logging ##########
-# The directory to host logging files, which must already exists
+# The directory to host logging files
 --log_dir=logs
 # Log level, 0, 1, 2, 3 for INFO, WARNING, ERROR, FATAL respectively
 --minloglevel=0

--- a/src/daemons/GraphDaemon.cpp
+++ b/src/daemons/GraphDaemon.cpp
@@ -25,6 +25,7 @@ using nebula::Status;
 using nebula::ProcessUtils;
 using nebula::graph::GraphService;
 using nebula::network::NetworkUtils;
+using nebula::fs::FileUtils;
 
 static std::unique_ptr<apache::thrift::ThriftServer> gServer;
 
@@ -197,6 +198,14 @@ void signalHandler(int sig) {
 
 
 Status setupLogging() {
+    // If the log directory does not exist, try to create
+    if (!FileUtils::exist(FLAGS_log_dir)) {
+        if (!FileUtils::makeDir(FLAGS_log_dir)) {
+            return Status::Error("Failed to create log directory `%s'",
+                                 FLAGS_log_dir.c_str());
+        }
+    }
+
     if (!FLAGS_redirect_stdout) {
         return Status::OK();
     }


### PR DESCRIPTION
As title

When we start the service with the following script, the log directory will be created in the script.
./scripts/nebula.service -c xxx/etc/nebula-graphd.conf start graphd> /dev/null 2>&1 &

But when we start the service in other ways, because the directory log does not exist, the startup fails.
xxx/bin/nebula-graphd --flagfile xxx/etc/nebula-graphd-1.conf >1.log 2 >&1 &

Therefore, before starting the service, the log directory needs to be created automatically when it does not exist.