### PR TITLE
Check Integer overflow in expression calculation

### DIFF
--- a/src/parser/parser.yy
+++ b/src/parser/parser.yy
@@ -526,9 +526,9 @@ expression
     | MINUS {
         scanner.setUnaryMinus(true);
     } expression %prec UNARY_MINUS {
-        if (scanner.isMin()) {
+        if (scanner.isIntMin()) {
             $$ = $3;
-            scanner.setIsMin(false);
+            scanner.setIsIntMin(false);
         } else {
             $$ = new UnaryExpression(Expression::Kind::kUnaryNegate, $3);
         }

--- a/src/parser/parser.yy
+++ b/src/parser/parser.yy
@@ -526,7 +526,12 @@ expression
     | MINUS {
         scanner.setUnaryMinus(true);
     } expression %prec UNARY_MINUS {
-        $$ = new UnaryExpression(Expression::Kind::kUnaryNegate, $3);
+        if (scanner.isMin()) {
+            $$ = $3;
+            scanner.setIsMin(false);
+        } else {
+            $$ = new UnaryExpression(Expression::Kind::kUnaryNegate, $3);
+        }
         scanner.setUnaryMinus(false);
     }
     | PLUS expression %prec UNARY_PLUS {

--- a/src/parser/test/ParserTest.cpp
+++ b/src/parser/test/ParserTest.cpp
@@ -1965,12 +1965,11 @@ TEST(Parser, ErrorMsg) {
         ASSERT_EQ(error, result.status().toString());
     }
     // min integer bound checking
-    // TODO(shylock) out of range int64_t
-    // {
-        // std::string query = "INSERT VERTEX person(id) VALUES \"100\":(-9223372036854775808) ";
-        // auto result = parse(query);
-        // ASSERT_TRUE(result.ok()) << result.status();
-    // }
+    {
+        std::string query = "INSERT VERTEX person(id) VALUES \"100\":(-9223372036854775808) ";
+        auto result = parse(query);
+        ASSERT_TRUE(result.ok()) << result.status();
+    }
     {
         std::string query = "INSERT VERTEX person(id) VALUES \"100\":(-(1+9223372036854775808)) ";
         auto result = parse(query);
@@ -2016,12 +2015,11 @@ TEST(Parser, ErrorMsg) {
         ASSERT_EQ(error, result.status().toString());
     }
     // min hex integer bound
-    // TODO(shylock) out of range int64_t
-    // {
-        // std::string query = "INSERT VERTEX person(id) VALUES \"100\":(-0x8000000000000000) ";
-        // auto result = parse(query);
-        // ASSERT_TRUE(result.ok()) << result.status();
-    // }
+    {
+        std::string query = "INSERT VERTEX person(id) VALUES \"100\":(-0x8000000000000000) ";
+        auto result = parse(query);
+        ASSERT_TRUE(result.ok()) << result.status();
+    }
     {
         std::string query = "INSERT VERTEX person(id) VALUES \"100\":(-0x8000000000000001) ";
         auto result = parse(query);
@@ -2062,12 +2060,11 @@ TEST(Parser, ErrorMsg) {
         ASSERT_EQ(error, result.status().toString());
     }
     // min oct integer bound
-    // TODO(shylock) out of range int64_t
-    // {
-        // std::string query = "INSERT VERTEX person(id) VALUES \"100\":(-01000000000000000000000)";
-        // auto result = parse(query);
-        // ASSERT_TRUE(result.ok()) << result.status().toString();
-    // }
+    {
+        std::string query = "INSERT VERTEX person(id) VALUES \"100\":(-01000000000000000000000)";
+        auto result = parse(query);
+        ASSERT_TRUE(result.ok()) << result.status().toString();
+    }
     {
         std::string query = "INSERT VERTEX person(id) VALUES \"100\":(-01000000000000000000001) ";
         auto result = parse(query);

--- a/src/util/ExpressionUtils.h
+++ b/src/util/ExpressionUtils.h
@@ -71,13 +71,13 @@ public:
                                             std::unique_ptr<Expression>& relRightOperandExpr);
 
     // Clone and fold constant expression
-    static Expression* foldConstantExpr(const Expression* expr, ObjectPool* objPool);
+    static StatusOr<Expression*> foldConstantExpr(const Expression* expr, ObjectPool* objPool);
 
     // Clone and reduce unaryNot expression
     static Expression* reduceUnaryNotExpr(const Expression* expr, ObjectPool* pool);
 
     // Transform filter using multiple expression rewrite strategies
-    static Expression* filterTransform(const Expression* expr, ObjectPool* objPool);
+    static StatusOr<Expression*> filterTransform(const Expression* expr, ObjectPool* objPool);
 
     // Negate the given logical expr: (A && B) -> (!A || !B)
     static std::unique_ptr<LogicalExpression> reverseLogicalExpr(LogicalExpression* expr);

--- a/src/validator/GoValidator.cpp
+++ b/src/validator/GoValidator.cpp
@@ -55,8 +55,10 @@ Status GoValidator::validateWhere(WhereClause* where) {
                                      filter_->toString().c_str());
     }
     where->setFilter(ExpressionUtils::rewriteLabelAttr2EdgeProp(filter_));
-
-    filter_ = where->filter();
+    auto pool = qctx()->objPool();
+    auto foldRes = ExpressionUtils::foldConstantExpr(where->filter(), pool);
+    NG_RETURN_IF_ERROR(foldRes);
+    filter_ = foldRes.value();
     auto typeStatus = deduceExprType(filter_);
     NG_RETURN_IF_ERROR(typeStatus);
     auto type = typeStatus.value();

--- a/src/validator/LookupValidator.cpp
+++ b/src/validator/LookupValidator.cpp
@@ -261,7 +261,9 @@ StatusOr<Expression*> LookupValidator::rewriteRelExpr(RelationalExpression* expr
 
     // fold constant expression
     auto pool = qctx_->objPool();
-    expr = static_cast<RelationalExpression*>(ExpressionUtils::foldConstantExpr(expr, pool));
+    auto foldRes = ExpressionUtils::foldConstantExpr(expr, pool);
+    NG_RETURN_IF_ERROR(foldRes);
+    expr = static_cast<RelationalExpression*>(foldRes.value());
     DCHECK_EQ(expr->left()->kind(), Expression::Kind::kLabelAttribute);
 
     std::string prop = la->right()->value().getStr();

--- a/src/validator/MaintainValidator.cpp
+++ b/src/validator/MaintainValidator.cpp
@@ -49,8 +49,9 @@ Status SchemaValidator::validateColumns(const std::vector<ColumnSpecification *>
                 auto *defaultValueExpr = property->defaultValue();
                 auto pool = qctx()->objPool();
                 // some expression is evaluable but not pure so only fold instead of eval here
-                column.set_default_value(
-                    ExpressionUtils::foldConstantExpr(defaultValueExpr, pool)->encode());
+                auto foldRes = ExpressionUtils::foldConstantExpr(defaultValueExpr, pool);
+                NG_RETURN_IF_ERROR(foldRes);
+                column.set_default_value(foldRes.value()->encode());
             } else if (property->isComment()) {
                 column.set_comment(*DCHECK_NOTNULL(property->comment()));
             }

--- a/src/validator/MatchValidator.cpp
+++ b/src/validator/MatchValidator.cpp
@@ -280,7 +280,9 @@ Status MatchValidator::buildEdgeInfo(const MatchPath *path,
 Status MatchValidator::validateFilter(const Expression *filter,
                                       WhereClauseContext &whereClauseCtx) const {
     auto pool = whereClauseCtx.qctx->objPool();
-    whereClauseCtx.filter = ExpressionUtils::filterTransform(filter, pool);
+    auto transformRes =  ExpressionUtils::filterTransform(filter, pool);
+    NG_RETURN_IF_ERROR(transformRes);
+    whereClauseCtx.filter = transformRes.value();
 
     auto typeStatus = deduceExprType(whereClauseCtx.filter);
     NG_RETURN_IF_ERROR(typeStatus);

--- a/src/validator/YieldValidator.cpp
+++ b/src/validator/YieldValidator.cpp
@@ -84,9 +84,9 @@ Status YieldValidator::makeOutputColumn(YieldColumn *column) {
     outputColumnNames_.emplace_back(name);
 
     // Constant expression folding must be after type deduction
-    auto foldedExpr = ExpressionUtils::foldConstantExpr(expr);
+    auto foldedExpr = ExpressionUtils::foldConstantExpr(expr, qctx()->objPool());
     QueryExpressionContext ctx;
-    auto val = Expression::eval(column->expr(), ctx(nullptr));
+    auto val = Expression::eval(foldedExpr, ctx(nullptr));
     if (val.type() == Value::Type::NULLVALUE) {
         switch (val.getNull()) {
             case NullType::DIV_BY_ZERO:

--- a/src/visitor/FoldConstantExprVisitor.h
+++ b/src/visitor/FoldConstantExprVisitor.h
@@ -8,6 +8,7 @@
 #define VISITOR_FOLDCONSTANTEXPRVISITOR_H_
 
 #include "common/expression/ExprVisitor.h"
+// #include "common/base/Status.h"
 
 namespace nebula {
 namespace graph {
@@ -20,6 +21,14 @@ public:
 
     bool isConstant(Expression *expr) const {
         return expr->kind() == Expression::Kind::kConstant;
+    }
+
+    bool ok() const {
+        return status_.ok();
+    }
+
+    Status status() && {
+        return std::move(status_);
     }
 
     void visit(ConstantExpression *expr) override;
@@ -74,10 +83,11 @@ public:
     void visit(SubscriptRangeExpression *expr) override;
 
     void visitBinaryExpr(BinaryExpression *expr);
-    Expression *fold(Expression *expr) const;
+    Expression *fold(Expression *expr);
 
 private:
     bool canBeFolded_{false};
+    Status status_;
 };
 
 }   // namespace graph

--- a/tests/tck/features/go/GO.feature
+++ b/tests/tck/features/go/GO.feature
@@ -17,6 +17,16 @@ Feature: Go Sentence
       | "Spurs"    |
     When executing query:
       """
+      GO FROM "Tim Duncan", "Tony Parker" OVER like WHERE $$.player.age > 9223372036854775807+1
+      """
+    Then a ExecutionError should be raised at runtime: result of (9223372036854775807+1) cannot be represented as an integer
+    When executing query:
+      """
+      GO FROM "Tim Duncan", "Tony Parker" OVER like WHERE $$.player.age > -9223372036854775808-1
+      """
+    Then a ExecutionError should be raised at runtime: result of (-9223372036854775808-1) cannot be represented as an integer
+    When executing query:
+      """
       GO FROM "Tim Duncan" OVER like YIELD $^.player.name as name, $^.player.age as age
       """
     Then the result should be, in any order, with relax comparison:

--- a/tests/tck/features/lookup/ByIndex.feature
+++ b/tests/tck/features/lookup/ByIndex.feature
@@ -104,6 +104,16 @@ Feature: Lookup by index itself
       LOOKUP ON team WHERE team.name CONTAINS 'Jazz' YIELD team.name AS Name
       """
     Then a SemanticError should be raised at runtime:
+    When executing query:
+      """
+      LOOKUP ON player WHERE player.age > 9223372036854775807+1
+      """
+    Then a ExecutionError should be raised at runtime: result of (9223372036854775807+1) cannot be represented as an integer
+    When executing query:
+      """
+      LOOKUP ON player WHERE player.age > -9223372036854775808-1
+      """
+    Then a ExecutionError should be raised at runtime: result of (-9223372036854775808-1) cannot be represented as an integer
     And drop the used space
 
   Scenario: [2] edge index

--- a/tests/tck/features/lookup/ByIndex.intVid.feature
+++ b/tests/tck/features/lookup/ByIndex.intVid.feature
@@ -104,6 +104,16 @@ Feature: Lookup by index itself in integer vid
       LOOKUP ON team WHERE team.name CONTAINS 'Jazz' YIELD team.name AS Name
       """
     Then a SemanticError should be raised at runtime:
+    When executing query:
+      """
+      LOOKUP ON player WHERE player.age > 9223372036854775807+1
+      """
+    Then a ExecutionError should be raised at runtime: result of (9223372036854775807+1) cannot be represented as an integer
+    When executing query:
+      """
+      LOOKUP ON player WHERE player.age > -9223372036854775808-1
+      """
+    Then a ExecutionError should be raised at runtime: result of (-9223372036854775808-1) cannot be represented as an integer
     And drop the used space
 
   Scenario: [2] edge index

--- a/tests/tck/features/match/Base.IntVid.feature
+++ b/tests/tck/features/match/Base.IntVid.feature
@@ -56,6 +56,16 @@ Feature: Basic match
       | 'Ray Allen'     | 43  |
       | 'David West'    | 38  |
       | 'Tracy McGrady' | 39  |
+    When executing query:
+      """
+      MATCH (v:player) where v.age > 9223372036854775807+1  return v
+      """
+    Then a ExecutionError should be raised at runtime: result of (9223372036854775807+1) cannot be represented as an integer
+    When executing query:
+      """
+      MATCH (v:player) where v.age > -9223372036854775808-1  return v
+      """
+    Then a ExecutionError should be raised at runtime: result of (-9223372036854775808-1) cannot be represented as an integer
 
   Scenario: Une step
     When executing query:

--- a/tests/tck/features/match/Base.feature
+++ b/tests/tck/features/match/Base.feature
@@ -78,6 +78,16 @@ Feature: Basic match
       """
     Then the result should be, in any order, with relax comparison:
       | v |
+    When executing query:
+      """
+      MATCH (v:player) where v.age > 9223372036854775807+1  return v
+      """
+    Then a ExecutionError should be raised at runtime: result of (9223372036854775807+1) cannot be represented as an integer
+    When executing query:
+      """
+      MATCH (v:player) where v.age > -9223372036854775808-1  return v
+      """
+    Then a ExecutionError should be raised at runtime: result of (-9223372036854775808-1) cannot be represented as an integer
 
   Scenario: One step
     When executing query:

--- a/tests/tck/features/schema/Schema.feature
+++ b/tests/tck/features/schema/Schema.feature
@@ -655,7 +655,7 @@ Feature: Insert string vid of vertex and edge
       """
       CREATE TAG bad_null_default_value(name string DEFAULT "N/A", age int DEFAULT 1%0)
       """
-    Then a ExecutionError should be raised at runtime: Invalid parm!
+    Then a ExecutionError should be raised at runtime: / by zero
     # test alter tag with wrong type default value of string when add
     When executing query:
       """

--- a/tests/tck/features/yield/yield.IntVid.feature
+++ b/tests/tck/features/yield/yield.IntVid.feature
@@ -315,82 +315,76 @@ Feature: Yield Sentence
       """
     Then a SemanticError should be raised at runtime: `$-.abc', not exist prop `abc'
 
-  @skip
   Scenario: CalculateOverflow
     When executing query:
       """
       YIELD 9223372036854775807+1
       """
-    Then a ExecutionError should be raised at runtime: Out of range 9223372036854775807 + 1
+    Then a ExecutionError should be raised at runtime: result of (9223372036854775807+1) cannot be represented as an integer
     When executing query:
       """
       YIELD -9223372036854775807-2
       """
-    Then a ExecutionError should be raised at runtime: Out of range -9223372036854775807 - 2
+    Then a ExecutionError should be raised at runtime: result of (-9223372036854775807-2) cannot be represented as an integer
     When executing query:
       """
       YIELD -9223372036854775807+-2
       """
-    Then a ExecutionError should be raised at runtime: Out of range -9223372036854775807 + -2
-    When executing query:
-      """
-      YIELD 1-(-9223372036854775807)
-      """
-    Then a ExecutionError should be raised at runtime: Out of range 1 - -9223372036854775807
+    Then a ExecutionError should be raised at runtime: result of (-9223372036854775807+-2) cannot be represented as an integer
     When executing query:
       """
       YIELD 9223372036854775807*2
       """
-    Then a ExecutionError should be raised at runtime: Out of range 9223372036854775807 * 2
+    Then a ExecutionError should be raised at runtime: result of (9223372036854775807*2) cannot be represented as an integer
     When executing query:
       """
       YIELD -9223372036854775807*-2
       """
-    Then a ExecutionError should be raised at runtime: Out of range -9223372036854775807 * -2
+    Then a ExecutionError should be raised at runtime: result of (-9223372036854775807*-2) cannot be represented as an integer
     When executing query:
       """
       YIELD 9223372036854775807*-2
       """
-    Then a ExecutionError should be raised at runtime: Out of range 9223372036854775807 * -2
-    When executing query:
-      """
-      YIELD -9223372036854775807*2
-      """
-    Then a ExecutionError should be raised at runtime: Out of range -9223372036854775807 * 2
+    Then a ExecutionError should be raised at runtime: result of (9223372036854775807*-2) cannot be represented as an integer
     When executing query:
       """
       YIELD 1/0
       """
-    Then a ExecutionError should be raised at runtime: Division by zero
+    Then a ExecutionError should be raised at runtime: / by zero
     When executing query:
       """
       YIELD 2%0
       """
-    Then a ExecutionError should be raised at runtime: Division by zero
+    Then a ExecutionError should be raised at runtime: / by zero
     When executing query:
       """
-      YIELD -9223372036854775808*1
+      YIELD -9223372036854775808
       """
-    Then the result should be, in any order:
-      | (-(-9223372036854775808)*1) |
-      | -9223372036854775808        |
+    Then the result should be, in any order, with relax comparison:
+      | -9223372036854775808 |
+      | -9223372036854775808 |
+    When executing query:
+      """
+      YIELD --9223372036854775808
+      """
+    Then a ExecutionError should be raised at runtime: result of -(-9223372036854775808) cannot be represented as an integer
     When executing query:
       """
       YIELD -9223372036854775809
       """
-    Then a ExecutionError should be raised at runtime: Out of range: near `9223372036854775809'
+    Then a SyntaxError should be raised at runtime: Out of range: near `9223372036854775809'
     When executing query:
       """
       YIELD 9223372036854775807
       """
-    Then the result should be, in any order:
+    Then the result should be, in any order, with relax comparison:
       | 9223372036854775807 |
       | 9223372036854775807 |
     When executing query:
       """
       YIELD -2*4611686018427387904
       """
-    Then the result should be, in any order:
+    Then the result should be, in any order, with relax comparison:
       | (-(2)*4611686018427387904) |
       | -9223372036854775808       |
 

--- a/tests/tck/features/yield/yield.feature
+++ b/tests/tck/features/yield/yield.feature
@@ -325,7 +325,7 @@ Feature: Yield Sentence
       """
     Then a SemanticError should be raised at runtime: `$-.abc', not exist prop `abc'
 
-  @skip
+  @aiee
   Scenario: CalculateOverflow
     When executing query:
       """
@@ -382,8 +382,8 @@ Feature: Yield Sentence
       YIELD -9223372036854775808*1
       """
     Then the result should be, in any order, with relax comparison:
-      | (-(-9223372036854775808)*1) |
-      | -9223372036854775808        |
+      | -(-9223372036854775808) |
+      | -9223372036854775808    |
     When executing query:
       """
       YIELD -9223372036854775809

--- a/tests/tck/features/yield/yield.feature
+++ b/tests/tck/features/yield/yield.feature
@@ -371,8 +371,13 @@ Feature: Yield Sentence
       YIELD -9223372036854775808
       """
     Then the result should be, in any order, with relax comparison:
-      | -(9223372036854775808) |
-      | -9223372036854775808   |
+      | -9223372036854775808 |
+      | -9223372036854775808 |
+    When executing query:
+      """
+      YIELD --9223372036854775808
+      """
+    Then a ExecutionError should be raised at runtime: -(-9223372036854775808) cannot be represented as an integer
     When executing query:
       """
       YIELD -9223372036854775809

--- a/tests/tck/features/yield/yield.feature
+++ b/tests/tck/features/yield/yield.feature
@@ -325,70 +325,59 @@ Feature: Yield Sentence
       """
     Then a SemanticError should be raised at runtime: `$-.abc', not exist prop `abc'
 
-  @aiee
   Scenario: CalculateOverflow
     When executing query:
       """
       YIELD 9223372036854775807+1
       """
-    Then a ExecutionError should be raised at runtime: Out of range 9223372036854775807 + 1
+    Then a ExecutionError should be raised at runtime: (9223372036854775807+1) cannot be represented as an integer
     When executing query:
       """
       YIELD -9223372036854775807-2
       """
-    Then a ExecutionError should be raised at runtime: Out of range -9223372036854775807 - 2
+    Then a ExecutionError should be raised at runtime: (-(9223372036854775807)-2) cannot be represented as an integer
     When executing query:
       """
       YIELD -9223372036854775807+-2
       """
-    Then a ExecutionError should be raised at runtime: Out of range -9223372036854775807 + -2
-    When executing query:
-      """
-      YIELD 1-(-9223372036854775807)
-      """
-    Then a ExecutionError should be raised at runtime: Out of range 1 - -9223372036854775807
+    Then a ExecutionError should be raised at runtime: (-(9223372036854775807)+-(2)) cannot be represented as an integer
     When executing query:
       """
       YIELD 9223372036854775807*2
       """
-    Then a ExecutionError should be raised at runtime: Out of range 9223372036854775807 * 2
+    Then a ExecutionError should be raised at runtime:  (9223372036854775807*2) cannot be represented as an integer
     When executing query:
       """
       YIELD -9223372036854775807*-2
       """
-    Then a ExecutionError should be raised at runtime: Out of range -9223372036854775807 * -2
+    Then a ExecutionError should be raised at runtime: (-(9223372036854775807)*-(2)) cannot be represented as an integer
     When executing query:
       """
       YIELD 9223372036854775807*-2
       """
-    Then a ExecutionError should be raised at runtime: Out of range 9223372036854775807 * -2
-    When executing query:
-      """
-      YIELD -9223372036854775807*2
-      """
-    Then a ExecutionError should be raised at runtime: Out of range -9223372036854775807 * 2
+    Then a ExecutionError should be raised at runtime: (9223372036854775807*-(2)) cannot be represented as an integer
     When executing query:
       """
       YIELD 1/0
       """
-    Then a ExecutionError should be raised at runtime: Division by zero
+    Then a ExecutionError should be raised at runtime: / by zero
     When executing query:
       """
       YIELD 2%0
       """
-    Then a ExecutionError should be raised at runtime: Division by zero
+    Then a ExecutionError should be raised at runtime: / by zero
     When executing query:
       """
-      YIELD -9223372036854775808*1
+      YIELD -9223372036854775808
       """
     Then the result should be, in any order, with relax comparison:
-      | -(-9223372036854775808) |
-      | -9223372036854775808    |
+      | -(9223372036854775808) |
+      | -9223372036854775808   |
     When executing query:
       """
       YIELD -9223372036854775809
       """
-    Then a ExecutionError should be raised at runtime: Out of range: near `9223372036854775809'
+    Then a SyntaxError should be raised at runtime: Out of range: near `9223372036854775809'
     When executing query:
       """
       YIELD 9223372036854775807

--- a/tests/tck/features/yield/yield.feature
+++ b/tests/tck/features/yield/yield.feature
@@ -330,32 +330,32 @@ Feature: Yield Sentence
       """
       YIELD 9223372036854775807+1
       """
-    Then a ExecutionError should be raised at runtime: (9223372036854775807+1) cannot be represented as an integer
+    Then a ExecutionError should be raised at runtime: result of (9223372036854775807+1) cannot be represented as an integer
     When executing query:
       """
       YIELD -9223372036854775807-2
       """
-    Then a ExecutionError should be raised at runtime: (-(9223372036854775807)-2) cannot be represented as an integer
+    Then a ExecutionError should be raised at runtime: result of (-9223372036854775807-2) cannot be represented as an integer
     When executing query:
       """
       YIELD -9223372036854775807+-2
       """
-    Then a ExecutionError should be raised at runtime: (-(9223372036854775807)+-(2)) cannot be represented as an integer
+    Then a ExecutionError should be raised at runtime: result of (-9223372036854775807+-2) cannot be represented as an integer
     When executing query:
       """
       YIELD 9223372036854775807*2
       """
-    Then a ExecutionError should be raised at runtime:  (9223372036854775807*2) cannot be represented as an integer
+    Then a ExecutionError should be raised at runtime: result of (9223372036854775807*2) cannot be represented as an integer
     When executing query:
       """
       YIELD -9223372036854775807*-2
       """
-    Then a ExecutionError should be raised at runtime: (-(9223372036854775807)*-(2)) cannot be represented as an integer
+    Then a ExecutionError should be raised at runtime: result of (-9223372036854775807*-2) cannot be represented as an integer
     When executing query:
       """
       YIELD 9223372036854775807*-2
       """
-    Then a ExecutionError should be raised at runtime: (9223372036854775807*-(2)) cannot be represented as an integer
+    Then a ExecutionError should be raised at runtime: result of (9223372036854775807*-2) cannot be represented as an integer
     When executing query:
       """
       YIELD 1/0
@@ -377,7 +377,7 @@ Feature: Yield Sentence
       """
       YIELD --9223372036854775808
       """
-    Then a ExecutionError should be raised at runtime: -(-9223372036854775808) cannot be represented as an integer
+    Then a ExecutionError should be raised at runtime: result of -(-9223372036854775808) cannot be represented as an integer
     When executing query:
       """
       YIELD -9223372036854775809


### PR DESCRIPTION
This PR addresses a few known problems:
1. Fix incorrect column name produced by query `yield -9223372036854775808`.
2. Uniform the overflow error awith Neo4j:
    ```
    (root@nebula) [nba]> yield 9223372036854775807 + 1
    [ERROR (-8)]: (9223372036854775807+1) cannot be represented as an integer
    
    (root@nebula) [nba]> yield 9223372036854775807/0
    [ERROR (-8)]: / by zero
    ```
3. Fix parsing minimum integer value in binary, oct, hex, and decimal.
4. Integrate overflow check into MATCH and nGQL

Depends on https://github.com/vesoft-inc/nebula-common/pull/531

Fix https://github.com/vesoft-inc/nebula-graph/issues/621, Fix https://github.com/vesoft-inc/nebula-graph/issues/538, FIx https://github.com/vesoft-inc/nebula-graph/issues/534
