### PR TITLE
Fix alias check

### DIFF
--- a/src/validator/MatchValidator.cpp
+++ b/src/validator/MatchValidator.cpp
@@ -762,7 +762,6 @@ Status MatchValidator::checkAlias(
     const Expression *refExpr,
     const std::unordered_map<std::string, AliasType> *aliasesUsed) const {
     auto kind = refExpr->kind();
-    // const std::string *name = nullptr;
     AliasType aliasType = AliasType::kDefault;
 
     switch (kind) {
@@ -789,18 +788,20 @@ Status MatchValidator::checkAlias(
                 return res.status();
             }
             aliasType = res.value();
-            if (aliasType == AliasType::kNode) {
-                return Status::SemanticError("Vertex `%s' does not have the src attribute",
-                                             name->c_str());
-            } else if (aliasType == AliasType::kEdge) {
-                return Status::SemanticError("To get the src vid of the edge, use src(%s)",
-                                             name->c_str());
-            } else if (aliasType == AliasType::kPath) {
-                return Status::SemanticError("To get the start node of the path, use startNode(%s)",
-                                             name->c_str());
+            switch (aliasType) {
+                case AliasType::kNode:
+                    return Status::SemanticError("Vertex `%s' does not have the src attribute",
+                                                 name->c_str());
+                case AliasType::kEdge:
+                    return Status::SemanticError("To get the src vid of the edge, use src(%s)",
+                                                 name->c_str());
+                case AliasType::kPath:
+                    return Status::SemanticError(
+                        "To get the start node of the path, use startNode(%s)", name->c_str());
+                default:
+                    return Status::SemanticError("Alias `%s' does not have the edge property src",
+                                                 name->c_str());
             }
-            return Status::SemanticError("Alias `%s' does not have the edge property src",
-                                         name->c_str());
         }
         case Expression::Kind::kEdgeDst: {
             auto name = static_cast<const EdgeDstIdExpression *>(refExpr)->sym();
@@ -809,18 +810,20 @@ Status MatchValidator::checkAlias(
                 return res.status();
             }
             aliasType = res.value();
-            if (aliasType == AliasType::kNode) {
-                return Status::SemanticError("Vertex `%s' does not have the dst attribute",
-                                             name->c_str());
-            } else if (aliasType == AliasType::kEdge) {
-                return Status::SemanticError("To get the dst vid of the edge, use dst(%s)",
-                                             name->c_str());
-            } else if (aliasType == AliasType::kPath) {
-                return Status::SemanticError("To get the end node of the path, use endNode(%s)",
-                                             name->c_str());
+            switch (aliasType) {
+                case AliasType::kNode:
+                    return Status::SemanticError("Vertex `%s' does not have the dst attribute",
+                                                 name->c_str());
+                case AliasType::kEdge:
+                    return Status::SemanticError("To get the dst vid of the edge, use dst(%s)",
+                                                 name->c_str());
+                case AliasType::kPath:
+                    return Status::SemanticError("To get the end node of the path, use endNode(%s)",
+                                                 name->c_str());
+                default:
+                    return Status::SemanticError("Alias `%s' does not have the edge property dst",
+                                                 name->c_str());
             }
-            return Status::SemanticError("Alias `%s' does not have the edge property dst",
-                                         name->c_str());
         }
         case Expression::Kind::kEdgeRank: {
             auto name = static_cast<const EdgeRankExpression *>(refExpr)->sym();
@@ -829,18 +832,20 @@ Status MatchValidator::checkAlias(
                 return res.status();
             }
             aliasType = res.value();
-            if (aliasType == AliasType::kNode) {
-                return Status::SemanticError("Vertex `%s' does not have the rank attribute",
-                                             name->c_str());
-            } else if (aliasType == AliasType::kEdge) {
-                return Status::SemanticError("To get the ranking of the edge, use rank(%s)",
-                                             name->c_str());
-            } else if (aliasType == AliasType::kPath) {
-                return Status::SemanticError("Path `%s' does not have the ranking attribute",
-                                             name->c_str());
+            switch (aliasType) {
+                case AliasType::kNode:
+                    return Status::SemanticError("Vertex `%s' does not have the ranking attribute",
+                                                 name->c_str());
+                case AliasType::kEdge:
+                    return Status::SemanticError("To get the ranking of the edge, use rank(%s)",
+                                                 name->c_str());
+                case AliasType::kPath:
+                    return Status::SemanticError("Path `%s' does not have the ranking attribute",
+                                                 name->c_str());
+                default:
+                    return Status::SemanticError(
+                        "Alias `%s' does not have the edge property ranking", name->c_str());
             }
-            return Status::SemanticError("Alias `%s' does not have the edge property ranking",
-                                         name->c_str());
         }
         case Expression::Kind::kEdgeType: {
             auto name = static_cast<const EdgeTypeExpression *>(refExpr)->sym();
@@ -849,18 +854,20 @@ Status MatchValidator::checkAlias(
                 return res.status();
             }
             aliasType = res.value();
-            if (aliasType == AliasType::kNode) {
-                return Status::SemanticError("Vertex `%s' does not have the type attribute",
-                                             name->c_str());
-            } else if (aliasType == AliasType::kEdge) {
-                return Status::SemanticError("To get the type of the edge, use type(%s)",
-                                             name->c_str());
-            } else if (aliasType == AliasType::kPath) {
-                return Status::SemanticError("Path `%s' does not have the type attribute",
-                                             name->c_str());
+            switch (aliasType) {
+                case AliasType::kNode:
+                    return Status::SemanticError("Vertex `%s' does not have the type attribute",
+                                                 name->c_str());
+                case AliasType::kEdge:
+                    return Status::SemanticError("To get the type of the edge, use type(%s)",
+                                                 name->c_str());
+                case AliasType::kPath:
+                    return Status::SemanticError("Path `%s' does not have the type attribute",
+                                                 name->c_str());
+                default:
+                    return Status::SemanticError(
+                        "Alias `%s' does not have the edge property ranking", name->c_str());
             }
-            return Status::SemanticError("Alias `%s' does not have the edge property type",
-                                         name->c_str());
         }
         default:   // refExpr must satisfy one of cases and should never hit this branch
             break;

--- a/src/validator/MatchValidator.cpp
+++ b/src/validator/MatchValidator.cpp
@@ -820,7 +820,7 @@ Status MatchValidator::checkAlias(
                 return Status::SemanticError("To get the ranking of the edge, use rank(%s)",
                                              name->c_str());
             } else if (aliasType == AliasType::kPath) {
-                return Status::SemanticError("Path `%s' does not have the rank attribute",
+                return Status::SemanticError("Path `%s' does not have the ranking attribute",
                                              name->c_str());
             }
             break;

--- a/src/validator/MatchValidator.h
+++ b/src/validator/MatchValidator.h
@@ -85,7 +85,16 @@ private:
 
     Status combineYieldColumns(YieldColumns *yieldColumns, YieldColumns *prevYieldColumns) const;
 
-    Status buildOutputs(const YieldColumns* yields);
+    Status isAliasDefined(const std::unordered_map<std::string, AliasType> *aliasesUsed,
+                          const std::string *name) const;
+
+    StatusOr<AliasType> getAliasType(const std::unordered_map<std::string, AliasType> *aliasesUsed,
+                                     const std::string *name) const;
+
+    Status checkAlias(const Expression *refExpr,
+                      const std::unordered_map<std::string, AliasType> *aliasesUsed) const;
+
+    Status buildOutputs(const YieldColumns *yields);
 
     template <typename T>
     std::unique_ptr<T> getContext() const {

--- a/src/validator/MatchValidator.h
+++ b/src/validator/MatchValidator.h
@@ -85,9 +85,6 @@ private:
 
     Status combineYieldColumns(YieldColumns *yieldColumns, YieldColumns *prevYieldColumns) const;
 
-    Status isAliasDefined(const std::unordered_map<std::string, AliasType> *aliasesUsed,
-                          const std::string *name) const;
-
     StatusOr<AliasType> getAliasType(const std::unordered_map<std::string, AliasType> *aliasesUsed,
                                      const std::string *name) const;
 

--- a/src/validator/test/MatchValidatorTest.cpp
+++ b/src/validator/test/MatchValidatorTest.cpp
@@ -549,7 +549,7 @@ TEST_F(MatchValidatorTest, validateAlias) {
                             "RETURN p._rank";
         auto result = checkResult(query);
         EXPECT_EQ(std::string(result.message()),
-                  "SemanticError: Vertex `p' does not have the ranking attribute");
+                  "SemanticError: Path `p' does not have the ranking attribute");
     }
 }
 

--- a/src/validator/test/MatchValidatorTest.cpp
+++ b/src/validator/test/MatchValidatorTest.cpp
@@ -534,7 +534,8 @@ TEST_F(MatchValidatorTest, validateAlias) {
         EXPECT_EQ(std::string(result.message()),
                   "SemanticError: Alias used but not defined: `abc'");
     }
-    // incorrect alias type in filter
+    // invalid prop attribute in filter
+    // vertex
     {
         std::string query = "MATCH (v :person{name:\"Tim Duncan\"})-[e]-(v2) "
                             "WHERE v._src>0"
@@ -543,13 +544,101 @@ TEST_F(MatchValidatorTest, validateAlias) {
         EXPECT_EQ(std::string(result.message()),
                   "SemanticError: Vertex `v' does not have the src attribute");
     }
-    // incorrect alias type in return clause
+    {
+        std::string query = "MATCH (v :person{name:\"Tim Duncan\"})-[e]-(v2) "
+                            "WHERE v._dst>0"
+                            "RETURN e";
+        auto result = checkResult(query);
+        EXPECT_EQ(std::string(result.message()),
+                  "SemanticError: Vertex `v' does not have the dst attribute");
+    }
+    {
+        std::string query = "MATCH (v :person{name:\"Tim Duncan\"})-[e]-(v2) "
+                            "WHERE v._rank>0"
+                            "RETURN e";
+        auto result = checkResult(query);
+        EXPECT_EQ(std::string(result.message()),
+                  "SemanticError: Vertex `v' does not have the ranking attribute");
+    }
+    {
+        std::string query = "MATCH (v :person{name:\"Tim Duncan\"})-[e]-(v2) "
+                            "WHERE v._type>0"
+                            "RETURN e";
+        auto result = checkResult(query);
+        EXPECT_EQ(std::string(result.message()),
+                  "SemanticError: Vertex `v' does not have the type attribute");
+    }
+    // edge
+    {
+        std::string query = "MATCH (v :person{name:\"Tim Duncan\"})-[e]-(v2) "
+                            "WHERE e._src>0"
+                            "RETURN e";
+        auto result = checkResult(query);
+        EXPECT_EQ(std::string(result.message()),
+                  "SemanticError: To get the src vid of the edge, use src(e)");
+    }
+    {
+        std::string query = "MATCH (v :person{name:\"Tim Duncan\"})-[e]-(v2) "
+                            "WHERE e._dst>0"
+                            "RETURN e";
+        auto result = checkResult(query);
+        EXPECT_EQ(std::string(result.message()),
+                  "SemanticError: To get the dst vid of the edge, use dst(e)");
+    }
+    {
+        std::string query = "MATCH (v :person{name:\"Tim Duncan\"})-[e]-(v2) "
+                            "WHERE e._rank>0"
+                            "RETURN e";
+        auto result = checkResult(query);
+        EXPECT_EQ(std::string(result.message()),
+                  "SemanticError: To get the ranking of the edge, use rank(e)");
+    }
+    {
+        std::string query = "MATCH (v :person{name:\"Tim Duncan\"})-[e]-(v2) "
+                            "WHERE e._type>0"
+                            "RETURN e";
+        auto result = checkResult(query);
+        EXPECT_EQ(std::string(result.message()),
+                  "SemanticError: To get the type of the edge, use type(e)");
+    }
+    // path
+    {
+        std::string query = "MATCH p = (v :person{name:\"Tim Duncan\"})-[e]-(v2) "
+                            "WHERE id(p._src) == \"Tim Duncan\""
+                            "RETURN p._src";
+        auto result = checkResult(query);
+        EXPECT_EQ(std::string(result.message()),
+                  "SemanticError: To get the start node of the path, use startNode(p)");
+    }
+    {
+        std::string query = "MATCH p = (v :person{name:\"Tim Duncan\"})-[e]-(v2) "
+                            "WHERE id(p._dst) == \"Tim Duncan\""
+                            "RETURN p._dst";
+        auto result = checkResult(query);
+        EXPECT_EQ(std::string(result.message()),
+                  "SemanticError: To get the end node of the path, use endNode(p)");
+    }
     {
         std::string query = "MATCH p = (v :person{name:\"Tim Duncan\"})-[e]-(v2) "
                             "RETURN p._rank";
         auto result = checkResult(query);
         EXPECT_EQ(std::string(result.message()),
                   "SemanticError: Path `p' does not have the ranking attribute");
+    }
+    {
+        std::string query = "MATCH p = (v :person{name:\"Tim Duncan\"})-[e]-(v2) "
+                            "RETURN p._type";
+        auto result = checkResult(query);
+        EXPECT_EQ(std::string(result.message()),
+                  "SemanticError: Path `p' does not have the type attribute");
+    }
+    // invalid prop attribute in return clause
+    {
+        std::string query = "MATCH p = (v :person{name:\"Tim Duncan\"})-[e]-(v2) "
+                            "RETURN p._type";
+        auto result = checkResult(query);
+        EXPECT_EQ(std::string(result.message()),
+                  "SemanticError: Path `p' does not have the type attribute");
     }
 }
 

--- a/src/validator/test/MatchValidatorTest.cpp
+++ b/src/validator/test/MatchValidatorTest.cpp
@@ -534,7 +534,7 @@ TEST_F(MatchValidatorTest, validateAlias) {
         EXPECT_EQ(std::string(result.message()),
                   "SemanticError: Alias used but not defined: `abc'");
     }
-    // validate invalid alias type in filter clause
+    // incorrect alias type in filter
     {
         std::string query = "MATCH (v :person{name:\"Tim Duncan\"})-[e]-(v2) "
                             "WHERE v._src>0"
@@ -542,6 +542,14 @@ TEST_F(MatchValidatorTest, validateAlias) {
         auto result = checkResult(query);
         EXPECT_EQ(std::string(result.message()),
                   "SemanticError: Vertex `v' does not have the src attribute");
+    }
+    // incorrect alias type in return clause
+    {
+        std::string query = "MATCH p = (v :person{name:\"Tim Duncan\"})-[e]-(v2) "
+                            "RETURN p._rank";
+        auto result = checkResult(query);
+        EXPECT_EQ(std::string(result.message()),
+                  "SemanticError: Vertex `p' does not have the ranking attribute");
     }
 }
 

--- a/src/validator/test/MatchValidatorTest.cpp
+++ b/src/validator/test/MatchValidatorTest.cpp
@@ -516,5 +516,34 @@ TEST_F(MatchValidatorTest, with) {
     }
 }
 
+TEST_F(MatchValidatorTest, validateAlias) {
+    // validate undefined alias in filter
+    {
+        std::string query = "MATCH (v :person{name:\"Tim Duncan\"})-[e]-(v2) "
+                            "WHERE abc._src>0"
+                            "RETURN e";
+        auto result = checkResult(query);
+        EXPECT_EQ(std::string(result.message()),
+                  "SemanticError: Alias used but not defined: `abc'");
+    }
+    // validate undefined alias in return clause
+    {
+        std::string query = "MATCH (v :person{name:\"Tim Duncan\"})-[e]-(v2) "
+                            "RETURN abc";
+        auto result = checkResult(query);
+        EXPECT_EQ(std::string(result.message()),
+                  "SemanticError: Alias used but not defined: `abc'");
+    }
+    // validate invalid alias type in filter clause
+    {
+        std::string query = "MATCH (v :person{name:\"Tim Duncan\"})-[e]-(v2) "
+                            "WHERE v._src>0"
+                            "RETURN e";
+        auto result = checkResult(query);
+        EXPECT_EQ(std::string(result.message()),
+                  "SemanticError: Vertex `v' does not have the src attribute");
+    }
+}
+
 }   // namespace graph
 }   // namespace nebula


### PR DESCRIPTION
1. Check for MATCH sentence alias when edgeProperty expressions are used.
    ```
    (root@nebula) [nba]> match p = (v:player{name:"Tony Parker"})-[e]->(v2) where v._src>0 return e
    [ERROR (-12)]: SemanticError: Vertex `v' does not have the src attribute
    ```
2. Add more intuitive error messages.
    ```
    (root@nebula) [nba]> match p = (v:player{name:"Tony Parker"})-[e]->(v2) return e._src
    [ERROR (-12)]: SemanticError: To get the srcID of the edge, use src(e)
    ```

Fix https://jira.nebula-graph.io/browse/NG-529
