### PR TITLE
add clang format rule

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -154,4 +154,5 @@ BinPackParameters: false
 IndentWidth:     4
 SpacesBeforeTrailingComments: 3
 AllowShortFunctionsOnASingleLine: Empty
+AlignConsecutiveDeclarations: true
 ...


### PR DESCRIPTION

连续声明时对齐变量名称