### PR TITLE
Fix size of GetNeighbors Iterator

### DIFF
--- a/src/context/Iterator.h
+++ b/src/context/Iterator.h
@@ -248,7 +248,11 @@ public:
     }
 
     size_t size() const override {
-        return 0;
+        size_t sz = 0;
+        for (const auto& idx : dsIndices_) {
+            sz += idx.ds->size();
+        }
+        return sz;
     }
 
     const Value& getColumn(const std::string& col) const override;


### PR DESCRIPTION
```
-----+--------------------+--------------+--------------------------------------------------------------+-------------------------------------------------------------
| 31 | GetNeighbors       | 26           | {                                                            | outputVar: [                                               |
|    |                    |              | ver: 0, rows: 1, execTime: 162us, totalTime: 1270us          |   {                                                        |
|    |                    |              | "127.0.0.1":23539 exec/total/vertices: 310(us)/800(us)/1,    |     "colNames": [],                                        |
|    |                    |              | total_rpc_time: 1083(us)                                     |     "type": "DATASET",                                     |
|    |                    |              | }                                                            |     "name": "__GetNeighbors_4"                             |
|    |                    |              |                                                              |   }                                                        |
|    |                    |              |                                                              | ]                                                          |
```