### PR TITLE
Fix float precision in comparison

### DIFF
--- a/src/optimizer/OptimizerUtils.h
+++ b/src/optimizer/OptimizerUtils.h
@@ -38,8 +38,6 @@ public:
     static Value boundValueWithMin(const meta::cpp2::ColumnDef& col);
 
     static Value normalizeValue(const meta::cpp2::ColumnDef& col, const Value& v);
-
-    static constexpr double kEpsilon = 0.0000000000000001;
 };
 
 }  // namespace graph

--- a/src/optimizer/test/IndexBoundValueTest.cpp
+++ b/src/optimizer/test/IndexBoundValueTest.cpp
@@ -115,14 +115,14 @@ TEST(IndexBoundValueTest, DoubleTest) {
 
     EXPECT_EQ(0.0,
               OptimizerUtils::boundValue(col, OP::LESS_THAN, Value(-minDouble)).getFloat());
-    EXPECT_EQ(maxDouble - 0.0000000000000001,
+    EXPECT_EQ(maxDouble - kEpsilon,
               OptimizerUtils::boundValue(col, OP::LESS_THAN, Value(maxDouble)).getFloat());
     EXPECT_EQ(-minDouble, OptimizerUtils::boundValue(col, OP::LESS_THAN, Value(0.0)).getFloat());
 
-    EXPECT_EQ(5.1 - 0.0000000000000001,
+    EXPECT_EQ(5.1 - kEpsilon,
               OptimizerUtils::boundValue(col, OP::LESS_THAN, Value(5.1)));
 
-    EXPECT_EQ(-(5.1 + 0.0000000000000001),
+    EXPECT_EQ(-(5.1 + kEpsilon),
               OptimizerUtils::boundValue(col, OP::LESS_THAN, Value(-5.1)));
 
     EXPECT_EQ(maxDouble,
@@ -132,10 +132,10 @@ TEST(IndexBoundValueTest, DoubleTest) {
 
     EXPECT_EQ(minDouble, OptimizerUtils::boundValue(col, OP::GREATER_THAN, Value(0.0)).getFloat());
 
-    EXPECT_EQ(5.1 + 0.0000000000000001,
+    EXPECT_EQ(5.1 + kEpsilon,
               OptimizerUtils::boundValue(col, OP::GREATER_THAN, Value(5.1)).getFloat());
 
-    EXPECT_EQ(-(5.1 - 0.0000000000000001),
+    EXPECT_EQ(-(5.1 - kEpsilon),
               OptimizerUtils::boundValue(col, OP::GREATER_THAN, Value(-5.1)).getFloat());
 }
 

--- a/src/optimizer/test/IndexScanRuleTest.cpp
+++ b/src/optimizer/test/IndexScanRuleTest.cpp
@@ -380,6 +380,20 @@ TEST(IndexScanRuleTest, BoundValueRangeTest) {
         }
         {
             std::vector<storage::cpp2::IndexColumnHint> hints;
+            // col_double <= 3.0
+            IndexScanRule::FilterItems items;
+            items.addItem("col_double", RelationalExpression::Kind::kRelLE, Value(3.0));
+            auto status = instance->appendColHint(hints, items, col);
+            EXPECT_TRUE(status.ok());
+            EXPECT_EQ(1, hints.size());
+            const auto& hint = hints[0];
+            EXPECT_EQ("col_double", *hint.column_name_ref());
+            EXPECT_EQ(storage::cpp2::ScanType::RANGE, *hint.scan_type_ref());
+            EXPECT_EQ(-std::numeric_limits<double>::max(), *hint.begin_value_ref());
+            EXPECT_EQ(3 + kEpsilon, *hint.end_value_ref());
+        }
+        {
+            std::vector<storage::cpp2::IndexColumnHint> hints;
             // col_double >= 1.0
             IndexScanRule::FilterItems items;
             items.addItem("col_double", RelationalExpression::Kind::kRelGE, Value(1.0));
@@ -405,7 +419,7 @@ TEST(IndexScanRuleTest, BoundValueRangeTest) {
             EXPECT_EQ("col_double", *hint.column_name_ref());
             EXPECT_EQ(storage::cpp2::ScanType::RANGE, *hint.scan_type_ref());
             EXPECT_EQ(1 + kEpsilon, *hint.begin_value_ref());
-            EXPECT_EQ(5 - kEpsilon, *hint.end_value_ref());
+            EXPECT_EQ(5 + kEpsilon, *hint.end_value_ref());
         }
     }
     {

--- a/src/optimizer/test/IndexScanRuleTest.cpp
+++ b/src/optimizer/test/IndexScanRuleTest.cpp
@@ -404,8 +404,8 @@ TEST(IndexScanRuleTest, BoundValueRangeTest) {
             const auto& hint = hints[0];
             EXPECT_EQ("col_double", *hint.column_name_ref());
             EXPECT_EQ(storage::cpp2::ScanType::RANGE, *hint.scan_type_ref());
-            EXPECT_EQ(1 + OptimizerUtils::kEpsilon, *hint.begin_value_ref());
-            EXPECT_EQ(5 - OptimizerUtils::kEpsilon, *hint.end_value_ref());
+            EXPECT_EQ(1 + kEpsilon, *hint.begin_value_ref());
+            EXPECT_EQ(5 - kEpsilon, *hint.end_value_ref());
         }
     }
     {

--- a/tests/tck/features/lookup/LookUp.IntVid.feature
+++ b/tests/tck/features/lookup/LookUp.IntVid.feature
@@ -304,15 +304,17 @@ Feature: LookUpTest_Vid_Int
       | VertexID |
     When executing query:
       """
-      LOOKUP ON lookup_tag_2 WHERE lookup_tag_2.col3 > 100.5
+      LOOKUP ON lookup_tag_2
+      WHERE lookup_tag_2.col3 > 100.5
+      YIELD lookup_tag_2.col3 AS col3
       """
     Then the result should be, in any order:
-      | VertexID |
-      | 221      |
-      | 222      |
-      | 223      |
-      | 224      |
-      | 225      |
+      | VertexID | col3  |
+      | 221      | 200.5 |
+      | 222      | 300.5 |
+      | 223      | 400.5 |
+      | 224      | 500.5 |
+      | 225      | 600.5 |
     When executing query:
       """
       LOOKUP ON lookup_tag_2 WHERE lookup_tag_2.col3 == 100.5
@@ -328,13 +330,15 @@ Feature: LookUpTest_Vid_Int
       | VertexID |
     When executing query:
       """
-      LOOKUP ON lookup_tag_2 WHERE lookup_tag_2.col3 >= 100.5 AND lookup_tag_2.col3 <= 300.5
+      LOOKUP ON lookup_tag_2
+      WHERE lookup_tag_2.col3 >= 100.5 AND lookup_tag_2.col3 <= 300.5
+      YIELD lookup_tag_2.col3 AS col3
       """
     Then the result should be, in any order:
-      | VertexID |
-      | 220      |
-      | 221      |
-      | 222      |
+      | VertexID | col3  |
+      | 220      | 100.5 |
+      | 221      | 200.5 |
+      | 222      | 300.5 |
     Then drop the used space
 
   Scenario: LookupTest IntVid EdgeConditionScan
@@ -452,14 +456,16 @@ Feature: LookUpTest_Vid_Int
       | SrcVID | DstVID | Ranking |
     When executing query:
       """
-      LOOKUP ON lookup_edge_2 WHERE lookup_edge_2.col3 > 100.5
+      LOOKUP ON lookup_edge_2
+      WHERE lookup_edge_2.col3 > 100.5
+      YIELD lookup_edge_2.col3 AS col3
       """
     Then the result should be, in any order:
-      | SrcVID | DstVID | Ranking |
-      | 220    | 222    | 0       |
-      | 220    | 223    | 0       |
-      | 220    | 224    | 0       |
-      | 220    | 225    | 0       |
+      | SrcVID | DstVID | Ranking | col3  |
+      | 220    | 222    | 0       | 200.5 |
+      | 220    | 223    | 0       | 300.5 |
+      | 220    | 224    | 0       | 400.5 |
+      | 220    | 225    | 0       | 500.5 |
     When executing query:
       """
       LOOKUP ON lookup_edge_2 WHERE lookup_edge_2.col3 == 100.5
@@ -475,14 +481,15 @@ Feature: LookUpTest_Vid_Int
       | SrcVID | DstVID | Ranking |
     When executing query:
       """
-      LOOKUP ON lookup_edge_2 WHERE lookup_edge_2.col3 >= 100.5
-      AND lookup_edge_2.col3 <= 300.5
+      LOOKUP ON lookup_edge_2
+      WHERE lookup_edge_2.col3 >= 100.5 AND lookup_edge_2.col3 <= 300.5
+      YIELD lookup_edge_2.col3 AS col3
       """
     Then the result should be, in any order:
-      | SrcVID | DstVID | Ranking |
-      | 220    | 221    | 0       |
-      | 220    | 222    | 0       |
-      | 220    | 223    | 0       |
+      | SrcVID | DstVID | Ranking | col3  |
+      | 220    | 221    | 0       | 100.5 |
+      | 220    | 222    | 0       | 200.5 |
+      | 220    | 223    | 0       | 300.5 |
     Then drop the used space
 
   Scenario: LookupTest IntVid FunctionExprTest

--- a/tests/tck/features/lookup/LookUp.IntVid.feature
+++ b/tests/tck/features/lookup/LookUp.IntVid.feature
@@ -302,14 +302,12 @@ Feature: LookUpTest_Vid_Int
       """
     Then the result should be, in any order:
       | VertexID |
-    # FIXME(aiee): should not contain vid 220
     When executing query:
       """
       LOOKUP ON lookup_tag_2 WHERE lookup_tag_2.col3 > 100.5
       """
     Then the result should be, in any order:
       | VertexID |
-      | 220      |
       | 221      |
       | 222      |
       | 223      |
@@ -328,7 +326,6 @@ Feature: LookUpTest_Vid_Int
       """
     Then the result should be, in any order:
       | VertexID |
-    # FIXME(aiee): should contain vid 222
     When executing query:
       """
       LOOKUP ON lookup_tag_2 WHERE lookup_tag_2.col3 >= 100.5 AND lookup_tag_2.col3 <= 300.5
@@ -337,6 +334,7 @@ Feature: LookUpTest_Vid_Int
       | VertexID |
       | 220      |
       | 221      |
+      | 222      |
     Then drop the used space
 
   Scenario: LookupTest IntVid EdgeConditionScan
@@ -452,14 +450,12 @@ Feature: LookUpTest_Vid_Int
       """
     Then the result should be, in any order:
       | SrcVID | DstVID | Ranking |
-    # FIXME(aiee): should not contains first line
     When executing query:
       """
       LOOKUP ON lookup_edge_2 WHERE lookup_edge_2.col3 > 100.5
       """
     Then the result should be, in any order:
       | SrcVID | DstVID | Ranking |
-      | 220    | 221    | 0       |
       | 220    | 222    | 0       |
       | 220    | 223    | 0       |
       | 220    | 224    | 0       |
@@ -477,7 +473,6 @@ Feature: LookUpTest_Vid_Int
       """
     Then the result should be, in any order:
       | SrcVID | DstVID | Ranking |
-    # FIXME(aiee): should contain 220->223
     When executing query:
       """
       LOOKUP ON lookup_edge_2 WHERE lookup_edge_2.col3 >= 100.5
@@ -487,6 +482,7 @@ Feature: LookUpTest_Vid_Int
       | SrcVID | DstVID | Ranking |
       | 220    | 221    | 0       |
       | 220    | 222    | 0       |
+      | 220    | 223    | 0       |
     Then drop the used space
 
   Scenario: LookupTest IntVid FunctionExprTest

--- a/tests/tck/features/lookup/LookUp.feature
+++ b/tests/tck/features/lookup/LookUp.feature
@@ -270,14 +270,12 @@ Feature: LookUpTest_Vid_String
       """
     Then the result should be, in any order:
       | VertexID |
-    # FIXME(aiee): should not contains vid 220
     When executing query:
       """
       LOOKUP ON lookup_tag_2 WHERE lookup_tag_2.col3 > 100.5
       """
     Then the result should be, in any order:
       | VertexID |
-      | "220"    |
       | "221"    |
       | "222"    |
       | "223"    |
@@ -296,7 +294,6 @@ Feature: LookUpTest_Vid_String
       """
     Then the result should be, in any order:
       | VertexID |
-    # FIXME(aiee): should contain vid 222
     When executing query:
       """
       LOOKUP ON lookup_tag_2 WHERE lookup_tag_2.col3 >= 100.5 AND lookup_tag_2.col3 <= 300.5
@@ -305,6 +302,7 @@ Feature: LookUpTest_Vid_String
       | VertexID |
       | "220"    |
       | "221"    |
+      | "222"    |
     Then drop the used space
 
   Scenario: LookupTest EdgeConditionScan
@@ -413,14 +411,12 @@ Feature: LookUpTest_Vid_String
       """
     Then the result should be, in any order:
       | SrcVID | DstVID | Ranking |
-    # FIXME(aiee): shouble not contain first line
     When executing query:
       """
       LOOKUP ON lookup_edge_2 WHERE lookup_edge_2.col3 > 100.5
       """
     Then the result should be, in any order:
       | SrcVID | DstVID | Ranking |
-      | "220"  | "221"  | 0       |
       | "220"  | "222"  | 0       |
       | "220"  | "223"  | 0       |
       | "220"  | "224"  | 0       |
@@ -438,7 +434,6 @@ Feature: LookUpTest_Vid_String
       """
     Then the result should be, in any order:
       | SrcVID | DstVID | Ranking |
-    # FIXME(aiee): should contain edge 200->223
     When executing query:
       """
       LOOKUP ON lookup_edge_2 WHERE lookup_edge_2.col3 >= 100.5
@@ -448,6 +443,7 @@ Feature: LookUpTest_Vid_String
       | SrcVID | DstVID | Ranking |
       | "220"  | "221"  | 0       |
       | "220"  | "222"  | 0       |
+      | "220"  | "223"  | 0       |
     Then drop the used space
 
   Scenario: LookupTest FunctionExprTest
@@ -462,14 +458,14 @@ Feature: LookUpTest_Vid_String
     When executing query:
       """
       INSERT VERTEX
-        lookup_tag_2(col1, col2, col3, col4)
+      lookup_tag_2(col1, col2, col3, col4)
       VALUES
-        "220":(true, 100, 100.5, true),
-        "221":(true, 200, 200.5, true),
-        "222":(true, 300, 300.5, true),
-        "223":(true, 400, 400.5, true),
-        "224":(true, 500, 500.5, true),
-        "225":(true, 600, 600.5, true)
+      "220":(true, 100, 100.5, true),
+      "221":(true, 200, 200.5, true),
+      "222":(true, 300, 300.5, true),
+      "223":(true, 400, 400.5, true),
+      "224":(true, 500, 500.5, true),
+      "225":(true, 600, 600.5, true)
       """
     Then the execution should be successful
     When executing query:
@@ -557,12 +553,6 @@ Feature: LookUpTest_Vid_String
     # When executing query:
     # """
     # LOOKUP ON lookup_tag_2 WHERE lookup_tag_2.col4 == strcasecmp("HelLo", "HelLo")
-    # """
-    # Then the result should be, in any order:
-    # | VertexID |
-    # When executing query:
-    # """
-    # LOOKUP ON lookup_tag_2 WHERE lookup_tag_2.col4 == strcasecmp("HelLo", "hello")
     # """
     # Then the result should be, in any order:
     # | VertexID |

--- a/tests/tck/features/lookup/LookUp.feature
+++ b/tests/tck/features/lookup/LookUp.feature
@@ -465,14 +465,14 @@ Feature: LookUpTest_Vid_String
     When executing query:
       """
       INSERT VERTEX
-      lookup_tag_2(col1, col2, col3, col4)
+        lookup_tag_2(col1, col2, col3, col4)
       VALUES
-      "220":(true, 100, 100.5, true),
-      "221":(true, 200, 200.5, true),
-      "222":(true, 300, 300.5, true),
-      "223":(true, 400, 400.5, true),
-      "224":(true, 500, 500.5, true),
-      "225":(true, 600, 600.5, true)
+        "220":(true, 100, 100.5, true),
+        "221":(true, 200, 200.5, true),
+        "222":(true, 300, 300.5, true),
+        "223":(true, 400, 400.5, true),
+        "224":(true, 500, 500.5, true),
+        "225":(true, 600, 600.5, true)
       """
     Then the execution should be successful
     When executing query:

--- a/tests/tck/features/lookup/LookUp.feature
+++ b/tests/tck/features/lookup/LookUp.feature
@@ -272,15 +272,17 @@ Feature: LookUpTest_Vid_String
       | VertexID |
     When executing query:
       """
-      LOOKUP ON lookup_tag_2 WHERE lookup_tag_2.col3 > 100.5
+      LOOKUP ON lookup_tag_2
+      WHERE lookup_tag_2.col3 > 100.5
+      YIELD lookup_tag_2.col3 AS col3
       """
     Then the result should be, in any order:
-      | VertexID |
-      | "221"    |
-      | "222"    |
-      | "223"    |
-      | "224"    |
-      | "225"    |
+      | VertexID | col3  |
+      | "221"    | 200.5 |
+      | "222"    | 300.5 |
+      | "223"    | 400.5 |
+      | "224"    | 500.5 |
+      | "225"    | 600.5 |
     When executing query:
       """
       LOOKUP ON lookup_tag_2 WHERE lookup_tag_2.col3 == 100.5
@@ -296,13 +298,15 @@ Feature: LookUpTest_Vid_String
       | VertexID |
     When executing query:
       """
-      LOOKUP ON lookup_tag_2 WHERE lookup_tag_2.col3 >= 100.5 AND lookup_tag_2.col3 <= 300.5
+      LOOKUP ON lookup_tag_2
+      WHERE lookup_tag_2.col3 >= 100.5 AND lookup_tag_2.col3 <= 300.5
+      YIELD lookup_tag_2.col3 AS col3
       """
     Then the result should be, in any order:
-      | VertexID |
-      | "220"    |
-      | "221"    |
-      | "222"    |
+      | VertexID | col3  |
+      | "220"    | 100.5 |
+      | "221"    | 200.5 |
+      | "222"    | 300.5 |
     Then drop the used space
 
   Scenario: LookupTest EdgeConditionScan
@@ -413,14 +417,16 @@ Feature: LookUpTest_Vid_String
       | SrcVID | DstVID | Ranking |
     When executing query:
       """
-      LOOKUP ON lookup_edge_2 WHERE lookup_edge_2.col3 > 100.5
+      LOOKUP ON lookup_edge_2
+      WHERE lookup_edge_2.col3 > 100.5
+      YIELD lookup_edge_2.col3 AS col3
       """
     Then the result should be, in any order:
-      | SrcVID | DstVID | Ranking |
-      | "220"  | "222"  | 0       |
-      | "220"  | "223"  | 0       |
-      | "220"  | "224"  | 0       |
-      | "220"  | "225"  | 0       |
+      | SrcVID | DstVID | Ranking | col3  |
+      | "220"  | "222"  | 0       | 200.5 |
+      | "220"  | "223"  | 0       | 300.5 |
+      | "220"  | "224"  | 0       | 400.5 |
+      | "220"  | "225"  | 0       | 500.5 |
     When executing query:
       """
       LOOKUP ON lookup_edge_2 WHERE lookup_edge_2.col3 == 100.5
@@ -436,14 +442,15 @@ Feature: LookUpTest_Vid_String
       | SrcVID | DstVID | Ranking |
     When executing query:
       """
-      LOOKUP ON lookup_edge_2 WHERE lookup_edge_2.col3 >= 100.5
-      AND lookup_edge_2.col3 <= 300.5
+      LOOKUP ON lookup_edge_2
+      WHERE lookup_edge_2.col3 >= 100.5 AND lookup_edge_2.col3 <= 300.5
+      YIELD lookup_edge_2.col3 AS col3
       """
     Then the result should be, in any order:
-      | SrcVID | DstVID | Ranking |
-      | "220"  | "221"  | 0       |
-      | "220"  | "222"  | 0       |
-      | "220"  | "223"  | 0       |
+      | SrcVID | DstVID | Ranking | col3  |
+      | "220"  | "221"  | 0       | 100.5 |
+      | "220"  | "222"  | 0       | 200.5 |
+      | "220"  | "223"  | 0       | 300.5 |
     Then drop the used space
 
   Scenario: LookupTest FunctionExprTest


### PR DESCRIPTION
As title.
Solve the problem by a naive approach: change the epsilon to a smaller value.