### PR TITLE
small change passThrough executor

### DIFF
--- a/src/executor/logic/PassThroughExecutor.cpp
+++ b/src/executor/logic/PassThroughExecutor.cpp
@@ -15,11 +15,10 @@ namespace graph {
 folly::Future<Status> PassThroughExecutor::execute() {
     SCOPED_TIMER(&execTime_);
 
-    const auto &result = ectx_->getResult(node()->outputVar());
+    auto &result = const_cast<Result&>(ectx_->getResult(node()->inputVar()));
     auto iter = result.iter();
     if (!iter->isDefaultIter() && !iter->empty()) {
-        // Return directly if this pass through output result is not empty
-        return Status::OK();
+        return finish(std::move(result));
     }
 
     DataSet ds;

--- a/src/planner/match/VertexIdSeek.cpp
+++ b/src/planner/match/VertexIdSeek.cpp
@@ -91,7 +91,7 @@ StatusOr<SubPlan> VertexIdSeek::transformNode(NodeContext *nodeCtx) {
     std::pair<std::string, Expression *> vidsResult = listToAnnoVarVid(qctx, nodeCtx->ids);
 
     auto* passThrough = PassThroughNode::make(qctx, nullptr);
-    passThrough->setOutputVar(vidsResult.first);
+    passThrough->setInputVar(vidsResult.first);
     passThrough->setColNames({kVid});
     plan.root = passThrough;
     plan.tail = passThrough;


### PR DESCRIPTION
To improve freedom of operation plannode in optimizer.

After this, If you want to delete the next plan node, you only need to reset the `outputVar`.