### PR TITLE
fix #1012: Collect values from InputExpression crash the nebula graphd

### DIFF
--- a/src/util/ExpressionUtils.cpp
+++ b/src/util/ExpressionUtils.cpp
@@ -139,17 +139,7 @@ Expression *ExpressionUtils::rewriteAgg2VarProp(const Expression *expr) {
 
         return RewriteVisitor::transform(expr,
                                          std::move(matcher),
-                                         std::move(rewriter),
-                                         {Expression::Kind::kFunctionCall,
-                                          Expression::Kind::kTypeCasting,
-                                          Expression::Kind::kAdd,
-                                          Expression::Kind::kMinus,
-                                          Expression::Kind::kMultiply,
-                                          Expression::Kind::kDivision,
-                                          Expression::Kind::kMod,
-                                          Expression::Kind::kPredicate,
-                                          Expression::Kind::kListComprehension,
-                                          Expression::Kind::kReduce});
+                                         std::move(rewriter));
     }
 
 std::unique_ptr<Expression> ExpressionUtils::foldConstantExpr(const Expression *expr) {

--- a/tests/tck/features/aggregate/Agg.feature
+++ b/tests/tck/features/aggregate/Agg.feature
@@ -466,6 +466,20 @@ Feature: Basic Aggregate and GroupBy
     Then the result should be, in order, with relax comparison:
       | count | sum | avg  | min  | max  | std  | b1   | b2   | b3   |
       | 0     | 0   | NULL | NULL | NULL | NULL | NULL | NULL | NULL |
+    When executing query:
+      """
+      UNWIND [1,2,3] AS d RETURN d | YIELD 1 IN COLLECT($-.d) AS b
+      """
+    Then the result should be, in order, with relax comparison:
+      | b    |
+      | True |
+    When executing query:
+      """
+      UNWIND [1,2,3] AS d RETURN d | YIELD ANY(l IN COLLECT($-.d) WHERE l==1) AS b
+      """
+    Then the result should be, in order, with relax comparison:
+      | b    |
+      | True |
 
   Scenario: Empty input
     When executing query:


### PR DESCRIPTION
fix #1012 

We don't need to pass a `needVisitedTypes` to agg rewriter because the expression kinds that don't need to be visited have an empty function of body implementation.
```
 void visit(ConstantExpression *) override {}
 void visit(LabelExpression*) override {}
 ...
```
Expression kinds such as kConstant, kLabelProperty are basic kinds, they are impossible to nest an agg