### PR TITLE
There is no tag id while execute show tags

### DIFF
--- a/src/executor/maintain/EdgeExecutor.cpp
+++ b/src/executor/maintain/EdgeExecutor.cpp
@@ -94,14 +94,15 @@ folly::Future<Status> ShowEdgesExecutor::execute() {
             auto edgeItems = std::move(resp).value();
 
             DataSet dataSet;
-            dataSet.colNames = {"Name"};
-            std::set<std::string> orderEdgeNames;
+            dataSet.colNames = {"ID", "Name"};
+            std::set<std::pair<EdgeType, std::string>> orderEdgeIdNames;
             for (auto &edge : edgeItems) {
-                orderEdgeNames.emplace(edge.get_edge_name());
+                orderEdgeIdNames.emplace(edge.get_edge_type(), edge.get_edge_name());
             }
-            for (auto &name : orderEdgeNames) {
+            for (auto &item : orderEdgeIdNames) {
                 Row row;
-                row.values.emplace_back(name);
+                row.values.emplace_back(item.first);
+                row.values.emplace_back(item.second);
                 dataSet.rows.emplace_back(std::move(row));
             }
             return finish(ResultBuilder()

--- a/src/executor/maintain/EdgeIndexExecutor.cpp
+++ b/src/executor/maintain/EdgeIndexExecutor.cpp
@@ -124,14 +124,15 @@ folly::Future<Status> ShowEdgeIndexesExecutor::execute() {
             auto edgeIndexItems = std::move(resp).value();
 
             DataSet dataSet;
-            dataSet.colNames = {"Names"};
-            std::set<std::string> orderEdgeIndexNames;
+            dataSet.colNames = {"ID", "Names"};
+            std::set<std::pair<IndexID, std::string>> orderEdgeIndexIdNames;
             for (auto &edgeIndex : edgeIndexItems) {
-                orderEdgeIndexNames.emplace(edgeIndex.get_index_name());
+                orderEdgeIndexIdNames.emplace(edgeIndex.get_index_id(), edgeIndex.get_index_name());
             }
-            for (auto &name : orderEdgeIndexNames) {
+            for (auto &item : orderEdgeIndexIdNames) {
                 Row row;
-                row.values.emplace_back(name);
+                row.values.emplace_back(item.first);
+                row.values.emplace_back(item.second);
                 dataSet.rows.emplace_back(std::move(row));
             }
             return finish(ResultBuilder()

--- a/src/executor/maintain/TagExecutor.cpp
+++ b/src/executor/maintain/TagExecutor.cpp
@@ -94,14 +94,15 @@ folly::Future<Status> ShowTagsExecutor::execute() {
             auto tagItems = std::move(resp).value();
 
             DataSet dataSet;
-            dataSet.colNames = {"Name"};
-            std::set<std::string> orderTagNames;
+            dataSet.colNames = {"ID", "Name"};
+            std::set<std::pair<TagID, std::string>> orderTagIdNames;
             for (auto &tag : tagItems) {
-                orderTagNames.emplace(tag.get_tag_name());
+                orderTagIdNames.emplace(tag.get_tag_id(), tag.get_tag_name());
             }
-            for (auto &name : orderTagNames) {
+            for (auto &item : orderTagIdNames) {
                 Row row;
-                row.values.emplace_back(name);
+                row.values.emplace_back(item.first);
+                row.values.emplace_back(item.second);
                 dataSet.rows.emplace_back(std::move(row));
             }
             return finish(ResultBuilder()

--- a/src/executor/maintain/TagIndexExecutor.cpp
+++ b/src/executor/maintain/TagIndexExecutor.cpp
@@ -124,14 +124,15 @@ folly::Future<Status> ShowTagIndexesExecutor::execute() {
             auto tagIndexItems = std::move(resp).value();
 
             DataSet dataSet;
-            dataSet.colNames = {"Names"};
-            std::set<std::string> orderTagIndexNames;
+            dataSet.colNames = {"ID", "Names"};
+            std::set<std::pair<IndexID, std::string>> orderTagIndexIdNames;
             for (auto &tagIndex : tagIndexItems) {
-                orderTagIndexNames.emplace(tagIndex.get_index_name());
+                orderTagIndexIdNames.emplace(tagIndex.get_index_id(), tagIndex.get_index_name());
             }
-            for (auto &name : orderTagIndexNames) {
+            for (auto &item : orderTagIndexIdNames) {
                 Row row;
-                row.values.emplace_back(name);
+                row.values.emplace_back(item.first);
+                row.values.emplace_back(item.second);
                 dataSet.rows.emplace_back(std::move(row));
             }
             return finish(ResultBuilder()


### PR DESCRIPTION
### What changes were proposed in this pull request?
1. SHOW TAGS returns add column ID
2. SHOW EDGES returns add column ID
3. SHOW TAG INDEXES returns add column ID
4. SHOW EDGE INDEXES returns add column ID

### Why are the changes needed?
1. We use offline generation of the underlying storage file (sst) to import data to the NebuleGraph cluster，which depends on the id of the schema。
2. SHOW TAGS only return tag name
![image](https://user-images.githubusercontent.com/45277783/112961663-281ca100-9178-11eb-866e-21c678df6f29.png)
3. now SHOW TAGS return id and name
![image](https://user-images.githubusercontent.com/45277783/112963043-91e97a80-9179-11eb-8286-b6daebcde78f.png)
4. show edges、show tag indexes、show edge indexes as same as show tags

### Will break the compatibility? How if so?
1. Incompatible with old logic

### Does this PR introduce any user-facing change?
1. no

### How was this patch tested?
1. all test passed

### Checklist
<!--Tick the checkbox(es) below to choose what you have done.-->

- [ ] I've informed the technical writer about the documentation change if necessary
- [ ] If this Pull Request resolves an issue, I linked to the issue in the text above
- [x] I've run the tests to see all new and existing tests pass



