### PR TITLE
Replace expression unique_ptr with raw pointer

### DIFF
--- a/src/context/ast/CypherAstContext.h
+++ b/src/context/ast/CypherAstContext.h
@@ -78,7 +78,7 @@ struct CypherClauseContextBase : AstContext {
 struct WhereClauseContext final : CypherClauseContextBase {
     WhereClauseContext() : CypherClauseContextBase(CypherClauseKind::kWhere) {}
 
-    Expression* filter;
+    Expression* filter{nullptr};
     std::unordered_map<std::string, AliasType>*  aliasesUsed{nullptr};
 };
 
@@ -134,7 +134,7 @@ struct MatchClauseContext final : CypherClauseContextBase {
 
     std::vector<NodeInfo>                       nodeInfos;
     std::vector<EdgeInfo>                       edgeInfos;
-    PathBuildExpression*                        pathBuild;
+    PathBuildExpression*                        pathBuild{nullptr};
     std::unique_ptr<WhereClauseContext>         where;
     std::unordered_map<std::string, AliasType>* aliasesUsed{nullptr};
     std::unordered_map<std::string, AliasType>  aliasesGenerated;
@@ -172,7 +172,7 @@ struct NodeContext final : PatternContext {
     ScanInfo                    scanInfo;
     List                        ids;
     // initialize start expression in project node
-    Expression* initialExpr;
+    Expression* initialExpr{nullptr};
 };
 
 struct EdgeContext final : PatternContext {
@@ -184,7 +184,7 @@ struct EdgeContext final : PatternContext {
     // Output fields
     ScanInfo                    scanInfo;
     // initialize start expression in project node
-    Expression* initialExpr;
+    Expression* initialExpr{nullptr};
 };
 }  // namespace graph
 }  // namespace nebula

--- a/src/context/ast/CypherAstContext.h
+++ b/src/context/ast/CypherAstContext.h
@@ -134,7 +134,7 @@ struct MatchClauseContext final : CypherClauseContextBase {
 
     std::vector<NodeInfo>                       nodeInfos;
     std::vector<EdgeInfo>                       edgeInfos;
-    std::unique_ptr<PathBuildExpression>        pathBuild;
+    PathBuildExpression*                        pathBuild;
     std::unique_ptr<WhereClauseContext>         where;
     std::unordered_map<std::string, AliasType>* aliasesUsed{nullptr};
     std::unordered_map<std::string, AliasType>  aliasesGenerated;
@@ -172,7 +172,7 @@ struct NodeContext final : PatternContext {
     ScanInfo                    scanInfo;
     List                        ids;
     // initialize start expression in project node
-    std::unique_ptr<Expression> initialExpr;
+    Expression* initialExpr;
 };
 
 struct EdgeContext final : PatternContext {
@@ -184,7 +184,7 @@ struct EdgeContext final : PatternContext {
     // Output fields
     ScanInfo                    scanInfo;
     // initialize start expression in project node
-    std::unique_ptr<Expression> initialExpr;
+    Expression* initialExpr;
 };
 }  // namespace graph
 }  // namespace nebula

--- a/src/executor/test/AggregateTest.cpp
+++ b/src/executor/test/AggregateTest.cpp
@@ -91,8 +91,8 @@ struct RowCmp {
     std::vector<Expression*> groupKeys;                                                            \
     std::vector<Expression*> groupItems;                                                           \
     auto expr = InputPropertyExpression::make(pool_, "col1");                                      \
-    auto item = *AggregateExpression::make(pool_, (FUN), expr, DISTINCT);                          \
-    groupItems.emplace_back(&item);                                                                \
+    auto item = AggregateExpression::make(pool_, (FUN), expr, DISTINCT);                           \
+    groupItems.emplace_back(item);                                                                 \
     auto* agg =                                                                                    \
         Aggregate::make(qctx_.get(), nullptr, std::move(groupKeys), std::move(groupItems));        \
     agg->setInputVar(*input_);                                                                     \
@@ -112,8 +112,8 @@ struct RowCmp {
     auto expr1 = InputPropertyExpression::make(pool_, "col2");                                     \
     auto expr2 = expr1->clone();                                                                   \
     groupKeys.emplace_back(expr1);                                                                 \
-    auto item = *AggregateExpression::make(pool_, (FUN), expr2, DISTINCT);                         \
-    groupItems.emplace_back(&item);                                                                \
+    auto item = AggregateExpression::make(pool_, (FUN), expr2, DISTINCT);                          \
+    groupItems.emplace_back(item);                                                                 \
     auto* agg =                                                                                    \
         Aggregate::make(qctx_.get(), nullptr, std::move(groupKeys), std::move(groupItems));        \
     agg->setInputVar(*input_);                                                                     \
@@ -135,12 +135,12 @@ struct RowCmp {
     auto expr1 = InputPropertyExpression::make(pool_, "col2");                                     \
     auto expr2 = expr1->clone();                                                                   \
     groupKeys.emplace_back(expr1);                                                                 \
-    auto item = *AggregateExpression::make(pool_, "", expr2, false);                               \
-    groupItems.emplace_back(&item);                                                                \
+    auto item = AggregateExpression::make(pool_, "", expr2, false);                                \
+    groupItems.emplace_back(item);                                                                 \
     auto expr3 = InputPropertyExpression::make(pool_, "col3");                                     \
     groupKeys.emplace_back(expr3);                                                                 \
-    auto item1 = *AggregateExpression::make(pool_, (FUN), expr3, DISTINCT);                        \
-    groupItems.emplace_back(&item1);                                                               \
+    auto item1 = AggregateExpression::make(pool_, (FUN), expr3, DISTINCT);                         \
+    groupItems.emplace_back(item1);                                                               \
     auto* agg =                                                                                    \
         Aggregate::make(qctx_.get(), nullptr, std::move(groupKeys), std::move(groupItems));        \
     agg->setInputVar(*input_);                                                                     \
@@ -160,8 +160,8 @@ struct RowCmp {
     std::vector<Expression*> groupKeys;                                                            \
     std::vector<Expression*> groupItems;                                                           \
     auto expr = ConstantExpression::make(pool_, 1);                                                \
-    auto item = *AggregateExpression::make(pool_, (FUN), expr, DISTINCT);                          \
-    groupItems.emplace_back(&item);                                                                \
+    auto item = AggregateExpression::make(pool_, (FUN), expr, DISTINCT);                           \
+    groupItems.emplace_back(item);                                                                 \
     auto* agg =                                                                                    \
         Aggregate::make(qctx_.get(), nullptr, std::move(groupKeys), std::move(groupItems));        \
     agg->setInputVar(*input_);                                                                     \
@@ -306,8 +306,8 @@ TEST_F(AggregateTest, Collect) {
         auto expr1 = InputPropertyExpression::make(pool_, "col1");
         auto expr2 = expr1->clone();
         groupKeys.emplace_back(expr1);
-        auto item = *AggregateExpression::make(pool_, "COLLECT", expr2, false);
-        groupItems.emplace_back(std::move(&item));
+        auto item = AggregateExpression::make(pool_, "COLLECT", expr2, false);
+        groupItems.emplace_back(item);
         auto* agg =
             Aggregate::make(qctx_.get(), nullptr, std::move(groupKeys), std::move(groupItems));
         agg->setInputVar(*input_);
@@ -411,8 +411,8 @@ TEST_F(AggregateTest, Collect) {
         std::vector<Expression*> groupKeys;
         std::vector<Expression*> groupItems;
         auto expr = InputPropertyExpression::make(pool_, "col1");
-        auto item = *AggregateExpression::make(pool_, "COLLECT", expr, true);
-        groupItems.emplace_back(std::move(&item));
+        auto item = AggregateExpression::make(pool_, "COLLECT", expr, true);
+        groupItems.emplace_back(item);
         auto* agg =
             Aggregate::make(qctx_.get(), nullptr, std::move(groupKeys), std::move(groupItems));
         agg->setInputVar(*input_);
@@ -472,8 +472,8 @@ TEST_F(AggregateTest, Collect) {
         std::vector<Expression*> groupItems;
         auto expr1 = InputPropertyExpression::make(pool_, "col1");
         auto expr2 = expr1->clone();
-        auto item = *AggregateExpression::make(pool_, "COLLECT", expr2, true);
-        groupItems.emplace_back(std::move(&item));
+        auto item = AggregateExpression::make(pool_, "COLLECT", expr2, true);
+        groupItems.emplace_back(item);
         auto* agg =
             Aggregate::make(qctx_.get(), nullptr, std::move(groupKeys), std::move(groupItems));
         agg->setInputVar(*input_);

--- a/src/executor/test/AggregateTest.cpp
+++ b/src/executor/test/AggregateTest.cpp
@@ -13,7 +13,7 @@
 namespace nebula {
 namespace graph {
 class AggregateTest : public testing::Test {
-   protected:
+protected:
     static void SetUpTestCase() {
         // ======================
         // | col1 | col2 | col3 |
@@ -40,6 +40,8 @@ class AggregateTest : public testing::Test {
         // ----------------------
         input_ = std::make_unique<std::string>("input_agg");
         qctx_ = std::make_unique<QueryContext>();
+        pool_ = qctx_->objPool();
+
         DataSet ds;
         ds.colNames = {"col1", "col2", "col3"};
         for (auto i = 0; i < 10; ++i) {
@@ -64,10 +66,12 @@ class AggregateTest : public testing::Test {
 protected:
     static std::unique_ptr<QueryContext> qctx_;
     static std::unique_ptr<std::string> input_;
+    static ObjectPool* pool_;
 };
 
 std::unique_ptr<QueryContext> AggregateTest::qctx_;
 std::unique_ptr<std::string> AggregateTest::input_;
+ObjectPool* AggregateTest::pool_;
 
 struct RowCmp {
     bool operator()(const Row& lhs, const Row& rhs) {
@@ -83,94 +87,93 @@ struct RowCmp {
     }
 };
 
-#define TEST_AGG_1(FUN, COL, DISTINCT)                                      \
-    std::vector<Expression*> groupKeys;                                     \
-    std::vector<Expression*> groupItems;                                    \
-    auto expr = std::make_unique<InputPropertyExpression>("col1");          \
-    AggregateExpression item((FUN), expr.release(), DISTINCT);              \
-    groupItems.emplace_back(&item);                                         \
-    auto* agg = Aggregate::make(qctx_.get(), nullptr, std::move(groupKeys), \
-                                std::move(groupItems));                     \
-    agg->setInputVar(*input_);                                              \
-    agg->setColNames(std::vector<std::string>{COL});                        \
-                                                                            \
-    auto aggExe = std::make_unique<AggregateExecutor>(agg, qctx_.get());    \
-    auto future = aggExe->execute();                                        \
-    auto status = std::move(future).get();                                  \
-    EXPECT_TRUE(status.ok());                                               \
-    auto& result = qctx_->ectx()->getResult(agg->outputVar());              \
-    EXPECT_EQ(result.value().getDataSet(), expected);                       \
+#define TEST_AGG_1(FUN, COL, DISTINCT)                                                             \
+    std::vector<Expression*> groupKeys;                                                            \
+    std::vector<Expression*> groupItems;                                                           \
+    auto expr = InputPropertyExpression::make(pool_, "col1");                                      \
+    auto item = *AggregateExpression::make(pool_, (FUN), expr, DISTINCT);                          \
+    groupItems.emplace_back(&item);                                                                \
+    auto* agg =                                                                                    \
+        Aggregate::make(qctx_.get(), nullptr, std::move(groupKeys), std::move(groupItems));        \
+    agg->setInputVar(*input_);                                                                     \
+    agg->setColNames(std::vector<std::string>{COL});                                               \
+                                                                                                   \
+    auto aggExe = std::make_unique<AggregateExecutor>(agg, qctx_.get());                           \
+    auto future = aggExe->execute();                                                               \
+    auto status = std::move(future).get();                                                         \
+    EXPECT_TRUE(status.ok());                                                                      \
+    auto& result = qctx_->ectx()->getResult(agg->outputVar());                                     \
+    EXPECT_EQ(result.value().getDataSet(), expected);                                              \
     EXPECT_EQ(result.state(), Result::State::kSuccess);
 
-#define TEST_AGG_2(FUN, COL, DISTINCT)                                      \
-    std::vector<Expression*> groupKeys;                                     \
-    std::vector<Expression*> groupItems;                                    \
-    auto expr1 = std::make_unique<InputPropertyExpression>("col2");         \
-    auto expr2 = expr1->clone();                                            \
-    groupKeys.emplace_back(expr1.get());                                    \
-    AggregateExpression item((FUN), expr2.release(), DISTINCT);             \
-    groupItems.emplace_back(&item);                                         \
-    auto* agg = Aggregate::make(qctx_.get(), nullptr, std::move(groupKeys), \
-                                std::move(groupItems));                     \
-    agg->setInputVar(*input_);                                              \
-    agg->setColNames(std::vector<std::string>{COL});                        \
-                                                                            \
-    auto aggExe = std::make_unique<AggregateExecutor>(agg, qctx_.get());    \
-    auto future = aggExe->execute();                                        \
-    auto status = std::move(future).get();                                  \
-    EXPECT_TRUE(status.ok());                                               \
-    auto& result = qctx_->ectx()->getResult(agg->outputVar());              \
-    DataSet sortedDs = result.value().getDataSet();                         \
-    std::sort(sortedDs.rows.begin(), sortedDs.rows.end(), RowCmp());        \
-    EXPECT_EQ(sortedDs, expected);                                          \
+#define TEST_AGG_2(FUN, COL, DISTINCT)                                                             \
+    std::vector<Expression*> groupKeys;                                                            \
+    std::vector<Expression*> groupItems;                                                           \
+    auto expr1 = InputPropertyExpression::make(pool_, "col2");                                     \
+    auto expr2 = expr1->clone();                                                                   \
+    groupKeys.emplace_back(expr1);                                                                 \
+    auto item = *AggregateExpression::make(pool_, (FUN), expr2, DISTINCT);                         \
+    groupItems.emplace_back(&item);                                                                \
+    auto* agg =                                                                                    \
+        Aggregate::make(qctx_.get(), nullptr, std::move(groupKeys), std::move(groupItems));        \
+    agg->setInputVar(*input_);                                                                     \
+    agg->setColNames(std::vector<std::string>{COL});                                               \
+                                                                                                   \
+    auto aggExe = std::make_unique<AggregateExecutor>(agg, qctx_.get());                           \
+    auto future = aggExe->execute();                                                               \
+    auto status = std::move(future).get();                                                         \
+    EXPECT_TRUE(status.ok());                                                                      \
+    auto& result = qctx_->ectx()->getResult(agg->outputVar());                                     \
+    DataSet sortedDs = result.value().getDataSet();                                                \
+    std::sort(sortedDs.rows.begin(), sortedDs.rows.end(), RowCmp());                               \
+    EXPECT_EQ(sortedDs, expected);                                                                 \
     EXPECT_EQ(result.state(), Result::State::kSuccess);
 
-#define TEST_AGG_3(FUN, COL, DISTINCT)                                      \
-    std::vector<Expression*> groupKeys;                                     \
-    std::vector<Expression*> groupItems;                                    \
-    auto expr1 = std::make_unique<InputPropertyExpression>("col2");         \
-    auto expr2 = expr1->clone();                                            \
-    groupKeys.emplace_back(expr1.get());                                    \
-    AggregateExpression item("", expr2.release(), false);                   \
-    groupItems.emplace_back(&item);                                         \
-    auto expr3 = std::make_unique<InputPropertyExpression>("col3");         \
-    groupKeys.emplace_back(expr3.get());                                    \
-    AggregateExpression item1((FUN), expr3.release(), DISTINCT);            \
-    groupItems.emplace_back(&item1);                                        \
-    auto* agg = Aggregate::make(qctx_.get(), nullptr, std::move(groupKeys), \
-                                std::move(groupItems));                     \
-    agg->setInputVar(*input_);                                              \
-    agg->setColNames(std::vector<std::string>{"col2", COL});                \
-                                                                            \
-    auto aggExe = std::make_unique<AggregateExecutor>(agg, qctx_.get());    \
-    auto future = aggExe->execute();                                        \
-    auto status = std::move(future).get();                                  \
-    EXPECT_TRUE(status.ok());                                               \
-    auto& result = qctx_->ectx()->getResult(agg->outputVar());              \
-    DataSet sortedDs = result.value().getDataSet();                         \
-    std::sort(sortedDs.rows.begin(), sortedDs.rows.end(), RowCmp());        \
-    EXPECT_EQ(sortedDs, expected);                                          \
+#define TEST_AGG_3(FUN, COL, DISTINCT)                                                             \
+    std::vector<Expression*> groupKeys;                                                            \
+    std::vector<Expression*> groupItems;                                                           \
+    auto expr1 = InputPropertyExpression::make(pool_, "col2");                                     \
+    auto expr2 = expr1->clone();                                                                   \
+    groupKeys.emplace_back(expr1);                                                                 \
+    auto item = *AggregateExpression::make(pool_, "", expr2, false);                               \
+    groupItems.emplace_back(&item);                                                                \
+    auto expr3 = InputPropertyExpression::make(pool_, "col3");                                     \
+    groupKeys.emplace_back(expr3);                                                                 \
+    auto item1 = *AggregateExpression::make(pool_, (FUN), expr3, DISTINCT);                        \
+    groupItems.emplace_back(&item1);                                                               \
+    auto* agg =                                                                                    \
+        Aggregate::make(qctx_.get(), nullptr, std::move(groupKeys), std::move(groupItems));        \
+    agg->setInputVar(*input_);                                                                     \
+    agg->setColNames(std::vector<std::string>{"col2", COL});                                       \
+                                                                                                   \
+    auto aggExe = std::make_unique<AggregateExecutor>(agg, qctx_.get());                           \
+    auto future = aggExe->execute();                                                               \
+    auto status = std::move(future).get();                                                         \
+    EXPECT_TRUE(status.ok());                                                                      \
+    auto& result = qctx_->ectx()->getResult(agg->outputVar());                                     \
+    DataSet sortedDs = result.value().getDataSet();                                                \
+    std::sort(sortedDs.rows.begin(), sortedDs.rows.end(), RowCmp());                               \
+    EXPECT_EQ(sortedDs, expected);                                                                 \
     EXPECT_EQ(result.state(), Result::State::kSuccess);
 
-#define TEST_AGG_4(FUN, COL, DISTINCT)                                      \
-    std::vector<Expression*> groupKeys;                                     \
-    std::vector<Expression*> groupItems;                                    \
-    auto expr = std::make_unique<ConstantExpression>(1);                    \
-    AggregateExpression item((FUN), expr.release(), DISTINCT); \
-    groupItems.emplace_back(&item);                                         \
-    auto* agg = Aggregate::make(qctx_.get(), nullptr, std::move(groupKeys), \
-                                std::move(groupItems));                     \
-    agg->setInputVar(*input_);                                              \
-    agg->setColNames(std::vector<std::string>{COL});                        \
-                                                                            \
-    auto aggExe = std::make_unique<AggregateExecutor>(agg, qctx_.get());    \
-    auto future = aggExe->execute();                                        \
-    auto status = std::move(future).get();                                  \
-    EXPECT_TRUE(status.ok());                                               \
-    auto& result = qctx_->ectx()->getResult(agg->outputVar());              \
-    EXPECT_EQ(result.value().getDataSet(), expected);                       \
+#define TEST_AGG_4(FUN, COL, DISTINCT)                                                             \
+    std::vector<Expression*> groupKeys;                                                            \
+    std::vector<Expression*> groupItems;                                                           \
+    auto expr = ConstantExpression::make(pool_, 1);                                                \
+    auto item = *AggregateExpression::make(pool_, (FUN), expr, DISTINCT);                          \
+    groupItems.emplace_back(&item);                                                                \
+    auto* agg =                                                                                    \
+        Aggregate::make(qctx_.get(), nullptr, std::move(groupKeys), std::move(groupItems));        \
+    agg->setInputVar(*input_);                                                                     \
+    agg->setColNames(std::vector<std::string>{COL});                                               \
+                                                                                                   \
+    auto aggExe = std::make_unique<AggregateExecutor>(agg, qctx_.get());                           \
+    auto future = aggExe->execute();                                                               \
+    auto status = std::move(future).get();                                                         \
+    EXPECT_TRUE(status.ok());                                                                      \
+    auto& result = qctx_->ectx()->getResult(agg->outputVar());                                     \
+    EXPECT_EQ(result.value().getDataSet(), expected);                                              \
     EXPECT_EQ(result.state(), Result::State::kSuccess);
-
 
 TEST_F(AggregateTest, Group) {
     {
@@ -300,13 +303,13 @@ TEST_F(AggregateTest, Collect) {
         // items = collect(col1)
         std::vector<Expression*> groupKeys;
         std::vector<Expression*> groupItems;
-        auto expr1 = std::make_unique<InputPropertyExpression>("col1");
+        auto expr1 = InputPropertyExpression::make(pool_, "col1");
         auto expr2 = expr1->clone();
-        groupKeys.emplace_back(expr1.get());
-        AggregateExpression item("COLLECT", expr2.release(), false);
+        groupKeys.emplace_back(expr1);
+        auto item = *AggregateExpression::make(pool_, "COLLECT", expr2, false);
         groupItems.emplace_back(std::move(&item));
-        auto* agg = Aggregate::make(qctx_.get(), nullptr, std::move(groupKeys),
-                                    std::move(groupItems));
+        auto* agg =
+            Aggregate::make(qctx_.get(), nullptr, std::move(groupKeys), std::move(groupItems));
         agg->setInputVar(*input_);
         agg->setColNames(std::vector<std::string>{"list"});
 
@@ -407,11 +410,11 @@ TEST_F(AggregateTest, Collect) {
         // items = collect(distinct col1)
         std::vector<Expression*> groupKeys;
         std::vector<Expression*> groupItems;
-        auto expr = std::make_unique<InputPropertyExpression>("col1");
-        AggregateExpression item("COLLECT", expr.release(), true);
+        auto expr = InputPropertyExpression::make(pool_, "col1");
+        auto item = *AggregateExpression::make(pool_, "COLLECT", expr, true);
         groupItems.emplace_back(std::move(&item));
-        auto* agg = Aggregate::make(qctx_.get(), nullptr, std::move(groupKeys),
-                                    std::move(groupItems));
+        auto* agg =
+            Aggregate::make(qctx_.get(), nullptr, std::move(groupKeys), std::move(groupItems));
         agg->setInputVar(*input_);
         agg->setColNames(std::vector<std::string>{"list"});
 
@@ -467,12 +470,12 @@ TEST_F(AggregateTest, Collect) {
         // items = collect(distinct col1)
         std::vector<Expression*> groupKeys;
         std::vector<Expression*> groupItems;
-        auto expr1 = std::make_unique<InputPropertyExpression>("col1");
+        auto expr1 = InputPropertyExpression::make(pool_, "col1");
         auto expr2 = expr1->clone();
-        AggregateExpression item("COLLECT", expr2.release(), true);
+        auto item = *AggregateExpression::make(pool_, "COLLECT", expr2, true);
         groupItems.emplace_back(std::move(&item));
-        auto* agg = Aggregate::make(qctx_.get(), nullptr, std::move(groupKeys),
-                                    std::move(groupItems));
+        auto* agg =
+            Aggregate::make(qctx_.get(), nullptr, std::move(groupKeys), std::move(groupItems));
         agg->setInputVar(*input_);
         agg->setColNames(std::vector<std::string>{"list"});
 
@@ -532,7 +535,7 @@ TEST_F(AggregateTest, Collect) {
         // key = col2, col3
         // items = col2, collect(distinct col3)
 
-       TEST_AGG_3("COLLECT", "list", true)
+        TEST_AGG_3("COLLECT", "list", true)
     }
     {
         // ====================================
@@ -797,7 +800,7 @@ TEST_F(AggregateTest, Sum) {
 
         // key = col2
         // items = sum(col2)
-       TEST_AGG_2("SUM", "sum", false)
+        TEST_AGG_2("SUM", "sum", false)
     }
     {
         // ================
@@ -2182,5 +2185,5 @@ TEST_F(AggregateTest, BitXor) {
         TEST_AGG_4("BIT_XOR", "bit_xor", true)
     }
 }
-}  // namespace graph
-}  // namespace nebula
+}   // namespace graph
+}   // namespace nebula

--- a/src/executor/test/AssignTest.cpp
+++ b/src/executor/test/AssignTest.cpp
@@ -18,10 +18,12 @@ class AssignExecutorTest : public testing::Test {
 protected:
     void SetUp() override {
         qctx_ = std::make_unique<QueryContext>();
+        pool_ = qctx_->objPool();
     }
 
 protected:
     std::unique_ptr<QueryContext> qctx_;
+    ObjectPool* pool_;
 };
 
 TEST_F(AssignExecutorTest, SingleExpression) {
@@ -29,7 +31,7 @@ TEST_F(AssignExecutorTest, SingleExpression) {
         std::string varName = "intVar";
         int val = 13;
         qctx_->symTable()->newVariable(varName);
-        auto* expr = ConstantExpression::make(poolval);
+        auto* expr = ConstantExpression::make(pool_, val);
 
         auto* assign = Assign::make(qctx_.get(), nullptr);
         assign->assignVar(varName, expr);
@@ -46,7 +48,7 @@ TEST_F(AssignExecutorTest, SingleExpression) {
         std::string varName = "floatVar";
         float val = 1.234563726090;
         qctx_->symTable()->newVariable(varName);
-        auto* expr = ConstantExpression::make(poolval);
+        auto* expr = ConstantExpression::make(pool_, val);
 
         auto* assign = Assign::make(qctx_.get(), nullptr);
         assign->assignVar(varName, expr);
@@ -63,7 +65,7 @@ TEST_F(AssignExecutorTest, SingleExpression) {
         std::string varName = "stringVar";
         std::string val = "hello world";
         qctx_->symTable()->newVariable(varName);
-        auto* expr = ConstantExpression::make(poolval);
+        auto* expr = ConstantExpression::make(pool_, val);
 
         auto* assign = Assign::make(qctx_.get(), nullptr);
         assign->assignVar(varName, expr);
@@ -87,9 +89,9 @@ TEST_F(AssignExecutorTest, MultiExpression) {
     qctx_->symTable()->newVariable(stringVar);
     auto* assign = Assign::make(qctx_.get(), nullptr);
 
-    assign->assignVar(intVar, ConstantExpression::make(pool, 1));
-    assign->assignVar(floatVar, ConstantExpression::make(pool, 3.2425787));
-    assign->assignVar(stringVar, ConstantExpression::make(pool, "hello"));
+    assign->assignVar(intVar, ConstantExpression::make(pool_, 1));
+    assign->assignVar(floatVar, ConstantExpression::make(pool_, 3.2425787));
+    assign->assignVar(stringVar, ConstantExpression::make(pool_, "hello"));
 
     auto assignExe = std::make_unique<AssignExecutor>(assign, qctx_.get());
     auto future = assignExe->execute();
@@ -120,7 +122,7 @@ TEST_F(AssignExecutorTest, VariableExpression) {
     {
         // var1 = 13
         int val = 13;
-        auto* expr = ConstantExpression::make(poolval);
+        auto* expr = ConstantExpression::make(pool_, val);
         auto* assign = Assign::make(qctx_.get(), nullptr);
         assign->assignVar(varName1, expr);
         auto assignExe = std::make_unique<AssignExecutor>(assign, qctx_.get());
@@ -132,8 +134,8 @@ TEST_F(AssignExecutorTest, VariableExpression) {
         EXPECT_EQ(result.getInt(), val);
     }
 
-    auto* addExpr = new ArithmeticExpression(
-        Expression::Kind::kAdd, new VariableExpression(varName1), ConstantExpression::make(pool7));
+    auto* addExpr = ArithmeticExpression::makeAdd(
+        pool_, VariableExpression::make(pool_, varName1), ConstantExpression::make(pool_, 7));
     auto* assign = Assign::make(qctx_.get(), nullptr);
     assign->assignVar(varName, addExpr);
     auto assignExe = std::make_unique<AssignExecutor>(assign, qctx_.get());
@@ -155,7 +157,7 @@ TEST_F(AssignExecutorTest, VariableExpression1) {
     {
         // var1 = 13
         int val = 13;
-        auto* expr = ConstantExpression::make(poolval);
+        auto* expr = ConstantExpression::make(pool_, val);
         auto* assign = Assign::make(qctx_.get(), nullptr);
         assign->assignVar(varName1, expr);
         auto assignExe = std::make_unique<AssignExecutor>(assign, qctx_.get());
@@ -167,8 +169,7 @@ TEST_F(AssignExecutorTest, VariableExpression1) {
         EXPECT_EQ(result.getInt(), val);
     }
     // var = var1++
-    auto* addExpr =
-        new UnaryExpression(Expression::Kind::kUnaryIncr, new VariableExpression(varName1));
+    auto* addExpr = UnaryExpression::makeIncr(pool_, VariableExpression::make(pool_, varName1));
     auto* assign = Assign::make(qctx_.get(), nullptr);
     assign->assignVar(varName, addExpr);
     auto assignExe = std::make_unique<AssignExecutor>(assign, qctx_.get());

--- a/src/executor/test/AssignTest.cpp
+++ b/src/executor/test/AssignTest.cpp
@@ -29,7 +29,7 @@ TEST_F(AssignExecutorTest, SingleExpression) {
         std::string varName = "intVar";
         int val = 13;
         qctx_->symTable()->newVariable(varName);
-        auto* expr = new ConstantExpression(val);
+        auto* expr = ConstantExpression::make(poolval);
 
         auto* assign = Assign::make(qctx_.get(), nullptr);
         assign->assignVar(varName, expr);
@@ -46,7 +46,7 @@ TEST_F(AssignExecutorTest, SingleExpression) {
         std::string varName = "floatVar";
         float val = 1.234563726090;
         qctx_->symTable()->newVariable(varName);
-        auto* expr = new ConstantExpression(val);
+        auto* expr = ConstantExpression::make(poolval);
 
         auto* assign = Assign::make(qctx_.get(), nullptr);
         assign->assignVar(varName, expr);
@@ -63,7 +63,7 @@ TEST_F(AssignExecutorTest, SingleExpression) {
         std::string varName = "stringVar";
         std::string val = "hello world";
         qctx_->symTable()->newVariable(varName);
-        auto* expr = new ConstantExpression(val);
+        auto* expr = ConstantExpression::make(poolval);
 
         auto* assign = Assign::make(qctx_.get(), nullptr);
         assign->assignVar(varName, expr);
@@ -87,9 +87,9 @@ TEST_F(AssignExecutorTest, MultiExpression) {
     qctx_->symTable()->newVariable(stringVar);
     auto* assign = Assign::make(qctx_.get(), nullptr);
 
-    assign->assignVar(intVar, new ConstantExpression(1));
-    assign->assignVar(floatVar, new ConstantExpression(3.2425787));
-    assign->assignVar(stringVar, new ConstantExpression("hello"));
+    assign->assignVar(intVar, ConstantExpression::make(pool, 1));
+    assign->assignVar(floatVar, ConstantExpression::make(pool, 3.2425787));
+    assign->assignVar(stringVar, ConstantExpression::make(pool, "hello"));
 
     auto assignExe = std::make_unique<AssignExecutor>(assign, qctx_.get());
     auto future = assignExe->execute();
@@ -120,7 +120,7 @@ TEST_F(AssignExecutorTest, VariableExpression) {
     {
         // var1 = 13
         int val = 13;
-        auto* expr = new ConstantExpression(val);
+        auto* expr = ConstantExpression::make(poolval);
         auto* assign = Assign::make(qctx_.get(), nullptr);
         assign->assignVar(varName1, expr);
         auto assignExe = std::make_unique<AssignExecutor>(assign, qctx_.get());
@@ -133,7 +133,7 @@ TEST_F(AssignExecutorTest, VariableExpression) {
     }
 
     auto* addExpr = new ArithmeticExpression(
-        Expression::Kind::kAdd, new VariableExpression(varName1), new ConstantExpression(7));
+        Expression::Kind::kAdd, new VariableExpression(varName1), ConstantExpression::make(pool7));
     auto* assign = Assign::make(qctx_.get(), nullptr);
     assign->assignVar(varName, addExpr);
     auto assignExe = std::make_unique<AssignExecutor>(assign, qctx_.get());
@@ -155,7 +155,7 @@ TEST_F(AssignExecutorTest, VariableExpression1) {
     {
         // var1 = 13
         int val = 13;
-        auto* expr = new ConstantExpression(val);
+        auto* expr = ConstantExpression::make(poolval);
         auto* assign = Assign::make(qctx_.get(), nullptr);
         assign->assignVar(varName1, expr);
         auto assignExe = std::make_unique<AssignExecutor>(assign, qctx_.get());

--- a/src/executor/test/DedupTest.cpp
+++ b/src/executor/test/DedupTest.cpp
@@ -24,7 +24,7 @@ public:
 #define DEDUP_RESUTL_CHECK(inputName, outputName, sentence, expected)                              \
     do {                                                                                           \
         qctx_->symTable()->newVariable(outputName);                                                \
-        auto yieldSentence = getYieldSentence(sentence);                                           \
+        auto yieldSentence = getYieldSentence(sentence, qctx_.get());                              \
         auto* dedupNode = Dedup::make(qctx_.get(), nullptr);                                       \
         dedupNode->setInputVar(inputName);                                                         \
         dedupNode->setOutputVar(outputName);                                                       \

--- a/src/executor/test/FilterTest.cpp
+++ b/src/executor/test/FilterTest.cpp
@@ -25,14 +25,15 @@ public:
 #define FILTER_RESUTL_CHECK(inputName, outputName, sentence, expected)                             \
     do {                                                                                           \
         qctx_->symTable()->newVariable(outputName);                                                \
-        auto yieldSentence = getYieldSentence(sentence);                                           \
+        auto* pool = qctx_->objPool();                                                             \
+        auto yieldSentence = getYieldSentence(sentence, qctx_.get());                              \
         auto columns = yieldSentence->columns();                                                   \
         for (auto& col : columns) {                                                                \
-            col->setExpr(ExpressionUtils::rewriteLabelAttr2EdgeProp(col->expr()));                 \
+            col->setExpr(ExpressionUtils::rewriteLabelAttr2EdgeProp(pool, col->expr()));           \
         }                                                                                          \
         auto* whereSentence = yieldSentence->where();                                              \
         whereSentence->setFilter(                                                                  \
-            ExpressionUtils::rewriteLabelAttr2EdgeProp(whereSentence->filter()));                  \
+            ExpressionUtils::rewriteLabelAttr2EdgeProp(pool, whereSentence->filter()));            \
         auto* filterNode = Filter::make(qctx_.get(), nullptr, yieldSentence->where()->filter());   \
         filterNode->setInputVar(inputName);                                                        \
         filterNode->setOutputVar(outputName);                                                      \

--- a/src/executor/test/GetNeighborsTest.cpp
+++ b/src/executor/test/GetNeighborsTest.cpp
@@ -57,7 +57,7 @@ TEST_F(GetNeighborsTest, BuildRequestDataSet) {
     auto edgeProps = std::make_unique<std::vector<storage::cpp2::EdgeProp>>();
     auto statProps = std::make_unique<std::vector<storage::cpp2::StatProp>>();
     auto exprs = std::make_unique<std::vector<storage::cpp2::Expr>>();
-    auto* vids = pool->add(new InputPropertyExpression("id"));
+    auto* vids = InputPropertyExpression::make(pool, "id");
     auto* gn = GetNeighbors::make(
             qctx_.get(),
             nullptr,

--- a/src/executor/test/JoinTest.cpp
+++ b/src/executor/test/JoinTest.cpp
@@ -89,10 +89,10 @@ protected:
 
 void JoinTest::testInnerJoin(std::string left, std::string right,
                             DataSet& expected, int64_t line) {
-    auto key = *VariablePropertyExpression::make(pool_, left, "dst");
-    std::vector<Expression*> hashKeys = {&key};
-    auto probe = *VariablePropertyExpression::make(pool_, right, "_vid");
-    std::vector<Expression*> probeKeys = {&probe};
+    auto key = VariablePropertyExpression::make(pool_, left, "dst");
+    std::vector<Expression*> hashKeys = {key};
+    auto probe = VariablePropertyExpression::make(pool_, right, "_vid");
+    std::vector<Expression*> probeKeys = {probe};
 
     auto* join =
         InnerJoin::make(qctx_.get(), nullptr, {left, 0}, {right, 0}, std::move(hashKeys),
@@ -127,10 +127,10 @@ void JoinTest::testInnerJoin(std::string left, std::string right,
 
 void JoinTest::testLeftJoin(std::string left, std::string right,
                             DataSet& expected, int64_t line) {
-    auto key = *VariablePropertyExpression::make(pool_, left, "_vid");
-    std::vector<Expression*> hashKeys = {&key};
-    auto probe = *VariablePropertyExpression::make(pool_, right, "dst");
-    std::vector<Expression*> probeKeys = {&probe};
+    auto key = VariablePropertyExpression::make(pool_, left, "_vid");
+    std::vector<Expression*> hashKeys = {key};
+    auto probe = VariablePropertyExpression::make(pool_, right, "dst");
+    std::vector<Expression*> probeKeys = {probe};
 
     auto* join =
         LeftJoin::make(qctx_.get(), nullptr, {left, 0}, {right, 0}, std::move(hashKeys),
@@ -196,10 +196,10 @@ TEST_F(JoinTest, InnerJoinTwice) {
     {
         std::string left = "var2";
         std::string right = "var1";
-        auto key = *VariablePropertyExpression::make(pool_, left, "dst");
-        std::vector<Expression*> hashKeys = {&key};
-        auto probe = *VariablePropertyExpression::make(pool_, right, "_vid");
-        std::vector<Expression*> probeKeys = {&probe};
+        auto key = VariablePropertyExpression::make(pool_, left, "dst");
+        std::vector<Expression*> hashKeys = {key};
+        auto probe = VariablePropertyExpression::make(pool_, right, "_vid");
+        std::vector<Expression*> probeKeys = {probe};
 
         auto* join =
             InnerJoin::make(qctx_.get(), nullptr, {left, 0}, {right, 0}, std::move(hashKeys),
@@ -216,10 +216,10 @@ TEST_F(JoinTest, InnerJoinTwice) {
 
     std::string left = joinOutput;
     std::string right = "var3";
-    auto key = *VariablePropertyExpression::make(pool_, left, "src");
-    std::vector<Expression*> hashKeys = {&key};
-    auto probe = *VariablePropertyExpression::make(pool_, right, "col1");
-    std::vector<Expression*> probeKeys = {&probe};
+    auto key = VariablePropertyExpression::make(pool_, left, "src");
+    std::vector<Expression*> hashKeys = {key};
+    auto probe = VariablePropertyExpression::make(pool_, right, "col1");
+    std::vector<Expression*> probeKeys = {probe};
 
     auto* join =
         InnerJoin::make(qctx_.get(), nullptr, {left, 0}, {right, 0}, std::move(hashKeys),
@@ -318,10 +318,10 @@ TEST_F(JoinTest, LeftJoinTwice) {
     {
         std::string left = "var1";
         std::string right = "var2";
-        auto key = *VariablePropertyExpression::make(pool_, left, "_vid");
-        std::vector<Expression*> hashKeys = {&key};
-        auto probe = *VariablePropertyExpression::make(pool_, right, "dst");
-        std::vector<Expression*> probeKeys = {&probe};
+        auto key = VariablePropertyExpression::make(pool_, left, "_vid");
+        std::vector<Expression*> hashKeys = {key};
+        auto probe = VariablePropertyExpression::make(pool_, right, "dst");
+        std::vector<Expression*> probeKeys = {probe};
 
         auto* join = LeftJoin::make(
             qctx_.get(), nullptr, {left, 0}, {right, 0}, std::move(hashKeys), std::move(probeKeys));
@@ -336,10 +336,10 @@ TEST_F(JoinTest, LeftJoinTwice) {
 
     std::string left = joinOutput;
     std::string right = "var3";
-    auto key = *VariablePropertyExpression::make(pool_, left, "src");
-    std::vector<Expression*> hashKeys = {&key};
-    auto probe = *VariablePropertyExpression::make(pool_, right, "col1");
-    std::vector<Expression*> probeKeys = {&probe};
+    auto key = VariablePropertyExpression::make(pool_, left, "src");
+    std::vector<Expression*> hashKeys = {key};
+    auto probe = VariablePropertyExpression::make(pool_, right, "col1");
+    std::vector<Expression*> probeKeys = {probe};
 
     auto* join = LeftJoin::make(
         qctx_.get(), nullptr, {left, 0}, {right, 0}, std::move(hashKeys), std::move(probeKeys));
@@ -421,10 +421,10 @@ TEST_F(JoinTest, LeftJoinAndInnerjoin) {
     {
         std::string left = "var1";
         std::string right = "var2";
-        auto key = *VariablePropertyExpression::make(pool_, left, "_vid");
-        std::vector<Expression*> hashKeys = {&key};
-        auto probe = *VariablePropertyExpression::make(pool_, right, "dst");
-        std::vector<Expression*> probeKeys = {&probe};
+        auto key = VariablePropertyExpression::make(pool_, left, "_vid");
+        std::vector<Expression*> hashKeys = {key};
+        auto probe = VariablePropertyExpression::make(pool_, right, "dst");
+        std::vector<Expression*> probeKeys = {probe};
 
         auto* join = LeftJoin::make(
             qctx_.get(), nullptr, {left, 0}, {right, 0}, std::move(hashKeys), std::move(probeKeys));
@@ -439,10 +439,10 @@ TEST_F(JoinTest, LeftJoinAndInnerjoin) {
 
     std::string left = joinOutput;
     std::string right = "var3";
-    auto key = *VariablePropertyExpression::make(pool_, left, "src");
-    std::vector<Expression*> hashKeys = {&key};
-    auto probe = *VariablePropertyExpression::make(pool_, right, "col1");
-    std::vector<Expression*> probeKeys = {&probe};
+    auto key = VariablePropertyExpression::make(pool_, left, "src");
+    std::vector<Expression*> hashKeys = {key};
+    auto probe = VariablePropertyExpression::make(pool_, right, "col1");
+    std::vector<Expression*> probeKeys = {probe};
 
     auto* join = InnerJoin::make(
         qctx_.get(), nullptr, {left, 0}, {right, 0}, std::move(hashKeys), std::move(probeKeys));
@@ -490,10 +490,10 @@ TEST_F(JoinTest, InnerJoinAndLeftjoin) {
     {
         std::string left = "var1";
         std::string right = "var2";
-        auto key = *VariablePropertyExpression::make(pool_, left, "_vid");
-        std::vector<Expression*> hashKeys = {&key};
-        auto probe = *VariablePropertyExpression::make(pool_, right, "dst");
-        std::vector<Expression*> probeKeys = {&probe};
+        auto key = VariablePropertyExpression::make(pool_, left, "_vid");
+        std::vector<Expression*> hashKeys = {key};
+        auto probe = VariablePropertyExpression::make(pool_, right, "dst");
+        std::vector<Expression*> probeKeys = {probe};
 
         auto* join = InnerJoin::make(
             qctx_.get(), nullptr, {left, 0}, {right, 0}, std::move(hashKeys), std::move(probeKeys));
@@ -508,10 +508,10 @@ TEST_F(JoinTest, InnerJoinAndLeftjoin) {
 
     std::string left = joinOutput;
     std::string right = "var3";
-    auto key = *VariablePropertyExpression::make(pool_, left, "src");
-    std::vector<Expression*> hashKeys = {&key};
-    auto probe = *VariablePropertyExpression::make(pool_, right, "col1");
-    std::vector<Expression*> probeKeys = {&probe};
+    auto key = VariablePropertyExpression::make(pool_, left, "src");
+    std::vector<Expression*> hashKeys = {key};
+    auto probe = VariablePropertyExpression::make(pool_, right, "col1");
+    std::vector<Expression*> probeKeys = {probe};
 
     auto* join = LeftJoin::make(
         qctx_.get(), nullptr, {left, 0}, {right, 0}, std::move(hashKeys), std::move(probeKeys));

--- a/src/executor/test/JoinTest.cpp
+++ b/src/executor/test/JoinTest.cpp
@@ -18,6 +18,8 @@ class JoinTest : public QueryTestBase {
 protected:
     void SetUp() override {
         qctx_ = std::make_unique<QueryContext>();
+        pool_ = qctx_->objPool();
+
         {
             DataSet ds;
             ds.colNames = {kVid, "tag_prop", "edge_prop", kDst};
@@ -82,13 +84,14 @@ protected:
 
 protected:
     std::unique_ptr<QueryContext> qctx_;
+    ObjectPool* pool_;
 };
 
 void JoinTest::testInnerJoin(std::string left, std::string right,
                             DataSet& expected, int64_t line) {
-    VariablePropertyExpression key(left, "dst");
+    auto key = *VariablePropertyExpression::make(pool_, left, "dst");
     std::vector<Expression*> hashKeys = {&key};
-    VariablePropertyExpression probe(right, "_vid");
+    auto probe = *VariablePropertyExpression::make(pool_, right, "_vid");
     std::vector<Expression*> probeKeys = {&probe};
 
     auto* join =
@@ -124,9 +127,9 @@ void JoinTest::testInnerJoin(std::string left, std::string right,
 
 void JoinTest::testLeftJoin(std::string left, std::string right,
                             DataSet& expected, int64_t line) {
-    VariablePropertyExpression key(left, "_vid");
+    auto key = *VariablePropertyExpression::make(pool_, left, "_vid");
     std::vector<Expression*> hashKeys = {&key};
-    VariablePropertyExpression probe(right, "dst");
+    auto probe = *VariablePropertyExpression::make(pool_, right, "dst");
     std::vector<Expression*> probeKeys = {&probe};
 
     auto* join =
@@ -193,9 +196,9 @@ TEST_F(JoinTest, InnerJoinTwice) {
     {
         std::string left = "var2";
         std::string right = "var1";
-        VariablePropertyExpression key(left, "dst");
+        auto key = *VariablePropertyExpression::make(pool_, left, "dst");
         std::vector<Expression*> hashKeys = {&key};
-        VariablePropertyExpression probe(right, "_vid");
+        auto probe = *VariablePropertyExpression::make(pool_, right, "_vid");
         std::vector<Expression*> probeKeys = {&probe};
 
         auto* join =
@@ -213,9 +216,9 @@ TEST_F(JoinTest, InnerJoinTwice) {
 
     std::string left = joinOutput;
     std::string right = "var3";
-    VariablePropertyExpression key(left, "src");
+    auto key = *VariablePropertyExpression::make(pool_, left, "src");
     std::vector<Expression*> hashKeys = {&key};
-    VariablePropertyExpression probe(right, "col1");
+    auto probe = *VariablePropertyExpression::make(pool_, right, "col1");
     std::vector<Expression*> probeKeys = {&probe};
 
     auto* join =
@@ -315,9 +318,9 @@ TEST_F(JoinTest, LeftJoinTwice) {
     {
         std::string left = "var1";
         std::string right = "var2";
-        VariablePropertyExpression key(left, "_vid");
+        auto key = *VariablePropertyExpression::make(pool_, left, "_vid");
         std::vector<Expression*> hashKeys = {&key};
-        VariablePropertyExpression probe(right, "dst");
+        auto probe = *VariablePropertyExpression::make(pool_, right, "dst");
         std::vector<Expression*> probeKeys = {&probe};
 
         auto* join = LeftJoin::make(
@@ -333,9 +336,9 @@ TEST_F(JoinTest, LeftJoinTwice) {
 
     std::string left = joinOutput;
     std::string right = "var3";
-    VariablePropertyExpression key(left, "src");
+    auto key = *VariablePropertyExpression::make(pool_, left, "src");
     std::vector<Expression*> hashKeys = {&key};
-    VariablePropertyExpression probe(right, "col1");
+    auto probe = *VariablePropertyExpression::make(pool_, right, "col1");
     std::vector<Expression*> probeKeys = {&probe};
 
     auto* join = LeftJoin::make(
@@ -418,9 +421,9 @@ TEST_F(JoinTest, LeftJoinAndInnerjoin) {
     {
         std::string left = "var1";
         std::string right = "var2";
-        VariablePropertyExpression key(left, "_vid");
+        auto key = *VariablePropertyExpression::make(pool_, left, "_vid");
         std::vector<Expression*> hashKeys = {&key};
-        VariablePropertyExpression probe(right, "dst");
+        auto probe = *VariablePropertyExpression::make(pool_, right, "dst");
         std::vector<Expression*> probeKeys = {&probe};
 
         auto* join = LeftJoin::make(
@@ -436,9 +439,9 @@ TEST_F(JoinTest, LeftJoinAndInnerjoin) {
 
     std::string left = joinOutput;
     std::string right = "var3";
-    VariablePropertyExpression key(left, "src");
+    auto key = *VariablePropertyExpression::make(pool_, left, "src");
     std::vector<Expression*> hashKeys = {&key};
-    VariablePropertyExpression probe(right, "col1");
+    auto probe = *VariablePropertyExpression::make(pool_, right, "col1");
     std::vector<Expression*> probeKeys = {&probe};
 
     auto* join = InnerJoin::make(
@@ -487,9 +490,9 @@ TEST_F(JoinTest, InnerJoinAndLeftjoin) {
     {
         std::string left = "var1";
         std::string right = "var2";
-        VariablePropertyExpression key(left, "_vid");
+        auto key = *VariablePropertyExpression::make(pool_, left, "_vid");
         std::vector<Expression*> hashKeys = {&key};
-        VariablePropertyExpression probe(right, "dst");
+        auto probe = *VariablePropertyExpression::make(pool_, right, "dst");
         std::vector<Expression*> probeKeys = {&probe};
 
         auto* join = InnerJoin::make(
@@ -505,9 +508,9 @@ TEST_F(JoinTest, InnerJoinAndLeftjoin) {
 
     std::string left = joinOutput;
     std::string right = "var3";
-    VariablePropertyExpression key(left, "src");
+    auto key = *VariablePropertyExpression::make(pool_, left, "src");
     std::vector<Expression*> hashKeys = {&key};
-    VariablePropertyExpression probe(right, "col1");
+    auto probe = *VariablePropertyExpression::make(pool_, right, "col1");
     std::vector<Expression*> probeKeys = {&probe};
 
     auto* join = LeftJoin::make(

--- a/src/executor/test/LimitTest.cpp
+++ b/src/executor/test/LimitTest.cpp
@@ -31,7 +31,7 @@ class LimitTest : public QueryTestBase {
         auto& limitResult = qctx_->ectx()->getResult(limitNode->outputVar());                      \
         EXPECT_EQ(limitResult.state(), Result::State::kSuccess);                                   \
         auto yieldSentence =                                                                       \
-            getYieldSentence("YIELD $-.v_name AS name, $-.e_start_year AS start");                 \
+            getYieldSentence("YIELD $-.v_name AS name, $-.e_start_year AS start", qctx_.get());    \
         auto columns = yieldSentence->columns();                                                   \
         auto* project = Project::make(qctx_.get(), limitNode, yieldSentence->yieldColumns());      \
         project->setInputVar(limitNode->outputVar());                                              \

--- a/src/executor/test/LogicExecutorsTest.cpp
+++ b/src/executor/test/LogicExecutorsTest.cpp
@@ -20,10 +20,12 @@ class LogicExecutorsTest : public testing::Test {
 protected:
     void SetUp() override {
         qctx_ = std::make_unique<QueryContext>();
+        pool_ = qctx_->objPool();
     }
 
 protected:
     std::unique_ptr<QueryContext> qctx_;
+    ObjectPool* pool_;
 };
 
 TEST_F(LogicExecutorsTest, Start) {
@@ -38,14 +40,14 @@ TEST_F(LogicExecutorsTest, Loop) {
     std::string counter = "counter";
     qctx_->ectx()->setValue(counter, 0);
     // ++counter{0} <= 5
-    auto condition = std::make_unique<RelationalExpression>(
-        Expression::Kind::kRelLE,
-        new UnaryExpression(
-            Expression::Kind::kUnaryIncr,
-            new VersionedVariableExpression(counter, ConstantExpression::make(pool0))),
-        ConstantExpression::make(poolstatic_cast<int32_t>(5)));
+    auto condition = RelationalExpression::makeLE(
+        pool_,
+        UnaryExpression::makeIncr(
+            pool_,
+            VersionedVariableExpression::make(pool_, counter, ConstantExpression::make(pool_, 0))),
+        ConstantExpression::make(pool_, static_cast<int32_t>(5)));
     auto* start = StartNode::make(qctx_.get());
-    auto* loop = Loop::make(qctx_.get(), start, start, condition.get());
+    auto* loop = Loop::make(qctx_.get(), start, start, condition);
     auto loopExe = Executor::create(loop, qctx_.get());
     for (size_t i = 0; i < 5; ++i) {
         auto f = loopExe->execute();
@@ -69,8 +71,8 @@ TEST_F(LogicExecutorsTest, Loop) {
 TEST_F(LogicExecutorsTest, Select) {
     {
         auto* start = StartNode::make(qctx_.get());
-        auto condition = std::make_unique<ConstantExpression>(true);
-        auto* select = Select::make(qctx_.get(), start, start, start, condition.get());
+        auto condition = ConstantExpression::make(pool_, true);
+        auto* select = Select::make(qctx_.get(), start, start, start, condition);
 
         auto selectExe = Executor::create(select, qctx_.get());
 
@@ -84,8 +86,8 @@ TEST_F(LogicExecutorsTest, Select) {
     }
     {
         auto* start = StartNode::make(qctx_.get());
-        auto condition = std::make_unique<ConstantExpression>(false);
-        auto* select = Select::make(qctx_.get(), start, start, start, condition.get());
+        auto condition = ConstantExpression::make(pool_, false);
+        auto* select = Select::make(qctx_.get(), start, start, start, condition);
 
         auto selectExe = Executor::create(select, qctx_.get());
 

--- a/src/executor/test/LogicExecutorsTest.cpp
+++ b/src/executor/test/LogicExecutorsTest.cpp
@@ -40,9 +40,10 @@ TEST_F(LogicExecutorsTest, Loop) {
     // ++counter{0} <= 5
     auto condition = std::make_unique<RelationalExpression>(
         Expression::Kind::kRelLE,
-        new UnaryExpression(Expression::Kind::kUnaryIncr,
-                            new VersionedVariableExpression(counter, new ConstantExpression(0))),
-        new ConstantExpression(static_cast<int32_t>(5)));
+        new UnaryExpression(
+            Expression::Kind::kUnaryIncr,
+            new VersionedVariableExpression(counter, ConstantExpression::make(pool0))),
+        ConstantExpression::make(poolstatic_cast<int32_t>(5)));
     auto* start = StartNode::make(qctx_.get());
     auto* loop = Loop::make(qctx_.get(), start, start, condition.get());
     auto loopExe = Executor::create(loop, qctx_.get());

--- a/src/executor/test/ProjectTest.cpp
+++ b/src/executor/test/ProjectTest.cpp
@@ -52,7 +52,7 @@ protected:
 
 TEST_F(ProjectTest, Project1Col) {
     std::string input = "input_project";
-    auto yieldColumns = getYieldColumns("YIELD $input_project.vid AS vid");
+    auto yieldColumns = getYieldColumns("YIELD $input_project.vid AS vid", qctx_.get());
 
     auto* project = Project::make(qctx_.get(), start_, yieldColumns);
     project->setInputVar(input);
@@ -77,8 +77,8 @@ TEST_F(ProjectTest, Project1Col) {
 
 TEST_F(ProjectTest, Project2Col) {
     std::string input = "input_project";
-    auto yieldColumns = getYieldColumns(
-            "YIELD $input_project.vid AS vid, $input_project.col2 AS num");
+    auto yieldColumns =
+        getYieldColumns("YIELD $input_project.vid AS vid, $input_project.col2 AS num", qctx_.get());
     auto* project = Project::make(qctx_.get(), start_, yieldColumns);
     project->setInputVar(input);
     project->setColNames(std::vector<std::string>{"vid", "num"});
@@ -103,7 +103,7 @@ TEST_F(ProjectTest, Project2Col) {
 
 TEST_F(ProjectTest, EmptyInput) {
     std::string input = "empty";
-    auto yieldColumns = getYieldColumns("YIELD $input_project.vid AS vid");
+    auto yieldColumns = getYieldColumns("YIELD $input_project.vid AS vid", qctx_.get());
     auto* project = Project::make(qctx_.get(), start_, std::move(yieldColumns));
     project->setInputVar(input);
     project->setColNames(std::vector<std::string>{"vid"});

--- a/src/executor/test/QueryTestBase.h
+++ b/src/executor/test/QueryTestBase.h
@@ -128,8 +128,8 @@ protected:
         }
     }
 
-    YieldSentence* getYieldSentence(const std::string &query) {
-        auto ret = GQLParser().parse(query);
+    YieldSentence* getYieldSentence(const std::string& query, QueryContext* qctx) {
+        auto ret = GQLParser(qctx).parse(query);
         CHECK(ret.ok()) << ret.status();
         sentences_ = std::move(ret).value();
         CHECK_EQ(sentences_->kind(), Sentence::Kind::kSequential);
@@ -139,20 +139,19 @@ protected:
         return static_cast<YieldSentence*>(sens[0]);
     }
 
-    YieldColumns* getYieldColumns(const std::string &query) {
-        auto yieldSentence = getYieldSentence(query);
+    YieldColumns* getYieldColumns(const std::string& query, QueryContext* qctx) {
+        auto yieldSentence = getYieldSentence(query, qctx);
         CHECK(yieldSentence);
         return yieldSentence->yieldColumns();
     }
 
-    Expression* getYieldFilter(const std::string &query) {
-        auto yieldSentence = getYieldSentence(query);
+    Expression* getYieldFilter(const std::string& query, QueryContext* qctx) {
+        auto yieldSentence = getYieldSentence(query, qctx);
         CHECK(yieldSentence);
         auto where = yieldSentence->where();
         CHECK(where);
         return where->filter();
     }
-
 
 protected:
     std::unique_ptr<QueryContext>         qctx_;

--- a/src/executor/test/SortTest.cpp
+++ b/src/executor/test/SortTest.cpp
@@ -39,7 +39,7 @@ class SortTest : public QueryTestBase {};
             sentence = "YIELD $-.v_age AS age";                                                    \
             colNames.emplace_back("age");                                                          \
         }                                                                                          \
-        auto yieldSentence = getYieldSentence(sentence);                                           \
+        auto yieldSentence = getYieldSentence(sentence, qctx_.get());                              \
         auto* project = Project::make(qctx_.get(), start, yieldSentence->yieldColumns());          \
         project->setInputVar(sortNode->outputVar());                                               \
         project->setColNames(std::move(colNames));                                                 \

--- a/src/executor/test/TopNTest.cpp
+++ b/src/executor/test/TopNTest.cpp
@@ -39,7 +39,7 @@ class TopNTest : public QueryTestBase {};
             sentence = "YIELD $-.v_age AS age";                                                    \
             colNames.emplace_back("age");                                                          \
         }                                                                                          \
-        auto yieldSentence = getYieldSentence(sentence);                                           \
+        auto yieldSentence = getYieldSentence(sentence, qctx_.get());                              \
         auto* project = Project::make(qctx_.get(), start, yieldSentence->yieldColumns());          \
         project->setInputVar(topnNode->outputVar());                                               \
         project->setColNames(std::move(colNames));                                                 \

--- a/src/executor/test/UnwindTest.cpp
+++ b/src/executor/test/UnwindTest.cpp
@@ -19,12 +19,13 @@ class UnwindTest : public QueryTestBase {
 protected:
     void SetUp() override {
         qctx_ = std::make_unique<QueryContext>();
+        pool_ = qctx_->objPool();
         start_ = StartNode::make(qctx_.get());
     }
 
     void testUnwind(std::vector<Value> l) {
-        auto list = std::make_unique<ConstantExpression>(List(l));
-        auto* unwind = Unwind::make(qctx_.get(), start_, list.get(), "items");
+        auto list = ConstantExpression::make(pool_, List(l));
+        auto* unwind = Unwind::make(qctx_.get(), start_, list, "items");
         unwind->setColNames(std::vector<std::string>{"items"});
 
         auto unwExe = Executor::create(unwind, qctx_.get());
@@ -46,6 +47,7 @@ protected:
 
 protected:
     std::unique_ptr<QueryContext> qctx_;
+    ObjectPool* pool_;
     StartNode* start_;
 };
 

--- a/src/optimizer/rule/CombineFilterRule.cpp
+++ b/src/optimizer/rule/CombineFilterRule.cpp
@@ -51,9 +51,7 @@ StatusOr<OptRule::TransformResult> CombineFilterRule::transform(
         auto* newFilter = static_cast<graph::Filter*>(filterBelow->clone());
         const auto* conditionBelow = newFilter->condition();
         auto* conditionCombine =
-            qctx->objPool()->add(LogicalExpression::makeAnd(pool,
-                                                       conditionAbove->clone(),
-                                                       conditionBelow->clone()));
+            LogicalExpression::makeAnd(pool, conditionAbove->clone(), conditionBelow->clone());
         newFilter->setCondition(conditionCombine);
         newFilter->setOutputVar(filterAbove->outputVar());
         auto* newGroupNode = OptGroupNode::create(octx, newFilter, filterGroup);

--- a/src/optimizer/rule/CombineFilterRule.cpp
+++ b/src/optimizer/rule/CombineFilterRule.cpp
@@ -40,6 +40,7 @@ StatusOr<OptRule::TransformResult> CombineFilterRule::transform(
     const auto& deps = matched.dependencies;
     const auto* filterGroup = filterGroupNode->group();
     auto* qctx = octx->qctx();
+    auto* pool = qctx->objPool();
 
     TransformResult result;
     result.eraseAll = true;
@@ -50,9 +51,9 @@ StatusOr<OptRule::TransformResult> CombineFilterRule::transform(
         auto* newFilter = static_cast<graph::Filter*>(filterBelow->clone());
         const auto* conditionBelow = newFilter->condition();
         auto* conditionCombine =
-            qctx->objPool()->add(new LogicalExpression(Expression::Kind::kLogicalAnd,
-                                                       conditionAbove->clone().release(),
-                                                       conditionBelow->clone().release()));
+            qctx->objPool()->add(LogicalExpression::makeAnd(pool,
+                                                       conditionAbove->clone(),
+                                                       conditionBelow->clone()));
         newFilter->setCondition(conditionCombine);
         newFilter->setOutputVar(filterAbove->outputVar());
         auto* newGroupNode = OptGroupNode::create(octx, newFilter, filterGroup);

--- a/src/optimizer/rule/IndexScanRule.cpp
+++ b/src/optimizer/rule/IndexScanRule.cpp
@@ -305,7 +305,7 @@ GraphSpaceID IndexScanRule::spaceId(const OptGroupNode *groupNode) const {
 Expression* IndexScanRule::filterExpr(const OptGroupNode* groupNode) const {
     auto in = static_cast<const IndexScan*>(groupNode->node());
     auto qct = in->queryContext();
-    // The initial IndexScan plan node has only zeor or one queryContext.
+    // The initial IndexScan plan node has only zero or one queryContext.
     // TODO(yee): Move this condition to match interface
     if (qct == nullptr) {
         return nullptr;

--- a/src/optimizer/rule/IndexScanRule.cpp
+++ b/src/optimizer/rule/IndexScanRule.cpp
@@ -45,7 +45,7 @@ StatusOr<OptRule::TransformResult> IndexScanRule::transform(OptContext* ctx,
     } else {
         FilterItems items;
         ScanKind kind;
-        NG_RETURN_IF_ERROR(analyzeExpression(filter.get(), &items, &kind, isEdge(groupNode)));
+        NG_RETURN_IF_ERROR(analyzeExpression(filter, &items, &kind, isEdge(groupNode)));
         NG_RETURN_IF_ERROR(createIndexQueryCtx(iqctx, kind, items, qctx, groupNode));
     }
 
@@ -302,9 +302,8 @@ GraphSpaceID IndexScanRule::spaceId(const OptGroupNode *groupNode) const {
     return in->space();
 }
 
-std::unique_ptr<Expression>
-IndexScanRule::filterExpr(const OptGroupNode *groupNode) const {
-    auto in = static_cast<const IndexScan *>(groupNode->node());
+Expression* IndexScanRule::filterExpr(const OptGroupNode* groupNode) const {
+    auto in = static_cast<const IndexScan*>(groupNode->node());
     auto qct = in->queryContext();
     // The initial IndexScan plan node has only zeor or one queryContext.
     // TODO(yee): Move this condition to match interface
@@ -316,7 +315,8 @@ IndexScanRule::filterExpr(const OptGroupNode *groupNode) const {
         LOG(ERROR) << "Index Scan plan node error";
         return nullptr;
     }
-    return Expression::decode(qct->begin()->get_filter());
+    auto* pool = in->qctx()->objPool();
+    return Expression::decode(pool, qct->begin()->get_filter());
 }
 
 Status IndexScanRule::analyzeExpression(Expression* expr,

--- a/src/optimizer/rule/IndexScanRule.h
+++ b/src/optimizer/rule/IndexScanRule.h
@@ -142,7 +142,7 @@ private:
 
     GraphSpaceID spaceId(const OptGroupNode *groupNode) const;
 
-    std::unique_ptr<Expression> filterExpr(const OptGroupNode *groupNode) const;
+    Expression* filterExpr(const OptGroupNode *groupNode) const;
 
     Status analyzeExpression(Expression* expr, FilterItems* items,
                              ScanKind* kind, bool isEdge) const;

--- a/src/optimizer/rule/MergeGetNbrsAndProjectRule.cpp
+++ b/src/optimizer/rule/MergeGetNbrsAndProjectRule.cpp
@@ -63,10 +63,9 @@ StatusOr<OptRule::TransformResult> MergeGetNbrsAndProjectRule::transform(
     DCHECK_EQ(optProj->node()->kind(), PlanNode::Kind::kProject);
     auto gn = static_cast<const GetNeighbors *>(optGN->node());
     auto project = static_cast<const Project *>(optProj->node());
-    auto qctx = ctx->qctx();
     auto newGN = static_cast<GetNeighbors *>(gn->clone());
     auto column = project->columns()->back();
-    auto srcExpr = qctx->objPool()->add(column->expr()->clone().release());
+    auto srcExpr = column->expr()->clone();
     newGN->setSrc(srcExpr);
     newGN->setInputVar(project->inputVar());
     auto newOptGV = OptGroupNode::create(ctx, newGN, optGN->group());

--- a/src/optimizer/rule/MergeGetVerticesAndProjectRule.cpp
+++ b/src/optimizer/rule/MergeGetVerticesAndProjectRule.cpp
@@ -64,8 +64,7 @@ StatusOr<OptRule::TransformResult> MergeGetVerticesAndProjectRule::transform(
     auto project = static_cast<const Project *>(optProj->node());
     auto newGV = static_cast<GetVertices *>(gv->clone());
     auto column = project->columns()->back();
-    auto qctx = ctx->qctx();
-    auto srcExpr = qctx->objPool()->add(column->expr()->clone().release());
+    auto srcExpr = column->expr()->clone();
     newGV->setSrc(srcExpr);
     newGV->setInputVar(project->inputVar());
     auto newOptGV = OptGroupNode::create(ctx, newGV, optGV->group());

--- a/src/optimizer/rule/PushFilterDownAggregateRule.cpp
+++ b/src/optimizer/rule/PushFilterDownAggregateRule.cpp
@@ -85,7 +85,7 @@ StatusOr<OptRule::TransformResult> PushFilterDownAggregateRule::transform(
     auto rewriter = [&rewriteMap](const Expression* e) -> Expression* {
         DCHECK_EQ(e->kind(), Expression::Kind::kVarProperty);
         auto& propName = static_cast<const VariablePropertyExpression*>(e)->prop();
-        return rewriteMap[propName]->clone().release();
+        return rewriteMap[propName]->clone();
     };
     auto* newCondition =
         graph::RewriteVisitor::transform(condition, std::move(matcher), std::move(rewriter));

--- a/src/optimizer/rule/PushFilterDownAggregateRule.cpp
+++ b/src/optimizer/rule/PushFilterDownAggregateRule.cpp
@@ -36,7 +36,6 @@ const Pattern& PushFilterDownAggregateRule::pattern() const {
 StatusOr<OptRule::TransformResult> PushFilterDownAggregateRule::transform(
     OptContext* octx,
     const MatchedResult& matched) const {
-    auto qctx = octx->qctx();
     auto* filterGroupNode = matched.node;
     auto* oldFilterNode = filterGroupNode->node();
     auto deps = matched.dependencies;
@@ -89,7 +88,6 @@ StatusOr<OptRule::TransformResult> PushFilterDownAggregateRule::transform(
     };
     auto* newCondition =
         graph::RewriteVisitor::transform(condition, std::move(matcher), std::move(rewriter));
-    qctx->objPool()->add(newCondition);
     newFilterNode->setCondition(newCondition);
 
     // Exchange planNode

--- a/src/optimizer/rule/PushFilterDownGetNbrsRule.cpp
+++ b/src/optimizer/rule/PushFilterDownGetNbrsRule.cpp
@@ -47,20 +47,20 @@ StatusOr<OptRule::TransformResult> PushFilterDownGetNbrsRule::transform(
     auto gnGroupNode = matched.dependencies.front().node;
     auto filter = static_cast<const Filter *>(filterGroupNode->node());
     auto gn = static_cast<const GetNeighbors *>(gnGroupNode->node());
-
+    auto qctx = ctx->qctx();
+    auto pool = qctx->objPool();
     auto condition = filter->condition()->clone();
-    graph::ExtractFilterExprVisitor visitor;
+
+    graph::ExtractFilterExprVisitor visitor(pool);
     condition->accept(&visitor);
     if (!visitor.ok()) {
         return TransformResult::noTransform();
     }
 
-    auto qctx = ctx->qctx();
-    auto pool = qctx->objPool();
     auto remainedExpr = std::move(visitor).remainedExpr();
     OptGroupNode *newFilterGroupNode = nullptr;
     if (remainedExpr != nullptr) {
-        auto newFilter = Filter::make(qctx, nullptr, pool->add(remainedExpr.release()));
+        auto newFilter = Filter::make(qctx, nullptr, pool->add(remainedExpr));
         newFilter->setOutputVar(filter->outputVar());
         newFilter->setInputVar(filter->inputVar());
         newFilterGroupNode = OptGroupNode::create(ctx, newFilter, filterGroupNode->group());
@@ -68,9 +68,8 @@ StatusOr<OptRule::TransformResult> PushFilterDownGetNbrsRule::transform(
 
     auto newGNFilter = condition->encode();
     if (!gn->filter().empty()) {
-        auto filterExpr = Expression::decode(gn->filter());
-        LogicalExpression logicExpr(
-            Expression::Kind::kLogicalAnd, condition.release(), filterExpr.release());
+        auto filterExpr = Expression::decode(pool, gn->filter());
+        auto logicExpr = *LogicalExpression::makeAnd(pool, condition, filterExpr);
         newGNFilter = logicExpr.encode();
     }
 

--- a/src/optimizer/rule/PushFilterDownGetNbrsRule.cpp
+++ b/src/optimizer/rule/PushFilterDownGetNbrsRule.cpp
@@ -69,8 +69,8 @@ StatusOr<OptRule::TransformResult> PushFilterDownGetNbrsRule::transform(
     auto newGNFilter = condition->encode();
     if (!gn->filter().empty()) {
         auto filterExpr = Expression::decode(pool, gn->filter());
-        auto logicExpr = *LogicalExpression::makeAnd(pool, condition, filterExpr);
-        newGNFilter = logicExpr.encode();
+        auto logicExpr = LogicalExpression::makeAnd(pool, condition, filterExpr);
+        newGNFilter = logicExpr->encode();
     }
 
     auto newGN = static_cast<GetNeighbors *>(gn->clone());

--- a/src/optimizer/rule/PushFilterDownGetNbrsRule.cpp
+++ b/src/optimizer/rule/PushFilterDownGetNbrsRule.cpp
@@ -60,7 +60,7 @@ StatusOr<OptRule::TransformResult> PushFilterDownGetNbrsRule::transform(
     auto remainedExpr = std::move(visitor).remainedExpr();
     OptGroupNode *newFilterGroupNode = nullptr;
     if (remainedExpr != nullptr) {
-        auto newFilter = Filter::make(qctx, nullptr, pool->add(remainedExpr));
+        auto newFilter = Filter::make(qctx, nullptr, remainedExpr);
         newFilter->setOutputVar(filter->outputVar());
         newFilter->setInputVar(filter->inputVar());
         newFilterGroupNode = OptGroupNode::create(ctx, newFilter, filterGroupNode->group());

--- a/src/optimizer/rule/PushFilterDownLeftJoinRule.cpp
+++ b/src/optimizer/rule/PushFilterDownLeftJoinRule.cpp
@@ -83,8 +83,7 @@ StatusOr<OptRule::TransformResult> PushFilterDownLeftJoinRule::transform(
     auto* newLeftFilterNode = graph::Filter::make(
         octx->qctx(),
         const_cast<graph::PlanNode*>(oldLeftJoinNode->dep()),
-        objPool->add(
-            graph::ExpressionUtils::rewriteInnerVar(objPool, filterPicked, leftVar.first)));
+        graph::ExpressionUtils::rewriteInnerVar(objPool, filterPicked, leftVar.first));
     newLeftFilterNode->setInputVar(leftVar.first);
     newLeftFilterNode->setColNames(leftVarColNames);
     auto newFilterGroup = OptGroup::create(octx);
@@ -100,8 +99,8 @@ StatusOr<OptRule::TransformResult> PushFilterDownLeftJoinRule::transform(
     const std::vector<Expression*>& hashKeys = oldLeftJoinNode->hashKeys();
     std::vector<Expression*> newHashKeys;
     for (auto* k : hashKeys) {
-        newHashKeys.emplace_back(objPool->add(
-            graph::ExpressionUtils::rewriteInnerVar(objPool, k, newLeftFilterOutputVar)));
+        newHashKeys.emplace_back(
+            graph::ExpressionUtils::rewriteInnerVar(objPool, k, newLeftFilterOutputVar));
     }
     newLeftJoinNode->setHashKeys(newHashKeys);
 
@@ -110,7 +109,7 @@ StatusOr<OptRule::TransformResult> PushFilterDownLeftJoinRule::transform(
     if (filterUnpicked) {
         auto* newAboveFilterNode = graph::Filter::make(octx->qctx(), newLeftJoinNode);
         newAboveFilterNode->setOutputVar(oldFilterNode->outputVar());
-        newAboveFilterNode->setCondition(objPool->add(filterUnpicked));
+        newAboveFilterNode->setCondition(filterUnpicked);
         auto newAboveFilterGroupNode =
             OptGroupNode::create(octx, newAboveFilterNode, filterGroupNode->group());
 
@@ -127,7 +126,6 @@ StatusOr<OptRule::TransformResult> PushFilterDownLeftJoinRule::transform(
         newLeftJoinGroupNode->setDeps({newFilterGroup});
         result.newGroupNodes.emplace_back(newLeftJoinGroupNode);
     }
-
     return result;
 }
 

--- a/src/optimizer/rule/PushFilterDownLeftJoinRule.cpp
+++ b/src/optimizer/rule/PushFilterDownLeftJoinRule.cpp
@@ -71,8 +71,8 @@ StatusOr<OptRule::TransformResult> PushFilterDownLeftJoinRule::transform(
         }
         return true;
     };
-    Expression* filterPicked;
-    Expression* filterUnpicked;
+    Expression* filterPicked = nullptr;
+    Expression* filterUnpicked = nullptr;
     graph::ExpressionUtils::splitFilter(objPool, condition, picker, &filterPicked, &filterUnpicked);
 
     if (!filterPicked) {

--- a/src/optimizer/rule/PushFilterDownProjectRule.cpp
+++ b/src/optimizer/rule/PushFilterDownProjectRule.cpp
@@ -110,9 +110,8 @@ StatusOr<OptRule::TransformResult> PushFilterDownProjectRule::transform(
                                       filterPicked, std::move(matcher), std::move(rewriter));
 
     // produce new Filter node below
-    auto* newBelowFilterNode = graph::Filter::make(octx->qctx(),
-                                                   const_cast<graph::PlanNode*>(oldProjNode->dep()),
-                                                   objPool->add(newFilterPicked));
+    auto* newBelowFilterNode = graph::Filter::make(
+        octx->qctx(), const_cast<graph::PlanNode*>(oldProjNode->dep()), newFilterPicked);
     newBelowFilterNode->setInputVar(oldProjNode->inputVar());
     auto newBelowFilterGroup = OptGroup::create(octx);
     auto newFilterGroupNode = newBelowFilterGroup->makeGroupNode(newBelowFilterNode);
@@ -128,8 +127,7 @@ StatusOr<OptRule::TransformResult> PushFilterDownProjectRule::transform(
     result.eraseAll = true;
     if (filterUnpicked) {
         // produce new Filter node above
-        auto* newAboveFilterNode =
-            graph::Filter::make(octx->qctx(), newProjNode, objPool->add(filterUnpicked));
+        auto* newAboveFilterNode = graph::Filter::make(octx->qctx(), newProjNode, filterUnpicked);
         newAboveFilterNode->setOutputVar(oldFilterNode->outputVar());
         auto newAboveFilterGroupNode =
             OptGroupNode::create(octx, newAboveFilterNode, filterGroupNode->group());

--- a/src/optimizer/rule/PushFilterDownProjectRule.cpp
+++ b/src/optimizer/rule/PushFilterDownProjectRule.cpp
@@ -84,8 +84,8 @@ StatusOr<OptRule::TransformResult> PushFilterDownProjectRule::transform(
         }
         return true;
     };
-    Expression* filterPicked;
-    Expression* filterUnpicked;
+    Expression* filterPicked = nullptr;
+    Expression* filterUnpicked = nullptr;
     graph::ExpressionUtils::splitFilter(objPool, condition, picker, &filterPicked, &filterUnpicked);
 
     if (!filterPicked) {

--- a/src/parser/AdminSentences.h
+++ b/src/parser/AdminSentences.h
@@ -419,7 +419,7 @@ public:
     ConfigRowItem(meta::cpp2::ConfigModule module, std::string* name, Expression* value) {
         module_ = module;
         name_.reset(name);
-        value_.reset(value);
+        value_ = value;
     }
 
     ConfigRowItem(meta::cpp2::ConfigModule module, std::string* name) {
@@ -442,7 +442,7 @@ public:
     }
 
     Expression* getValue() const {
-        return value_.get();
+        return value_;
     }
 
     const UpdateList* getUpdateItems() const {
@@ -454,7 +454,7 @@ public:
 private:
     meta::cpp2::ConfigModule        module_;
     std::unique_ptr<std::string>    name_;
-    std::unique_ptr<Expression>     value_;
+    Expression*     value_;
     std::unique_ptr<UpdateList>     updateItems_;
 };
 

--- a/src/parser/AdminSentences.h
+++ b/src/parser/AdminSentences.h
@@ -454,7 +454,7 @@ public:
 private:
     meta::cpp2::ConfigModule        module_;
     std::unique_ptr<std::string>    name_;
-    Expression*     value_;
+    Expression*                     value_{nullptr};
     std::unique_ptr<UpdateList>     updateItems_;
 };
 

--- a/src/parser/Clauses.h
+++ b/src/parser/Clauses.h
@@ -65,7 +65,7 @@ public:
         std::vector<Expression*> result;
         result.reserve(vidList_.size());
         for (auto &expr : vidList_) {
-            result.push_back(expr.get());
+            result.push_back(expr);
         }
         return result;
     }
@@ -73,7 +73,7 @@ public:
     std::string toString() const;
 
 private:
-    std::vector<std::unique_ptr<Expression>>    vidList_;
+    std::vector<Expression*>    vidList_;
 };
 
 
@@ -84,7 +84,7 @@ public:
     }
 
     explicit VerticesClause(Expression *ref) {
-        ref_.reset(ref);
+        ref_ = ref;
     }
 
     auto vidList() const {
@@ -96,14 +96,14 @@ public:
     }
 
     auto ref() const {
-        return ref_.get();
+        return ref_;
     }
 
     std::string toString() const;
 
 protected:
-    std::unique_ptr<VertexIDList>               vidList_;
-    std::unique_ptr<Expression>                 ref_;
+    std::unique_ptr<VertexIDList> vidList_;
+    Expression *ref_;
 };
 
 class FromClause final : public VerticesClause {
@@ -227,25 +227,25 @@ private:
 class WhereClause {
 public:
     explicit WhereClause(Expression *filter) {
-        filter_.reset(filter);
+        filter_ = filter;
     }
 
     Expression* filter() const {
-        return filter_.get();
+        return filter_;
     }
 
     void setFilter(Expression* expr) {
-        filter_.reset(expr);
+        filter_ = expr;
     }
 
     std::unique_ptr<WhereClause> clone() const {
-        return std::make_unique<WhereClause>(filter_->clone().release());
+        return std::make_unique<WhereClause>(filter_->clone());
     }
 
     std::string toString() const;
 
 private:
-    std::unique_ptr<Expression>                 filter_;
+    Expression*                 filter_;
 };
 
 class WhenClause : public WhereClause {
@@ -258,20 +258,20 @@ public:
 class YieldColumn final {
 public:
     explicit YieldColumn(Expression *expr, const std::string &alias = "") {
-        expr_.reset(expr);
+        expr_ = expr;
         alias_ = alias;
     }
 
     std::unique_ptr<YieldColumn> clone() const {
-        return std::make_unique<YieldColumn>(expr_->clone().release(), alias_);
+        return std::make_unique<YieldColumn>(expr_->clone(), alias_);
     }
 
     void setExpr(Expression* expr) {
-        expr_.reset(expr);
+        expr_ = expr;
     }
 
     Expression* expr() const {
-        return expr_.get();
+        return expr_;
     }
 
     void setAlias(const std::string& alias) {
@@ -289,7 +289,7 @@ public:
     std::string toString() const;
 
 private:
-    std::unique_ptr<Expression> expr_;
+    Expression* expr_;
     std::string alias_;
 };
 

--- a/src/parser/Clauses.h
+++ b/src/parser/Clauses.h
@@ -61,7 +61,7 @@ public:
         vidList_.emplace_back(expr);
     }
 
-    std::vector<Expression*> vidList() const {
+    const std::vector<Expression*> &vidList() const {
         return vidList_;
     }
 

--- a/src/parser/Clauses.h
+++ b/src/parser/Clauses.h
@@ -196,16 +196,16 @@ private:
 class TruncateClause {
 public:
     TruncateClause(Expression* expr, bool isSample) {
-        truncate_.reset(expr);
+        truncate_ = expr;
         isSample_ = isSample;
     }
 
     Expression* truncate() const {
-        return truncate_.get();
+        return truncate_;
     }
 
     std::unique_ptr<TruncateClause> clone() const {
-        return std::make_unique<TruncateClause>(truncate_->clone().release(), isSample_);
+        return std::make_unique<TruncateClause>(truncate_->clone(), isSample_);
     }
 
     bool isSample() const {
@@ -216,7 +216,7 @@ public:
 
 private:
     bool isSample_{false};
-    std::unique_ptr<Expression> truncate_;
+    Expression* truncate_{nullptr};
 };
 
 class WhereClause {

--- a/src/parser/Clauses.h
+++ b/src/parser/Clauses.h
@@ -62,12 +62,7 @@ public:
     }
 
     std::vector<Expression*> vidList() const {
-        std::vector<Expression*> result;
-        result.reserve(vidList_.size());
-        for (auto &expr : vidList_) {
-            result.push_back(expr);
-        }
-        return result;
+        return vidList_;
     }
 
     std::string toString() const;
@@ -103,7 +98,7 @@ public:
 
 protected:
     std::unique_ptr<VertexIDList> vidList_;
-    Expression *ref_;
+    Expression *ref_{nullptr};
 };
 
 class FromClause final : public VerticesClause {
@@ -245,7 +240,7 @@ public:
     std::string toString() const;
 
 private:
-    Expression*                 filter_;
+    Expression*                 filter_{nullptr};
 };
 
 class WhenClause : public WhereClause {
@@ -289,7 +284,7 @@ public:
     std::string toString() const;
 
 private:
-    Expression* expr_;
+    Expression* expr_{nullptr};
     std::string alias_;
 };
 

--- a/src/parser/EdgeKey.h
+++ b/src/parser/EdgeKey.h
@@ -23,17 +23,17 @@ class Expression;
 class EdgeKey final {
 public:
     EdgeKey(Expression *srcid, Expression *dstid, int64_t rank) {
-        srcid_.reset(srcid);
-        dstid_.reset(dstid);
+        srcid_ = srcid;
+        dstid_ = dstid;
         rank_ = rank;
     }
 
     Expression *srcid() const {
-        return srcid_.get();
+        return srcid_;
     }
 
     Expression *dstid() const {
-        return dstid_.get();
+        return dstid_;
     }
 
     int64_t rank() {
@@ -43,8 +43,8 @@ public:
     std::string toString() const;
 
 private:
-    std::unique_ptr<Expression> srcid_;
-    std::unique_ptr<Expression> dstid_;
+    Expression* srcid_;
+    Expression* dstid_;
     EdgeRanking rank_;
 };
 
@@ -73,30 +73,30 @@ private:
 class EdgeKeyRef final {
 public:
     EdgeKeyRef(Expression *srcid, Expression *dstid, Expression *rank, bool isInputExpr = true) {
-        srcid_.reset(srcid);
-        dstid_.reset(dstid);
-        rank_.reset(rank);
+        srcid_ = srcid;
+        dstid_ = dstid;
+        rank_ = rank;
         isInputExpr_ = isInputExpr;
     }
 
     Expression *srcid() const {
-        return srcid_.get();
+        return srcid_;
     }
 
     Expression *dstid() const {
-        return dstid_.get();
+        return dstid_;
     }
 
     Expression *rank() const {
-        return rank_.get();
+        return rank_;
     }
 
     Expression *type() const {
-        return type_.get();
+        return type_;
     }
 
     void setType(Expression *type) {
-        type_.reset(type);
+        type_ = type;
     }
 
     bool isInputExpr() const {
@@ -106,10 +106,10 @@ public:
     std::string toString() const;
 
 private:
-    std::unique_ptr<Expression> srcid_;
-    std::unique_ptr<Expression> dstid_;
-    std::unique_ptr<Expression> rank_;
-    std::unique_ptr<Expression> type_;
+    Expression* srcid_;
+    Expression* dstid_;
+    Expression* rank_;
+    Expression* type_;
     std::unordered_set<std::string> uniqVar_;
     bool isInputExpr_;
 };

--- a/src/parser/EdgeKey.h
+++ b/src/parser/EdgeKey.h
@@ -43,8 +43,8 @@ public:
     std::string toString() const;
 
 private:
-    Expression* srcid_;
-    Expression* dstid_;
+    Expression* srcid_{nullptr};
+    Expression* dstid_{nullptr};
     EdgeRanking rank_;
 };
 
@@ -106,10 +106,10 @@ public:
     std::string toString() const;
 
 private:
-    Expression* srcid_;
-    Expression* dstid_;
-    Expression* rank_;
-    Expression* type_;
+    Expression *srcid_{nullptr};
+    Expression *dstid_{nullptr};
+    Expression *rank_{nullptr};
+    Expression *type_{nullptr};
     std::unordered_set<std::string> uniqVar_;
     bool isInputExpr_;
 };

--- a/src/parser/MaintainSentences.h
+++ b/src/parser/MaintainSentences.h
@@ -21,13 +21,13 @@ std::ostream& operator<<(std::ostream& os, meta::cpp2::PropertyType type);
 
 class ColumnProperty final {
 public:
-    using Value = std::variant<bool, std::unique_ptr<Expression>, std::unique_ptr<std::string>>;
+    using Value = std::variant<bool, Expression*, std::unique_ptr<std::string>>;
 
     explicit ColumnProperty(bool nullable = true)
         : v_(nullable) {}
 
     explicit ColumnProperty(Expression *defaultValue = nullptr)
-        : v_(std::unique_ptr<Expression>(defaultValue)) {}
+        : v_(defaultValue) {}
 
     explicit ColumnProperty(std::string *comment = nullptr)
         : v_(std::unique_ptr<std::string>(comment)) {}
@@ -42,12 +42,12 @@ public:
     }
 
     bool isDefaultValue() const {
-        return std::holds_alternative<std::unique_ptr<Expression>>(v_);
+        return std::holds_alternative<Expression*>(v_);
     }
 
     const auto* defaultValue() const {
         DCHECK(isDefaultValue());
-        return std::get<std::unique_ptr<Expression>>(v_).get();
+        return std::get<Expression*>(v_);
     }
 
     bool isComment() const {

--- a/src/parser/MatchSentence.h
+++ b/src/parser/MatchSentence.h
@@ -419,7 +419,7 @@ public:
     std::string toString() const override;
 
 private:
-    Expression* expr_;
+    Expression* expr_{nullptr};
     std::string alias_;
 };
 

--- a/src/parser/MatchSentence.h
+++ b/src/parser/MatchSentence.h
@@ -61,7 +61,7 @@ public:
                   Expression *props = nullptr) {
         alias_ = alias;
         range_.reset(range);
-        props_.reset(static_cast<MapExpression*>(props));
+        props_ = static_cast<MapExpression*>(props);
         if (types != nullptr) {
             types_ = std::move(*types).items();
             delete types;
@@ -78,7 +78,7 @@ public:
 private:
     std::string                                         alias_;
     std::vector<std::unique_ptr<std::string>>           types_;
-    std::unique_ptr<MapExpression>                      props_;
+    MapExpression*                                      props_{nullptr};
     std::unique_ptr<MatchStepRange>                     range_;
 };
 
@@ -111,7 +111,7 @@ public:
     }
 
     const MapExpression* props() const {
-        return props_.get();
+        return props_;
     }
 
     auto* range() const {
@@ -125,7 +125,7 @@ private:
     std::string                                     alias_;
     std::vector<std::unique_ptr<std::string>>       types_;
     std::unique_ptr<MatchStepRange>                 range_;
-    std::unique_ptr<MapExpression>                  props_;
+    MapExpression*                                  props_{nullptr};
 };
 
 class MatchNodeLabel final {
@@ -140,11 +140,11 @@ public:
     }
 
     const MapExpression* props() const {
-        return props_.get();
+        return props_;
     }
 
     MapExpression* props() {
-        return props_.get();
+        return props_;
     }
 
     std::string toString() const {
@@ -157,8 +157,8 @@ public:
     }
 
 private:
-    std::unique_ptr<std::string>                    label_;
-    std::unique_ptr<MapExpression>                  props_;
+    std::unique_ptr<std::string>    label_;
+    MapExpression*                  props_{nullptr};
 };
 
 class MatchNodeLabelList final {
@@ -190,7 +190,7 @@ public:
               Expression *props = nullptr) {
         alias_ = alias;
         labels_.reset(labels);
-        props_.reset(static_cast<MapExpression*>(props));
+        props_ = static_cast<MapExpression*>(props);
     }
 
     const std::string& alias() const {
@@ -202,7 +202,7 @@ public:
     }
 
     const MapExpression* props() const {
-        return props_.get();
+        return props_;
     }
 
     std::string toString() const;
@@ -210,7 +210,7 @@ public:
 private:
     std::string                                     alias_;
     std::unique_ptr<MatchNodeLabelList>             labels_;
-    std::unique_ptr<MapExpression>                  props_;
+    MapExpression*                                  props_{nullptr};
 };
 
 
@@ -314,12 +314,12 @@ public:
     std::string toString() const;
 
 private:
-    std::unique_ptr<YieldColumns>                   columns_;
-    bool                                            isAll_{false};
-    bool                                            isDistinct_{false};
-    std::unique_ptr<OrderFactors>                   orderFactors_;
-    Expression*                     skip_;
-    Expression*                     limit_;
+    std::unique_ptr<YieldColumns>   columns_;
+    bool                            isAll_{false};
+    bool                            isDistinct_{false};
+    std::unique_ptr<OrderFactors>   orderFactors_;
+    Expression*                     skip_{nullptr};
+    Expression*                     limit_{nullptr};
 };
 
 
@@ -489,8 +489,8 @@ public:
 private:
     std::unique_ptr<YieldColumns>       columns_;
     std::unique_ptr<OrderFactors>       orderFactors_;
-    Expression*         skip_;
-    Expression*         limit_;
+    Expression*                         skip_{nullptr};
+    Expression*                         limit_{nullptr};
     std::unique_ptr<WhereClause>        where_;
     bool                                isDistinct_;
 };

--- a/src/parser/MatchSentence.h
+++ b/src/parser/MatchSentence.h
@@ -264,15 +264,15 @@ private:
 
 class MatchReturn final {
 public:
-    explicit MatchReturn(YieldColumns *columns = nullptr,
-                         OrderFactors *orderFactors = nullptr,
-                         Expression *skip = nullptr,
-                         Expression *limit = nullptr,
+    explicit MatchReturn(YieldColumns* columns = nullptr,
+                         OrderFactors* orderFactors = nullptr,
+                         Expression* skip = nullptr,
+                         Expression* limit = nullptr,
                          bool distinct = false) {
         columns_.reset(columns);
         orderFactors_.reset(orderFactors);
-        skip_.reset(skip);
-        limit_.reset(limit);
+        skip_ = skip;
+        limit_ = limit;
         isDistinct_ = distinct;
         if (columns_ == nullptr) {
             isAll_ = true;
@@ -296,11 +296,11 @@ public:
     }
 
     const Expression* skip() const {
-        return skip_.get();
+        return skip_;
     }
 
     const Expression* limit() const {
-        return limit_.get();
+        return limit_;
     }
 
     OrderFactors* orderFactors() {
@@ -318,8 +318,8 @@ private:
     bool                                            isAll_{false};
     bool                                            isDistinct_{false};
     std::unique_ptr<OrderFactors>                   orderFactors_;
-    std::unique_ptr<Expression>                     skip_;
-    std::unique_ptr<Expression>                     limit_;
+    Expression*                     skip_;
+    Expression*                     limit_;
 };
 
 
@@ -400,16 +400,16 @@ class UnwindClause final : public ReadingClause {
 public:
     UnwindClause(Expression *expr, const std::string &alias)
         : ReadingClause(Kind::kUnwind) {
-        expr_.reset(expr);
+        expr_ = expr;
         alias_ = alias;
     }
 
     Expression* expr() {
-        return expr_.get();
+        return expr_;
     }
 
     const Expression* expr() const {
-        return expr_.get();
+        return expr_;
     }
 
     const std::string& alias() const {
@@ -419,7 +419,7 @@ public:
     std::string toString() const override;
 
 private:
-    std::unique_ptr<Expression> expr_;
+    Expression* expr_;
     std::string alias_;
 };
 
@@ -434,8 +434,8 @@ public:
         : ReadingClause(Kind::kWith) {
         columns_.reset(cols);
         orderFactors_.reset(orderFactors);
-        skip_.reset(skip);
-        limit_.reset(limit);
+        skip_ = skip;
+        limit_ = limit;
         where_.reset(where);
         isDistinct_ = distinct;
     }
@@ -457,19 +457,19 @@ public:
     }
 
     Expression* skip() {
-        return skip_.get();
+        return skip_;
     }
 
     const Expression* skip() const {
-        return skip_.get();
+        return skip_;
     }
 
     Expression* limit() {
-        return limit_.get();
+        return limit_;
     }
 
     const Expression* limit() const {
-        return limit_.get();
+        return limit_;
     }
 
     WhereClause* where() {
@@ -489,8 +489,8 @@ public:
 private:
     std::unique_ptr<YieldColumns>       columns_;
     std::unique_ptr<OrderFactors>       orderFactors_;
-    std::unique_ptr<Expression>         skip_;
-    std::unique_ptr<Expression>         limit_;
+    Expression*         skip_;
+    Expression*         limit_;
     std::unique_ptr<WhereClause>        where_;
     bool                                isDistinct_;
 };

--- a/src/parser/MutateSentences.h
+++ b/src/parser/MutateSentences.h
@@ -99,7 +99,7 @@ public:
 
     std::string toString() const;
 
-    std::vector<Expression*> values() const {
+    const std::vector<Expression*> &values() const {
         return values_;
     }
 

--- a/src/parser/MutateSentences.h
+++ b/src/parser/MutateSentences.h
@@ -100,11 +100,7 @@ public:
     std::string toString() const;
 
     std::vector<Expression*> values() const {
-        std::vector<Expression*> result;
-        result.resize(values_.size());
-        auto get = [] (const auto &ptr) { return ptr; };
-        std::transform(values_.begin(), values_.end(), result.begin(), get);
-        return result;
+        return values_;
     }
 
 private:
@@ -130,8 +126,8 @@ public:
     std::string toString() const;
 
 private:
-    Expression*                 id_;
-    std::unique_ptr<ValueList>                  values_;
+    Expression*                 id_{nullptr};
+    std::unique_ptr<ValueList>  values_;
 };
 
 
@@ -230,12 +226,11 @@ public:
     std::string toString() const;
 
 private:
-    Expression*                 srcid_;
-    Expression*                 dstid_;
-    EdgeRanking                                 rank_{0};
-    std::unique_ptr<ValueList>                  values_;
+    Expression *srcid_{nullptr};
+    Expression *dstid_{nullptr};
+    EdgeRanking rank_{0};
+    std::unique_ptr<ValueList> values_;
 };
-
 
 class EdgeRowList final {
 public:
@@ -338,11 +333,10 @@ public:
     StatusOr<std::string> toEvaledString() const;
 
 private:
-    std::unique_ptr<std::string>                fieldStr_;
-    Expression*                 fieldExpr_;
-    Expression*                 value_;
+    std::unique_ptr<std::string> fieldStr_;
+    Expression *fieldExpr_{nullptr};
+    Expression *value_{nullptr};
 };
-
 
 class UpdateList final {
 public:
@@ -462,7 +456,7 @@ public:
     std::string toString() const override;
 
 private:
-    Expression*                 vid_;
+    Expression*                 vid_{nullptr};
 };
 
 
@@ -498,9 +492,9 @@ public:
     std::string toString() const override;
 
 private:
-    Expression*                 srcId_;
-    Expression*                 dstId_;
-    int64_t                                     rank_{0L};
+    Expression *srcId_{nullptr};
+    Expression *dstId_{nullptr};
+    int64_t rank_{0L};
 };
 
 

--- a/src/parser/MutateSentences.h
+++ b/src/parser/MutateSentences.h
@@ -102,25 +102,25 @@ public:
     std::vector<Expression*> values() const {
         std::vector<Expression*> result;
         result.resize(values_.size());
-        auto get = [] (const auto &ptr) { return ptr.get(); };
+        auto get = [] (const auto &ptr) { return ptr; };
         std::transform(values_.begin(), values_.end(), result.begin(), get);
         return result;
     }
 
 private:
-    std::vector<std::unique_ptr<Expression>>    values_;
+    std::vector<Expression*>    values_;
 };
 
 
 class VertexRowItem final {
 public:
     VertexRowItem(Expression *id, ValueList *values) {
-        id_.reset(id);
+        id_ = id;
         values_.reset(values);
     }
 
     Expression* id() const {
-        return id_.get();
+        return id_;
     }
 
     std::vector<Expression*> values() const {
@@ -130,7 +130,7 @@ public:
     std::string toString() const;
 
 private:
-    std::unique_ptr<Expression>                 id_;
+    Expression*                 id_;
     std::unique_ptr<ValueList>                  values_;
 };
 
@@ -199,24 +199,24 @@ private:
 class EdgeRowItem final {
 public:
     EdgeRowItem(Expression *srcid, Expression *dstid, ValueList *values) {
-        srcid_.reset(srcid);
-        dstid_.reset(dstid);
+        srcid_ = srcid;
+        dstid_ = dstid;
         values_.reset(values);
     }
 
     EdgeRowItem(Expression *srcid, Expression *dstid, int64_t rank, ValueList *values) {
-        srcid_.reset(srcid);
-        dstid_.reset(dstid);
+        srcid_ = srcid;
+        dstid_ = dstid;
         rank_ = rank;
         values_.reset(values);
     }
 
     auto srcid() const {
-        return srcid_.get();
+        return srcid_;
     }
 
     auto dstid() const {
-        return dstid_.get();
+        return dstid_;
     }
 
     auto rank() const {
@@ -230,8 +230,8 @@ public:
     std::string toString() const;
 
 private:
-    std::unique_ptr<Expression>                 srcid_;
-    std::unique_ptr<Expression>                 dstid_;
+    Expression*                 srcid_;
+    Expression*                 dstid_;
     EdgeRanking                                 rank_{0};
     std::unique_ptr<ValueList>                  values_;
 };
@@ -313,12 +313,12 @@ class UpdateItem final {
 public:
     UpdateItem(std::string *field, Expression *value) {
         fieldStr_.reset(field);
-        value_.reset(value);
+        value_ = value;
     }
 
     UpdateItem(Expression *field, Expression *value) {
-        fieldExpr_.reset(field);
-        value_.reset(value);
+        fieldExpr_ = field;
+        value_ = value;
     }
 
     std::string* getFieldName() const {
@@ -326,11 +326,11 @@ public:
     }
 
     const Expression* getFieldExpr() const {
-        return fieldExpr_.get();
+        return fieldExpr_;
     }
 
     const Expression* value() const {
-        return value_.get();
+        return value_;
     }
 
     std::string toString() const;
@@ -339,8 +339,8 @@ public:
 
 private:
     std::unique_ptr<std::string>                fieldStr_;
-    std::unique_ptr<Expression>                 fieldExpr_;
-    std::unique_ptr<Expression>                 value_;
+    Expression*                 fieldExpr_;
+    Expression*                 value_;
 };
 
 
@@ -424,7 +424,7 @@ public:
                          bool isInsertable = false)
         : UpdateBaseSentence(updateList, whenClause, yieldClause, tagName, isInsertable) {
         kind_ = Kind::kUpdateVertex;
-        vid_.reset(vid);
+        vid_ = vid;
     }
 
     UpdateVertexSentence(Expression *vid,
@@ -434,7 +434,7 @@ public:
                          bool isInsertable = false)
         : UpdateBaseSentence(updateList, whenClause, yieldClause, nullptr, isInsertable) {
         kind_ = Kind::kUpdateVertex;
-        vid_.reset(vid);
+        vid_ = vid;
     }
 
     ~UpdateVertexSentence() {}
@@ -444,7 +444,7 @@ public:
     }
 
     Expression* getVid() const {
-        return vid_.get();
+        return vid_;
     }
 
     const UpdateList* updateList() const {
@@ -462,7 +462,7 @@ public:
     std::string toString() const override;
 
 private:
-    std::unique_ptr<Expression>                 vid_;
+    Expression*                 vid_;
 };
 
 
@@ -478,17 +478,17 @@ public:
                        bool isInsertable = false)
         : UpdateBaseSentence(updateList, whenClause, yieldClause, edgeName, isInsertable) {
         kind_ = Kind::kUpdateEdge;
-        srcId_.reset(srcId);
-        dstId_.reset(dstId);
+        srcId_ = srcId;
+        dstId_ = dstId;
         rank_ = rank;
     }
 
     Expression* getSrcId() const {
-        return srcId_.get();
+        return srcId_;
     }
 
     Expression* getDstId() const {
-        return dstId_.get();
+        return dstId_;
     }
 
     int64_t getRank() const {
@@ -498,8 +498,8 @@ public:
     std::string toString() const override;
 
 private:
-    std::unique_ptr<Expression>                 srcId_;
-    std::unique_ptr<Expression>                 dstId_;
+    Expression*                 srcId_;
+    Expression*                 dstId_;
     int64_t                                     rank_{0L};
 };
 

--- a/src/parser/TraverseSentences.h
+++ b/src/parser/TraverseSentences.h
@@ -248,7 +248,7 @@ public:
     std::string toString() const;
 
 private:
-    Expression* expr_;
+    Expression* expr_{nullptr};
     OrderType orderType_;
 };
 

--- a/src/parser/TraverseSentences.h
+++ b/src/parser/TraverseSentences.h
@@ -226,22 +226,19 @@ private:
 
 class OrderFactor final {
 public:
-    enum OrderType : uint8_t {
-        ASCEND,
-        DESCEND
-    };
+    enum OrderType : uint8_t { ASCEND, DESCEND };
 
-    OrderFactor(Expression *expr, OrderType op) {
-        expr_.reset(expr);
+    OrderFactor(Expression* expr, OrderType op) {
+        expr_ = expr;
         orderType_ = op;
     }
 
     Expression* expr() {
-        return expr_.get();
+        return expr_;
     }
 
-    void setExpr(Expression *expr) {
-        expr_.reset(expr);
+    void setExpr(Expression* expr) {
+        expr_ = expr;
     }
 
     OrderType orderType() {
@@ -251,8 +248,8 @@ public:
     std::string toString() const;
 
 private:
-    std::unique_ptr<Expression>                 expr_;
-    OrderType                                   orderType_;
+    Expression* expr_;
+    OrderType orderType_;
 };
 
 class OrderFactors final {

--- a/src/parser/parser.yy
+++ b/src/parser/parser.yy
@@ -843,7 +843,6 @@ predicate_expression
         nebula::graph::ParserUtil::rewritePred(qctx, expr, innerVar);
         $$ = expr;
         delete $1;
-        delete $3;
     }
     | KW_EXISTS L_PAREN expression R_PAREN {
         if ($3->kind() != Expression::Kind::kLabelAttribute && $3->kind() != Expression::Kind::kAttribute &&
@@ -863,7 +862,6 @@ list_comprehension_expression
         auto *expr = ListComprehensionExpression::make(qctx->objPool(), innerVar, $4, $6, nullptr);
         nebula::graph::ParserUtil::rewriteLC(qctx, expr, innerVar);
         $$ = expr;
-        delete $2;
     }
     | L_BRACKET expression KW_IN expression PIPE expression R_BRACKET {
         if ($2->kind() != Expression::Kind::kLabel) {
@@ -873,7 +871,6 @@ list_comprehension_expression
         auto *expr = ListComprehensionExpression::make(qctx->objPool(), innerVar, $4, nullptr, $6);
         nebula::graph::ParserUtil::rewriteLC(qctx, expr, innerVar);
         $$ = expr;
-        delete $2;
     }
     | L_BRACKET expression KW_IN expression KW_WHERE expression PIPE expression R_BRACKET {
         if ($2->kind() != Expression::Kind::kLabel) {
@@ -883,7 +880,6 @@ list_comprehension_expression
         auto *expr = ListComprehensionExpression::make(qctx->objPool(), innerVar, $4, $6, $8);
         nebula::graph::ParserUtil::rewriteLC(qctx, expr, innerVar);
         $$ = expr;
-        delete $2;
     }
     ;
 
@@ -976,7 +972,6 @@ function_call_expression
             delete($1);
         } else {
             delete($1);
-            delete($4);
             throw nebula::GraphParser::syntax_error(@1, "Unknown aggregate function ");
         }
     }
@@ -1043,13 +1038,13 @@ opt_argument_list
 argument_list
     : expression {
         $$ = ArgumentList::make(qctx->objPool());
-        Expression* arg;
+        Expression* arg = nullptr;
         arg = $1;
         $$->addArgument(arg);
     }
     | argument_list COMMA expression {
         $$ = $1;
-        Expression* arg;
+        Expression* arg = nullptr;
         arg = $3;
         $$->addArgument(arg);
     }

--- a/src/parser/parser.yy
+++ b/src/parser/parser.yy
@@ -9,6 +9,7 @@
 %parse-param { std::string &errmsg }
 %parse-param { nebula::Sentence** sentences }
 %parse-param { nebula::graph::QueryContext* qctx }
+/* %parse-param { nebula::graph::ObjectPool* qctxPool } */
 
 %code requires {
 #include <iostream>
@@ -53,6 +54,9 @@ static constexpr size_t kCommentLengthLimit = 256;
 
     void ifOutOfRange(const int64_t input,
                       const nebula::GraphParser::location_type& loc);
+
+    // Manage lifetime of expressions
+    // auto qctx->objPool() = qctx->objPool();
 }
 
 %union {
@@ -516,11 +520,11 @@ expression
         $$ = $1;
     }
     | name_label {
-        $$ = new LabelExpression(*$1);
+        $$ = LabelExpression::make(qctx->objPool(), *$1);
         delete $1;
     }
     | VARIABLE {
-        $$ = new VariableExpression(*$1);
+        $$ = VariableExpression::make(qctx->objPool(), *$1);
         delete $1;
     }
     | compound_expression {
@@ -533,103 +537,103 @@ expression
             $$ = $3;
             scanner.setIsIntMin(false);
         } else {
-            $$ = new UnaryExpression(Expression::Kind::kUnaryNegate, $3);
+            $$ = UnaryExpression::makeNegate(qctx->objPool(), $3);
         }
         scanner.setUnaryMinus(false);
     }
     | PLUS expression %prec UNARY_PLUS {
-        $$ = new UnaryExpression(Expression::Kind::kUnaryPlus, $2);
+        $$ = UnaryExpression::makePlus(qctx->objPool(), $2);
     }
     | NOT expression {
-        $$ = new UnaryExpression(Expression::Kind::kUnaryNot, $2);
+        $$ = UnaryExpression::makeNot(qctx->objPool(), $2);
     }
     | KW_NOT expression {
-        $$ = new UnaryExpression(Expression::Kind::kUnaryNot, $2);
+        $$ = UnaryExpression::makeNot(qctx->objPool(), $2);
     }
     | L_PAREN type_spec R_PAREN expression %prec CASTING {
-        $$ = new TypeCastingExpression(graph::SchemaUtil::propTypeToValueType($2->type), $4);
+        $$ = TypeCastingExpression::make(qctx->objPool(), graph::SchemaUtil::propTypeToValueType($2->type), $4);
         delete $2;
     }
     | expression STAR expression {
-        $$ = new ArithmeticExpression(Expression::Kind::kMultiply, $1, $3);
+        $$ = ArithmeticExpression::makeMultiply(qctx->objPool(), $1, $3);
     }
     | expression DIV expression {
-        $$ = new ArithmeticExpression(Expression::Kind::kDivision, $1, $3);
+        $$ = ArithmeticExpression::makeDivision(qctx->objPool(), $1, $3);
     }
     | expression MOD expression {
-        $$ = new ArithmeticExpression(Expression::Kind::kMod, $1, $3);
+        $$ = ArithmeticExpression::makeMod(qctx->objPool(), $1, $3);
     }
     | expression PLUS expression {
-        $$ = new ArithmeticExpression(Expression::Kind::kAdd, $1, $3);
+        $$ = ArithmeticExpression::makeAdd(qctx->objPool(), $1, $3);
     }
     | expression MINUS expression {
-        $$ = new ArithmeticExpression(Expression::Kind::kMinus, $1, $3);
+        $$ = ArithmeticExpression::makeMinus(qctx->objPool(), $1, $3);
     }
     | expression LT expression {
-        $$ = new RelationalExpression(Expression::Kind::kRelLT, $1, $3);
+        $$ = RelationalExpression::makeLT(qctx->objPool(), $1, $3);
     }
     | expression GT expression {
-        $$ = new RelationalExpression(Expression::Kind::kRelGT, $1, $3);
+        $$ = RelationalExpression::makeGT(qctx->objPool(), $1, $3);
     }
     | expression LE expression {
-        $$ = new RelationalExpression(Expression::Kind::kRelLE, $1, $3);
+        $$ = RelationalExpression::makeLE(qctx->objPool(), $1, $3);
     }
     | expression GE expression {
-        $$ = new RelationalExpression(Expression::Kind::kRelGE, $1, $3);
+        $$ = RelationalExpression::makeGE(qctx->objPool(), $1, $3);
     }
     | expression REG expression {
-        $$ = new RelationalExpression(Expression::Kind::kRelREG, $1, $3);
+        $$ = RelationalExpression::makeREG(qctx->objPool(), $1, $3);
     }
     | expression KW_IN expression {
-        $$ = new RelationalExpression(Expression::Kind::kRelIn, $1, $3);
+        $$ = RelationalExpression::makeIn(qctx->objPool(), $1, $3);
     }
     | expression KW_NOT_IN expression {
-        $$ = new RelationalExpression(Expression::Kind::kRelNotIn, $1, $3);
+        $$ = RelationalExpression::makeNotIn(qctx->objPool(), $1, $3);
     }
     | expression KW_CONTAINS expression {
-        $$ = new RelationalExpression(Expression::Kind::kContains, $1, $3);
+        $$ = RelationalExpression::makeContains(qctx->objPool(), $1, $3);
     }
     | expression KW_NOT_CONTAINS expression {
-        $$ = new RelationalExpression(Expression::Kind::kNotContains, $1, $3);
+        $$ = RelationalExpression::makeNotContains(qctx->objPool(), $1, $3);
     }
     | expression KW_STARTS_WITH expression {
-        $$ = new RelationalExpression(Expression::Kind::kStartsWith, $1, $3);
+        $$ = RelationalExpression::makeStartsWith(qctx->objPool(), $1, $3);
     }
     | expression KW_NOT_STARTS_WITH expression {
-        $$ = new RelationalExpression(Expression::Kind::kNotStartsWith, $1, $3);
+        $$ = RelationalExpression::makeNotStartsWith(qctx->objPool(), $1, $3);
     }
     | expression KW_ENDS_WITH expression {
-        $$ = new RelationalExpression(Expression::Kind::kEndsWith, $1, $3);
+        $$ = RelationalExpression::makeEndsWith(qctx->objPool(), $1, $3);
     }
     | expression KW_NOT_ENDS_WITH expression {
-        $$ = new RelationalExpression(Expression::Kind::kNotEndsWith, $1, $3);
+        $$ = RelationalExpression::makeNotEndsWith(qctx->objPool(), $1, $3);
     }
     | expression KW_IS_NULL {
-        $$ = new UnaryExpression(Expression::Kind::kIsNull, $1);
+        $$ = UnaryExpression::makeIsNull(qctx->objPool(), $1);
     }
     | expression KW_IS_NOT_NULL {
-        $$ = new UnaryExpression(Expression::Kind::kIsNotNull, $1);
+        $$ = UnaryExpression::makeIsNotNull(qctx->objPool(), $1);
     }
     | expression KW_IS_EMPTY {
-        $$ = new UnaryExpression(Expression::Kind::kIsEmpty, $1);
+        $$ = UnaryExpression::makeIsEmpty(qctx->objPool(), $1);
     }
     | expression KW_IS_NOT_EMPTY {
-        $$ = new UnaryExpression(Expression::Kind::kIsNotEmpty, $1);
+        $$ = UnaryExpression::makeIsNotEmpty(qctx->objPool(), $1);
     }
     | expression EQ expression {
-        $$ = new RelationalExpression(Expression::Kind::kRelEQ, $1, $3);
+        $$ = RelationalExpression::makeEQ(qctx->objPool(), $1, $3);
     }
     | expression NE expression {
-        $$ = new RelationalExpression(Expression::Kind::kRelNE, $1, $3);
+        $$ = RelationalExpression::makeNE(qctx->objPool(), $1, $3);
     }
     | expression KW_AND expression {
-        $$ = new LogicalExpression(Expression::Kind::kLogicalAnd, $1, $3);
+        $$ = LogicalExpression::makeAnd(qctx->objPool(), $1, $3);
     }
     | expression KW_OR expression {
-        $$ = new LogicalExpression(Expression::Kind::kLogicalOr, $1, $3);
+        $$ = LogicalExpression::makeOr(qctx->objPool(), $1, $3);
     }
     | expression KW_XOR expression {
-        $$ = new LogicalExpression(Expression::Kind::kLogicalXor, $1, $3);
+        $$ = LogicalExpression::makeXor(qctx->objPool(), $1, $3);
     }
     | case_expression {
         $$ = $1;
@@ -647,20 +651,20 @@ expression
 
 constant_expression
     : DOUBLE {
-        $$ = new ConstantExpression($1);
+        $$ = ConstantExpression::make(qctx->objPool(), $1);
     }
     | STRING {
-        $$ = new ConstantExpression(*$1);
+        $$ = ConstantExpression::make(qctx->objPool(), *$1);
         delete $1;
     }
     | BOOL {
-        $$ = new ConstantExpression($1);
+        $$ = ConstantExpression::make(qctx->objPool(), $1);
     }
     | KW_NULL {
-        $$ = new ConstantExpression(NullType::__NULL__);
+        $$ = ConstantExpression::make(qctx->objPool(), NullType::__NULL__);
     }
     | INTEGER {
-        $$ = new ConstantExpression($1);
+        $$ = ConstantExpression::make(qctx->objPool(), $1);
     }
     ;
 
@@ -705,63 +709,63 @@ property_expression
 
 subscript_expression
     : name_label L_BRACKET expression R_BRACKET {
-        $$ = new SubscriptExpression(new LabelExpression(*$1), $3);
+        $$ = SubscriptExpression::make(qctx->objPool(), LabelExpression::make(qctx->objPool(), *$1), $3);
         delete $1;
     }
     | VARIABLE L_BRACKET expression R_BRACKET {
-        $$ = new SubscriptExpression(new VariableExpression(*$1), $3);
+        $$ = SubscriptExpression::make(qctx->objPool(), VariableExpression::make(qctx->objPool(), *$1), $3);
         delete $1;
     }
     | compound_expression L_BRACKET expression R_BRACKET {
-        $$ = new SubscriptExpression($1, $3);
+        $$ = SubscriptExpression::make(qctx->objPool(), $1, $3);
     }
     ;
 
 subscript_range_expression
     : name_label L_BRACKET expression DOT_DOT expression R_BRACKET {
-        $$ = new SubscriptRangeExpression(new LabelExpression(*$1), $3, $5);
+        $$ = SubscriptRangeExpression::make(qctx->objPool(), LabelExpression::make(qctx->objPool(), *$1), $3, $5);
         delete($1);
     }
     | name_label L_BRACKET DOT_DOT expression R_BRACKET {
-        $$ = new SubscriptRangeExpression(new LabelExpression(*$1), nullptr, $4);
+        $$ = SubscriptRangeExpression::make(qctx->objPool(), LabelExpression::make(qctx->objPool(), *$1), nullptr, $4);
         delete($1);
     }
     | name_label L_BRACKET expression DOT_DOT R_BRACKET {
-        $$ = new SubscriptRangeExpression(new LabelExpression(*$1), $3, nullptr);
+        $$ = SubscriptRangeExpression::make(qctx->objPool(), LabelExpression::make(qctx->objPool(), *$1), $3, nullptr);
         delete($1);
     }
     | VARIABLE L_BRACKET expression DOT_DOT expression R_BRACKET {
-        $$ = new SubscriptRangeExpression(new VariableExpression(*$1), $3, $5);
+        $$ = SubscriptRangeExpression::make(qctx->objPool(), VariableExpression::make(qctx->objPool(), *$1), $3, $5);
         delete($1);
     }
     | VARIABLE L_BRACKET DOT_DOT expression R_BRACKET {
-        $$ = new SubscriptRangeExpression(new VariableExpression(*$1), nullptr, $4);
+        $$ = SubscriptRangeExpression::make(qctx->objPool(), VariableExpression::make(qctx->objPool(), *$1), nullptr, $4);
         delete($1);
     }
     | VARIABLE L_BRACKET expression DOT_DOT R_BRACKET {
-        $$ = new SubscriptRangeExpression(new VariableExpression(*$1), $3, nullptr);
+        $$ = SubscriptRangeExpression::make(qctx->objPool(), VariableExpression::make(qctx->objPool(), *$1), $3, nullptr);
         delete($1);
     }
     | compound_expression L_BRACKET expression DOT_DOT expression R_BRACKET {
-        $$ = new SubscriptRangeExpression($1, $3, $5);
+        $$ = SubscriptRangeExpression::make(qctx->objPool(), $1, $3, $5);
     }
     | compound_expression L_BRACKET DOT_DOT expression R_BRACKET {
-        $$ = new SubscriptRangeExpression($1, nullptr, $4);
+        $$ = SubscriptRangeExpression::make(qctx->objPool(), $1, nullptr, $4);
     }
     | compound_expression L_BRACKET expression DOT_DOT R_BRACKET {
-        $$ = new SubscriptRangeExpression($1, $3, nullptr);
+        $$ = SubscriptRangeExpression::make(qctx->objPool(), $1, $3, nullptr);
     }
     ;
 
 attribute_expression
     : name_label DOT name_label {
-        $$ = new LabelAttributeExpression(new LabelExpression(*$1),
-                                          new ConstantExpression(*$3));
+        $$ = LabelAttributeExpression::make(qctx->objPool(), LabelExpression::make(qctx->objPool(), *$1),
+                                          ConstantExpression::make(qctx->objPool(), *$3));
         delete $1;
         delete $3;
     }
     | compound_expression DOT name_label {
-        $$ = new AttributeExpression($1, new ConstantExpression(*$3));
+        $$ = AttributeExpression::make(qctx->objPool(), $1, ConstantExpression::make(qctx->objPool(), *$3));
         delete $3;
     }
     ;
@@ -777,7 +781,7 @@ case_expression
 
 generic_case_expression
     : KW_CASE case_condition when_then_list case_default KW_END {
-        auto expr = new CaseExpression($3);
+        auto expr = CaseExpression::make(qctx->objPool(), $3);
         expr->setCondition($2);
         expr->setDefault($4);
         $$ = expr;
@@ -788,7 +792,7 @@ conditional_expression
     : expression QM expression COLON expression {
         auto cases = new CaseList();
         cases->add($1, $3);
-        auto expr = new CaseExpression(cases, false);
+        auto expr = CaseExpression::make(qctx->objPool(), cases, false);
         expr->setDefault($5);
         $$ = expr;
     }
@@ -836,7 +840,7 @@ predicate_expression
             throw nebula::GraphParser::syntax_error(@3, "The loop variable must be a label in predicate functions");
         }
         auto &innerVar = static_cast<const LabelExpression *>($3)->name();
-        auto *expr = new PredicateExpression(*$1, innerVar, $5, $7);
+        auto *expr = PredicateExpression::make(qctx->objPool(), *$1, innerVar, $5, $7);
         nebula::graph::ParserUtil::rewritePred(qctx, expr, innerVar);
         $$ = expr;
         delete $1;
@@ -847,7 +851,7 @@ predicate_expression
             $3->kind() != Expression::Kind::kSubscript) {
             throw nebula::GraphParser::syntax_error(@3, "The exists only accept LabelAttribe, Attribute and Subscript");
         }
-        $$ = new PredicateExpression("exists", "", $3, nullptr);
+        $$ = PredicateExpression::make(qctx->objPool(), "exists", "", $3, nullptr);
     }
     ;
 
@@ -857,7 +861,7 @@ list_comprehension_expression
             throw nebula::GraphParser::syntax_error(@2, "The loop variable must be a label in list comprehension");
         }
         auto &innerVar = static_cast<const LabelExpression *>($2)->name();
-        auto *expr = new ListComprehensionExpression(innerVar, $4, $6, nullptr);
+        auto *expr = ListComprehensionExpression::make(qctx->objPool(), innerVar, $4, $6, nullptr);
         nebula::graph::ParserUtil::rewriteLC(qctx, expr, innerVar);
         $$ = expr;
         delete $2;
@@ -867,7 +871,7 @@ list_comprehension_expression
             throw nebula::GraphParser::syntax_error(@2, "The loop variable must be a label in list comprehension");
         }
         auto &innerVar = static_cast<const LabelExpression *>($2)->name();
-        auto *expr = new ListComprehensionExpression(innerVar, $4, nullptr, $6);
+        auto *expr = ListComprehensionExpression::make(qctx->objPool(), innerVar, $4, nullptr, $6);
         nebula::graph::ParserUtil::rewriteLC(qctx, expr, innerVar);
         $$ = expr;
         delete $2;
@@ -877,7 +881,7 @@ list_comprehension_expression
             throw nebula::GraphParser::syntax_error(@2, "The loop variable must be a label in list comprehension");
         }
         auto &innerVar = static_cast<const LabelExpression *>($2)->name();
-        auto *expr = new ListComprehensionExpression(innerVar, $4, $6, $8);
+        auto *expr = ListComprehensionExpression::make(qctx->objPool(), innerVar, $4, $6, $8);
         nebula::graph::ParserUtil::rewriteLC(qctx, expr, innerVar);
         $$ = expr;
         delete $2;
@@ -886,7 +890,7 @@ list_comprehension_expression
 
 reduce_expression
     : KW_REDUCE L_PAREN name_label ASSIGN expression COMMA name_label KW_IN expression PIPE expression R_PAREN {
-        auto *expr = new ReduceExpression(*$3, $5, *$7, $9, $11);
+        auto *expr = ReduceExpression::make(qctx->objPool(), *$3, $5, *$7, $9, $11);
         nebula::graph::ParserUtil::rewriteReduce(qctx, expr, *$3, *$7);
         $$ = expr;
         delete $3;
@@ -896,22 +900,22 @@ reduce_expression
 
 input_prop_expression
     : INPUT_REF DOT name_label {
-        $$ = new InputPropertyExpression(*$3);
+        $$ = InputPropertyExpression::make(qctx->objPool(), *$3);
         delete $3;
     }
     | INPUT_REF DOT STAR {
-        $$ = new InputPropertyExpression("*");
+        $$ = InputPropertyExpression::make(qctx->objPool(), "*");
     }
     ;
 
 vertex_prop_expression
     : SRC_REF DOT name_label DOT name_label {
-        $$ = new SourcePropertyExpression(*$3, *$5);
+        $$ = SourcePropertyExpression::make(qctx->objPool(), *$3, *$5);
         delete $3;
         delete $5;
     }
     | DST_REF DOT name_label DOT name_label {
-        $$ = new DestPropertyExpression(*$3, *$5);
+        $$ = DestPropertyExpression::make(qctx->objPool(), *$3, *$5);
         delete $3;
         delete $5;
     }
@@ -919,31 +923,31 @@ vertex_prop_expression
 
 var_prop_expression
     : VARIABLE DOT name_label {
-        $$ = new VariablePropertyExpression(*$1, *$3);
+        $$ = VariablePropertyExpression::make(qctx->objPool(), *$1, *$3);
         delete $1;
         delete $3;
     }
     | VARIABLE DOT STAR {
-        $$ = new VariablePropertyExpression(*$1, "*");
+        $$ = VariablePropertyExpression::make(qctx->objPool(), *$1, "*");
         delete $1;
     }
     ;
 
 edge_prop_expression
     : name_label DOT TYPE_PROP {
-        $$ = new EdgeTypeExpression(*$1);
+        $$ = EdgeTypeExpression::make(qctx->objPool(), *$1);
         delete $1;
     }
     | name_label DOT SRC_ID_PROP {
-        $$ = new EdgeSrcIdExpression(*$1);
+        $$ = EdgeSrcIdExpression::make(qctx->objPool(), *$1);
         delete $1;
     }
     | name_label DOT DST_ID_PROP {
-        $$ = new EdgeDstIdExpression(*$1);
+        $$ = EdgeDstIdExpression::make(qctx->objPool(), *$1);
         delete $1;
     }
     | name_label DOT RANK_PROP {
-        $$ = new EdgeRankExpression(*$1);
+        $$ = EdgeRankExpression::make(qctx->objPool(), *$1);
         delete $1;
     }
     ;
@@ -951,18 +955,18 @@ edge_prop_expression
 function_call_expression
     : LABEL L_PAREN opt_argument_list R_PAREN {
         if ($3->numArgs() == 1 && AggFunctionManager::find(*$1).ok()) {
-            if (graph::ExpressionUtils::findInnerRandFunction($3->args()[0].get())) {
+            if (graph::ExpressionUtils::findInnerRandFunction($3->args()[0])) {
                 delete($1);
                 delete($3);
                 throw nebula::GraphParser::syntax_error(
                     @3,
                     "Can't use non-deterministic (random) functions inside of aggregate functions");
             }
-            $$ = new AggregateExpression(*$1, $3->args()[0].release(), false);
+            $$ = AggregateExpression::make(qctx->objPool(), *$1, $3->args()[0], false);
             delete($1);
             delete($3);
         } else if (FunctionManager::find(*$1, $3->numArgs()).ok()) {
-            $$ = new FunctionCallExpression(*$1, $3);
+            $$ = FunctionCallExpression::make(qctx->objPool(), *$1, $3);
             delete($1);
         } else {
             delete($1);
@@ -972,7 +976,7 @@ function_call_expression
     }
     | LABEL L_PAREN KW_DISTINCT expression R_PAREN {
         if (AggFunctionManager::find(*$1).ok()) {
-            $$ = new AggregateExpression(*$1, $4, true);
+            $$ = AggregateExpression::make(qctx->objPool(), *$1, $4, true);
             delete($1);
         } else {
             delete($1);
@@ -984,8 +988,8 @@ function_call_expression
         auto func = *$1;
         std::transform(func.begin(), func.end(), func.begin(), ::toupper);
         if (!func.compare("COUNT")) {
-            auto star = new ConstantExpression(std::string("*"));
-            $$ = new AggregateExpression(*$1, star, false);
+            auto star = ConstantExpression::make(qctx->objPool(), std::string("*"));
+            $$ = AggregateExpression::make(qctx->objPool(), *$1, star, false);
             delete $1;
         } else {
             delete($1);
@@ -996,8 +1000,8 @@ function_call_expression
         auto func = *$1;
         std::transform(func.begin(), func.end(), func.begin(), ::toupper);
         if (!func.compare("COUNT")) {
-            auto star = new ConstantExpression(std::string("*"));
-            $$ = new AggregateExpression(*$1, star, true);
+            auto star = ConstantExpression::make(qctx->objPool(), std::string("*"));
+            $$ = AggregateExpression::make(qctx->objPool(), *$1, star, true);
             delete $1;
         } else {
             delete($1);
@@ -1005,35 +1009,35 @@ function_call_expression
         }
     }
     | KW_TIMESTAMP L_PAREN opt_argument_list R_PAREN {
-        $$ = new FunctionCallExpression("timestamp", $3);
+        $$ = FunctionCallExpression::make(qctx->objPool(), "timestamp", $3);
     }
     | KW_DATE L_PAREN opt_argument_list R_PAREN {
-        $$ = new FunctionCallExpression("date", $3);
+        $$ = FunctionCallExpression::make(qctx->objPool(), "date", $3);
     }
     | KW_TIME L_PAREN opt_argument_list R_PAREN {
-        $$ = new FunctionCallExpression("time", $3);
+        $$ = FunctionCallExpression::make(qctx->objPool(), "time", $3);
     }
     | KW_DATETIME L_PAREN opt_argument_list R_PAREN {
-        $$ = new FunctionCallExpression("datetime", $3);
+        $$ = FunctionCallExpression::make(qctx->objPool(), "datetime", $3);
     }
     | KW_TAGS L_PAREN opt_argument_list R_PAREN {
-        $$ = new FunctionCallExpression("tags", $3);
+        $$ = FunctionCallExpression::make(qctx->objPool(), "tags", $3);
     }
     | KW_SIGN L_PAREN opt_argument_list R_PAREN {
-        $$ = new FunctionCallExpression("sign", $3);
+        $$ = FunctionCallExpression::make(qctx->objPool(), "sign", $3);
     }
     ;
 
 uuid_expression
     : KW_UUID L_PAREN STRING R_PAREN {
-        $$ = new UUIDExpression(*$3);
+        $$ = UUIDExpression::make(qctx->objPool(), *$3);
         delete $3;
     }
     ;
 
 opt_argument_list
     : %empty {
-        $$ = new ArgumentList();
+        $$ = ArgumentList::make(qctx->objPool());
     }
     | argument_list {
         $$ = $1;
@@ -1042,15 +1046,15 @@ opt_argument_list
 
 argument_list
     : expression {
-        $$ = new ArgumentList();
-        std::unique_ptr<Expression> arg;
-        arg.reset($1);
+        $$ = ArgumentList::make(qctx->objPool());
+        Expression* arg;
+        arg = $1;
         $$->addArgument(std::move(arg));
     }
     | argument_list COMMA expression {
         $$ = $1;
-        std::unique_ptr<Expression> arg;
-        arg.reset($3);
+        Expression* arg;
+        arg = $3;
         $$->addArgument(std::move(arg));
     }
     ;
@@ -1133,19 +1137,19 @@ container_expression
 
 list_expression
     : L_BRACKET expression_list R_BRACKET {
-        $$ = new ListExpression($2);
+        $$ = ListExpression::make(qctx->objPool(), $2);
     }
     ;
 
 set_expression
     : L_BRACE expression_list R_BRACE {
-        $$ = new SetExpression($2);
+        $$ = SetExpression::make(qctx->objPool(), $2);
     }
     ;
 
 expression_list
     : expression {
-        $$ = new ExpressionList();
+        $$ = ExpressionList::make(qctx->objPool());
         $$->add($1);
     }
     | expression_list COMMA expression {
@@ -1156,13 +1160,13 @@ expression_list
 
 map_expression
     : L_BRACE map_item_list R_BRACE {
-        $$ = new MapExpression($2);
+        $$ = MapExpression::make(qctx->objPool(), $2);
     }
     ;
 
 map_item_list
     : name_label COLON expression {
-        $$ = new MapItemList();
+        $$ = MapItemList::make(qctx->objPool());
         $$->add(*$1, $3);
         delete $1;
     }
@@ -1192,7 +1196,7 @@ go_sentence
             auto *cols = new YieldColumns();
             if (!$4->isOverAll()) {
                 for (auto e : $4->edges()) {
-                    auto *expr  = new EdgeDstIdExpression(*e->edge());
+                    auto *expr  = EdgeDstIdExpression::make(qctx->objPool(), *e->edge());
                     auto *col   = new YieldColumn(expr);
                     cols->addColumn(col);
                 }
@@ -1236,7 +1240,7 @@ vid_list
 
 vid
     : unary_integer {
-        $$ = new ConstantExpression($1);
+        $$ = ConstantExpression::make(qctx->objPool(), $1);
     }
     | function_call_expression {
         $$ = $1;
@@ -1245,7 +1249,7 @@ vid
         $$ = $1;
     }
     | STRING {
-        $$ = new ConstantExpression(*$1);
+        $$ = ConstantExpression::make(qctx->objPool(), *$1);
         delete $1;
     }
     ;
@@ -1693,7 +1697,7 @@ sign_out_text_search_service_sentence
 
 base_text_search_argument
     : name_label DOT name_label COMMA STRING {
-        auto arg = new TextSearchArgument(*$1, *$3, *$5);
+        auto arg = TextSearchArgument::make(qctx->objPool(), *$1, *$3, *$5);
         $$ = arg;
         delete $1;
         delete $3;
@@ -1792,7 +1796,7 @@ text_search_expression
             delete $3;
             throw nebula::GraphParser::syntax_error(@3, "argument error:");
         }
-        $$ = new TextSearchExpression(Expression::Kind::kTSPrefix, $3);
+        $$ = TextSearchExpression::makePrefix(qctx->objPool(), $3);
     }
     | KW_WILDCARD L_PAREN text_search_argument R_PAREN {
         if (!$3->op().empty()) {
@@ -1803,7 +1807,7 @@ text_search_expression
             delete $3;
             throw nebula::GraphParser::syntax_error(@3, "argument error:");
         }
-        $$ = new TextSearchExpression(Expression::Kind::kTSWildcard, $3);
+        $$ = TextSearchExpression::makeWildcard(qctx->objPool(), $3);
     }
     | KW_REGEXP L_PAREN text_search_argument R_PAREN {
         if (!$3->op().empty()) {
@@ -1814,10 +1818,10 @@ text_search_expression
             delete $3;
             throw nebula::GraphParser::syntax_error(@3, "argument error:");
         }
-        $$ = new TextSearchExpression(Expression::Kind::kTSRegexp, $3);
+        $$ = TextSearchExpression::makeRegexp(qctx->objPool(), $3);
     }
     | KW_FUZZY L_PAREN text_search_argument R_PAREN {
-        $$ = new TextSearchExpression(Expression::Kind::kTSFuzzy, $3);
+        $$ = TextSearchExpression::makeFuzzy(qctx->objPool(), $3);
     }
     ;
 
@@ -1924,10 +1928,10 @@ edge_key_ref
         $$ = new EdgeKeyRef($1, $3, $5, false);
     }
     | input_prop_expression R_ARROW input_prop_expression {
-        $$ = new EdgeKeyRef($1, $3, new ConstantExpression(0));
+        $$ = new EdgeKeyRef($1, $3, ConstantExpression::make(qctx->objPool(), 0));
     }
     | var_prop_expression R_ARROW var_prop_expression {
-        $$ = new EdgeKeyRef($1, $3, new ConstantExpression(0), false);
+        $$ = new EdgeKeyRef($1, $3, ConstantExpression::make(qctx->objPool(), 0), false);
     }
     ;
 
@@ -2703,8 +2707,8 @@ update_item
         $$ = new UpdateItem($1, $3);
     }
     | name_label DOT name_label ASSIGN expression {
-        auto expr = new LabelAttributeExpression(new LabelExpression(*$1),
-                                                 new ConstantExpression(*$3));
+        auto expr = LabelAttributeExpression::make(qctx->objPool(), LabelExpression::make(qctx->objPool(), *$1),
+                                                 ConstantExpression::make(qctx->objPool(), *$3));
         $$ = new UpdateItem(expr, $5);
         delete $1;
         delete $3;

--- a/src/parser/test/ExpressionParsingTest.cpp
+++ b/src/parser/test/ExpressionParsingTest.cpp
@@ -11,17 +11,24 @@
 
 namespace nebula {
 
+using graph::QueryContext;
 
 class ExpressionParsingTest : public ::testing::Test {
+    void SetUp() override {
+        qctx_ = std::make_unique<QueryContext>();
+        pool = qctx_->objPool();
+    }
+
 protected:
-    template <typename T, typename...Args>
-    static T* make(Args&&...args) {
-        return new T(std::forward<Args>(args)...);
+    template <typename T, typename... Args>
+    T *make(Args &&...args) {
+        return T::make(pool, std::forward<Args>(args)...);
     }
 
     const Expression* parse(std::string expr) {
         std::string query = "GO FROM '1' OVER * WHERE " + expr;
-        GQLParser parser;
+
+        GQLParser parser(qctx_.get());
         auto result = parser.parse(std::move(query));
         CHECK(result.ok()) << result.status();
         stmt_ = std::move(result).value();
@@ -58,8 +65,8 @@ protected:
 
         // verify
         for (auto i = 0u; i < items.size(); i++) {
-            auto *parsed = items[i].get();
-            auto *expected = items_[i].second.get();
+            auto *parsed = items[i];
+            auto *expected = items_[i].second;
             ASSERT_EQ(*parsed, *expected) << "Expression: " << items_[i].first
                                           << ", Expected: " << expected->toString()
                                           << ", Actual:   " << parsed->toString();
@@ -71,184 +78,185 @@ protected:
     using Item = std::pair<std::string, Expression*>;
     std::vector<Item>                       items_;
     std::unique_ptr<Sentence>               stmt_;
-    const Expression                       *expr_;
+    const Expression                        *expr_;
+    std::unique_ptr<QueryContext>           qctx_;
+    ObjectPool                              *pool;
 };
-
 
 TEST_F(ExpressionParsingTest, Associativity) {
     Expression * ast = nullptr;
 
-    ast = make<ArithmeticExpression>(Kind::kAdd,
-                                     make<ArithmeticExpression>(Kind::kAdd,
+    ast = ArithmeticExpression::makeAdd(pool,
+                                     ArithmeticExpression::makeAdd(pool,
                                          make<ConstantExpression>(1),
                                          make<ConstantExpression>(2)),
                                      make<ConstantExpression>(3));
     add("1 + 2 + 3", ast);
 
-    ast = make<ArithmeticExpression>(Kind::kMinus,
-                                     make<ArithmeticExpression>(Kind::kMinus,
+    ast = ArithmeticExpression::makeMinus(pool,
+                                     ArithmeticExpression::makeMinus(pool,
                                          make<ConstantExpression>(1),
                                          make<ConstantExpression>(2)),
                                      make<ConstantExpression>(3));
     add("1 - 2 - 3", ast);
 
-    ast = make<ArithmeticExpression>(Kind::kMinus,
-                                     make<ArithmeticExpression>(Kind::kAdd,
+    ast = ArithmeticExpression::makeMinus(pool,
+                                     ArithmeticExpression::makeAdd(pool,
                                          make<ConstantExpression>(1),
                                          make<ConstantExpression>(2)),
                                      make<ConstantExpression>(3));
     add("1 + 2 - 3", ast);
 
-    ast = make<ArithmeticExpression>(Kind::kAdd,
-                                     make<ArithmeticExpression>(Kind::kMinus,
+    ast = ArithmeticExpression::makeAdd(pool,
+                                     ArithmeticExpression::makeMinus(pool,
                                          make<ConstantExpression>(1),
                                          make<ConstantExpression>(2)),
                                      make<ConstantExpression>(3));
     add("1 - 2 + 3", ast);
 
-    ast = make<ArithmeticExpression>(Kind::kMultiply,
-                                     make<ArithmeticExpression>(Kind::kMultiply,
+    ast = ArithmeticExpression::makeMultiply(pool,
+                                     ArithmeticExpression::makeMultiply(pool,
                                          make<ConstantExpression>(1),
                                          make<ConstantExpression>(2)),
                                      make<ConstantExpression>(3));
     add("1 * 2 * 3", ast);
 
-    ast = make<ArithmeticExpression>(Kind::kDivision,
-                                     make<ArithmeticExpression>(Kind::kDivision,
+    ast = ArithmeticExpression::makeDivision(pool,
+                                     ArithmeticExpression::makeDivision(pool,
                                          make<ConstantExpression>(1),
                                          make<ConstantExpression>(2)),
                                      make<ConstantExpression>(3));
     add("1 / 2 / 3", ast);
 
-    ast = make<ArithmeticExpression>(Kind::kMod,
-                                     make<ArithmeticExpression>(Kind::kMod,
+    ast = ArithmeticExpression::makeMod(pool,
+                                     ArithmeticExpression::makeMod(pool,
                                          make<ConstantExpression>(1),
                                          make<ConstantExpression>(2)),
                                      make<ConstantExpression>(3));
     add("1 % 2 % 3", ast);
 
-    ast = make<ArithmeticExpression>(Kind::kDivision,
-                                     make<ArithmeticExpression>(Kind::kMultiply,
+    ast = ArithmeticExpression::makeDivision(pool,
+                                     ArithmeticExpression::makeMultiply(pool,
                                          make<ConstantExpression>(1),
                                          make<ConstantExpression>(2)),
                                      make<ConstantExpression>(3));
     add("1 * 2 / 3", ast);
 
-    ast = make<ArithmeticExpression>(Kind::kMod,
-                                     make<ArithmeticExpression>(Kind::kMultiply,
+    ast = ArithmeticExpression::makeMod(pool,
+                                     ArithmeticExpression::makeMultiply(pool,
                                          make<ConstantExpression>(1),
                                          make<ConstantExpression>(2)),
                                      make<ConstantExpression>(3));
     add("1 * 2 % 3", ast);
 
-    ast = make<ArithmeticExpression>(Kind::kMultiply,
-                                     make<ArithmeticExpression>(Kind::kDivision,
+    ast = ArithmeticExpression::makeMultiply(pool,
+                                     ArithmeticExpression::makeDivision(pool,
                                          make<ConstantExpression>(1),
                                          make<ConstantExpression>(2)),
                                      make<ConstantExpression>(3));
     add("1 / 2 * 3", ast);
 
-    ast = make<ArithmeticExpression>(Kind::kMod,
-                                     make<ArithmeticExpression>(Kind::kDivision,
+    ast = ArithmeticExpression::makeMod(pool,
+                                     ArithmeticExpression::makeDivision(pool,
                                          make<ConstantExpression>(1),
                                          make<ConstantExpression>(2)),
                                      make<ConstantExpression>(3));
     add("1 / 2 % 3", ast);
 
-    ast = make<ArithmeticExpression>(Kind::kMultiply,
-                                     make<ArithmeticExpression>(Kind::kMod,
+    ast = ArithmeticExpression::makeMultiply(pool,
+                                     ArithmeticExpression::makeMod(pool,
                                          make<ConstantExpression>(1),
                                          make<ConstantExpression>(2)),
                                      make<ConstantExpression>(3));
     add("1 % 2 * 3", ast);
 
-    ast = make<ArithmeticExpression>(Kind::kDivision,
-                                     make<ArithmeticExpression>(Kind::kMod,
+    ast = ArithmeticExpression::makeDivision(pool,
+                                     ArithmeticExpression::makeMod(pool,
                                          make<ConstantExpression>(1),
                                          make<ConstantExpression>(2)),
                                      make<ConstantExpression>(3));
     add("1 % 2 / 3", ast);
 
-    ast = make<RelationalExpression>(Kind::kRelEQ,
-                                     make<RelationalExpression>(Kind::kRelEQ,
+    ast = RelationalExpression::makeEQ(pool,
+                                     RelationalExpression::makeEQ(pool,
                                          make<ConstantExpression>(1),
                                          make<ConstantExpression>(2)),
                                      make<ConstantExpression>(3));
     add("1 == 2 == 3", ast);
 
-    ast = make<RelationalExpression>(Kind::kRelNE,
-                                     make<RelationalExpression>(Kind::kRelNE,
+    ast = RelationalExpression::makeNE(pool,
+                                     RelationalExpression::makeNE(pool,
                                          make<ConstantExpression>(1),
                                          make<ConstantExpression>(2)),
                                      make<ConstantExpression>(3));
     add("1 != 2 != 3", ast);
 
-    ast = make<RelationalExpression>(Kind::kRelLT,
-                                     make<RelationalExpression>(Kind::kRelLT,
+    ast = RelationalExpression::makeLT(pool,
+                                     RelationalExpression::makeLT(pool,
                                          make<ConstantExpression>(1),
                                          make<ConstantExpression>(2)),
                                      make<ConstantExpression>(3));
     add("1 < 2 < 3", ast);
 
-    ast = make<RelationalExpression>(Kind::kRelLE,
-                                     make<RelationalExpression>(Kind::kRelLE,
+    ast = RelationalExpression::makeLE(pool,
+                                     RelationalExpression::makeLE(pool,
                                          make<ConstantExpression>(1),
                                          make<ConstantExpression>(2)),
                                      make<ConstantExpression>(3));
     add("1 <= 2 <= 3", ast);
 
-    ast = make<RelationalExpression>(Kind::kRelGT,
-                                     make<RelationalExpression>(Kind::kRelGT,
+    ast = RelationalExpression::makeGT(pool,
+                                     RelationalExpression::makeGT(pool,
                                          make<ConstantExpression>(1),
                                          make<ConstantExpression>(2)),
                                      make<ConstantExpression>(3));
     add("1 > 2 > 3", ast);
 
-    ast = make<RelationalExpression>(Kind::kRelGE,
-                                     make<RelationalExpression>(Kind::kRelGE,
+    ast = RelationalExpression::makeGE(pool,
+                                     RelationalExpression::makeGE(pool,
                                          make<ConstantExpression>(1),
                                          make<ConstantExpression>(2)),
                                      make<ConstantExpression>(3));
     add("1 >= 2 >= 3", ast);
 
-    ast = make<RelationalExpression>(Kind::kRelIn,
-                                     make<RelationalExpression>(Kind::kRelIn,
+    ast = RelationalExpression::makeIn(pool,
+                                     RelationalExpression::makeIn(pool,
                                          make<LabelExpression>("a"),
                                          make<LabelExpression>("b")),
                                      make<LabelExpression>("c"));
     add("a IN b IN c", ast);
 
-    ast = make<RelationalExpression>(Kind::kRelNotIn,
-                                     make<RelationalExpression>(Kind::kRelNotIn,
+    ast = RelationalExpression::makeNotIn(pool,
+                                     RelationalExpression::makeNotIn(pool,
                                          make<LabelExpression>("a"),
                                          make<LabelExpression>("b")),
                                      make<LabelExpression>("c"));
     add("a NOT IN b NOT IN c", ast);
 
-    ast = make<RelationalExpression>(Kind::kContains,
-                                     make<RelationalExpression>(Kind::kContains,
+    ast = RelationalExpression::makeContains(pool,
+                                     RelationalExpression::makeContains(pool,
                                          make<LabelExpression>("a"),
                                          make<LabelExpression>("b")),
                                      make<LabelExpression>("c"));
     add("a CONTAINS b CONTAINS c", ast);
 
     /*
-    ast = make<RelationalExpression>(Kind::kRelNotContains,
-                                     make<RelationalExpression>(Kind::kRelNotContains,
+    ast = RelationalExpression::makeNotContains(pool,
+                                     RelationalExpression::makeNotContains(pool,
                                         make<LabelExpression>("a"),
                                         make<LabelExpression>("b")),
                                      make<LabelExpression>("c"));
     add("1 NOT CONTAINS 2 NOT CONTAINS 3", ast);
     */
-    ast = make<RelationalExpression>(Kind::kStartsWith,
-                                     make<RelationalExpression>(Kind::kStartsWith,
+    ast = RelationalExpression::makeStartsWith(pool,
+                                     RelationalExpression::makeStartsWith(pool,
                                          make<LabelExpression>("a"),
                                          make<LabelExpression>("b")),
                                      make<LabelExpression>("c"));
     add("a STARTS WITH b STARTS WITH c", ast);
 
-    ast = make<RelationalExpression>(Kind::kEndsWith,
-                                     make<RelationalExpression>(Kind::kEndsWith,
+    ast = RelationalExpression::makeEndsWith(pool,
+                                     RelationalExpression::makeEndsWith(pool,
                                          make<LabelExpression>("a"),
                                          make<LabelExpression>("b")),
                                      make<LabelExpression>("c"));
@@ -266,36 +274,36 @@ TEST_F(ExpressionParsingTest, Associativity) {
                                     make<ConstantExpression>("c"));
     add("a.b.c", ast);
 
-    ast = make<LogicalExpression>(Kind::kLogicalAnd,
-                                  make<LogicalExpression>(Kind::kLogicalAnd,
+    ast = LogicalExpression::makeAnd(pool,
+                                  LogicalExpression::makeAnd(pool,
                                       make<LabelExpression>("a"),
                                       make<LabelExpression>("b")),
                                   make<LabelExpression>("c"));
     add("a AND b AND c", ast);
 
-    ast = make<LogicalExpression>(Kind::kLogicalAnd,
-                                  make<LogicalExpression>(Kind::kLogicalAnd,
+    ast = LogicalExpression::makeAnd(pool,
+                                  LogicalExpression::makeAnd(pool,
                                       make<LabelExpression>("a"),
                                       make<LabelExpression>("b")),
                                   make<LabelExpression>("c"));
     add("a AND b AND c", ast);
 
-    ast = make<LogicalExpression>(Kind::kLogicalOr,
-                                  make<LogicalExpression>(Kind::kLogicalOr,
+    ast = LogicalExpression::makeOr(pool,
+                                  LogicalExpression::makeOr(pool,
                                       make<LabelExpression>("a"),
                                       make<LabelExpression>("b")),
                                   make<LabelExpression>("c"));
     add("a OR b OR c", ast);
 
-    ast = make<LogicalExpression>(Kind::kLogicalOr,
-                                  make<LogicalExpression>(Kind::kLogicalOr,
+    ast = LogicalExpression::makeOr(pool,
+                                  LogicalExpression::makeOr(pool,
                                       make<LabelExpression>("a"),
                                       make<LabelExpression>("b")),
                                   make<LabelExpression>("c"));
     add("a OR b OR c", ast);
 
-    ast = make<LogicalExpression>(Kind::kLogicalXor,
-                                  make<LogicalExpression>(Kind::kLogicalXor,
+    ast = LogicalExpression::makeXor(pool,
+                                  LogicalExpression::makeXor(pool,
                                       make<LabelExpression>("a"),
                                       make<LabelExpression>("b")),
                                   make<LabelExpression>("c"));
@@ -306,16 +314,16 @@ TEST_F(ExpressionParsingTest, Associativity) {
                                           make<ConstantExpression>(3.14)));
     add("(int)(double)3.14", ast);
 
-    ast = make<UnaryExpression>(Kind::kUnaryNot,
-                                make<UnaryExpression>(Kind::kUnaryNot,
+    ast = UnaryExpression::makeNot(pool,
+                                UnaryExpression::makeNot(pool,
                                     make<ConstantExpression>(false)));
     add("!!false", ast);
 
-    auto cases = new CaseList();
+    auto cases = CaseList::make(pool);
     cases->add(make<ConstantExpression>(3), make<ConstantExpression>(4));
     ast = make<CaseExpression>(cases);
     static_cast<CaseExpression*>(ast)->setCondition(make<LabelExpression>("a"));
-    auto cases2 = new CaseList();
+    auto cases2 = CaseList::make(pool);
     cases2->add(make<ConstantExpression>(5), make<ConstantExpression>(6));
     auto ast2 = make<CaseExpression>(cases2);
     ast2->setCondition(make<LabelExpression>("b"));
@@ -330,102 +338,102 @@ TEST_F(ExpressionParsingTest, Associativity) {
 TEST_F(ExpressionParsingTest, Precedence) {
     Expression *ast = nullptr;
 
-    ast = make<ArithmeticExpression>(Kind::kAdd,
+    ast = ArithmeticExpression::makeAdd(pool,
                                      make<ConstantExpression>(1),
-                                     make<ArithmeticExpression>(Kind::kMultiply,
+                                     ArithmeticExpression::makeMultiply(pool,
                                          make<ConstantExpression>(2),
                                          make<ConstantExpression>(3)));
     add("1 + 2 * 3", ast);
 
-    ast = make<ArithmeticExpression>(Kind::kMinus,
+    ast = ArithmeticExpression::makeMinus(pool,
                                      make<ConstantExpression>(1),
-                                     make<ArithmeticExpression>(Kind::kMultiply,
+                                     ArithmeticExpression::makeMultiply(pool,
                                          make<ConstantExpression>(2),
                                          make<ConstantExpression>(3)));
     add("1 - 2 * 3", ast);
 
-    ast = make<ArithmeticExpression>(Kind::kAdd,
+    ast = ArithmeticExpression::makeAdd(pool,
                                      make<ConstantExpression>(1),
-                                     make<ArithmeticExpression>(Kind::kDivision,
+                                     ArithmeticExpression::makeDivision(pool,
                                          make<ConstantExpression>(2),
                                          make<ConstantExpression>(3)));
     add("1 + 2 / 3", ast);
 
-    ast = make<ArithmeticExpression>(Kind::kMinus,
+    ast = ArithmeticExpression::makeMinus(pool,
                                      make<ConstantExpression>(1),
-                                     make<ArithmeticExpression>(Kind::kDivision,
+                                     ArithmeticExpression::makeDivision(pool,
                                          make<ConstantExpression>(2),
                                          make<ConstantExpression>(3)));
     add("1 - 2 / 3", ast);
 
-    ast = make<ArithmeticExpression>(Kind::kAdd,
+    ast = ArithmeticExpression::makeAdd(pool,
                                      make<ConstantExpression>(1),
-                                     make<ArithmeticExpression>(Kind::kMod,
+                                     ArithmeticExpression::makeMod(pool,
                                          make<ConstantExpression>(2),
                                          make<ConstantExpression>(3)));
     add("1 + 2 % 3", ast);
 
-    ast = make<ArithmeticExpression>(Kind::kMinus,
+    ast = ArithmeticExpression::makeMinus(pool,
                                      make<ConstantExpression>(1),
-                                     make<ArithmeticExpression>(Kind::kMod,
+                                     ArithmeticExpression::makeMod(pool,
                                          make<ConstantExpression>(2),
                                          make<ConstantExpression>(3)));
     add("1 - 2 % 3", ast);
 
-    ast = make<RelationalExpression>(Kind::kRelLT,
-                                     make<ArithmeticExpression>(Kind::kAdd,
+    ast = RelationalExpression::makeLT(pool,
+                                     ArithmeticExpression::makeAdd(pool,
                                          make<ConstantExpression>(1),
                                          make<ConstantExpression>(2)),
-                                     make<ArithmeticExpression>(Kind::kAdd,
+                                     ArithmeticExpression::makeAdd(pool,
                                          make<ConstantExpression>(3),
                                          make<ConstantExpression>(4)));
     add("1 + 2 < 3 + 4", ast);
 
-    ast = make<LogicalExpression>(Kind::kLogicalOr,
-                                  make<UnaryExpression>(Kind::kUnaryPlus,
+    ast = LogicalExpression::makeOr(pool,
+                                  UnaryExpression::makePlus(pool,
                                       make<ConstantExpression>(1)),
-                                  make<LogicalExpression>(Kind::kLogicalAnd,
-                                      make<RelationalExpression>(Kind::kRelNE,
+                                  LogicalExpression::makeAnd(pool,
+                                      RelationalExpression::makeNE(pool,
                                           make<ConstantExpression>(1),
-                                          make<ArithmeticExpression>(Kind::kMinus,
+                                          ArithmeticExpression::makeMinus(pool,
                                               make<ConstantExpression>(2),
                                               make<ConstantExpression>(1))),
-                                      make<RelationalExpression>(Kind::kRelEQ,
+                                      RelationalExpression::makeEQ(pool,
                                           make<ConstantExpression>(3),
                                           make<ConstantExpression>(4))));
     add("+1 OR 1 != 2 - 1 AND 3 == 4", ast);
 
-    ast = make<UnaryExpression>(Kind::kUnaryNot,
-            make<RelationalExpression>(Kind::kRelLT,
-                make<ArithmeticExpression>(Kind::kAdd,
+    ast = UnaryExpression::makeNot(pool,
+            RelationalExpression::makeLT(pool,
+                ArithmeticExpression::makeAdd(pool,
                     make<ConstantExpression>(1),
                     make<ConstantExpression>(2)),
                 make<ConstantExpression>(3)));
     add("NOT 1 + 2 < 3", ast);
 
-    ast = make<LogicalExpression>(Kind::kLogicalAnd,
-            make<UnaryExpression>(Kind::kUnaryNot,
-                make<RelationalExpression>(Kind::kRelLT,
-                    make<ArithmeticExpression>(Kind::kAdd,
+    ast = LogicalExpression::makeAnd(pool,
+            UnaryExpression::makeNot(pool,
+                RelationalExpression::makeLT(pool,
+                    ArithmeticExpression::makeAdd(pool,
                         make<ConstantExpression>(1),
                         make<ConstantExpression>(2)),
                     make<ConstantExpression>(3))),
-            make<UnaryExpression>(Kind::kUnaryNot,
-                make<RelationalExpression>(Kind::kRelLT,
-                    make<ArithmeticExpression>(Kind::kAdd,
+            UnaryExpression::makeNot(pool,
+                RelationalExpression::makeLT(pool,
+                    ArithmeticExpression::makeAdd(pool,
                         make<ConstantExpression>(1),
                         make<ConstantExpression>(2)),
                     make<ConstantExpression>(3))));
     add("NOT 1 + 2 < 3 AND NOT 1 + 2 < 3", ast);
 
-    ast = make<ArithmeticExpression>(Kind::kMinus,
-                                     make<ArithmeticExpression>(Kind::kMultiply,
-                                         make<UnaryExpression>(Kind::kUnaryNot,
+    ast = ArithmeticExpression::makeMinus(pool,
+                                     ArithmeticExpression::makeMultiply(pool,
+                                         UnaryExpression::makeNot(pool,
                                              make<ConstantExpression>(true)),
-                                         make<UnaryExpression>(Kind::kUnaryNegate,
+                                         UnaryExpression::makeNegate(pool,
                                              make<ConstantExpression>(1))),
-                                     make<UnaryExpression>(Kind::kUnaryNot,
-                                         make<UnaryExpression>(Kind::kUnaryNot,
+                                     UnaryExpression::makeNot(pool,
+                                         UnaryExpression::makeNot(pool,
                                              make<ConstantExpression>(false))));
     add("!true * -1 - NOT NOT false", ast);
 
@@ -438,9 +446,9 @@ TEST_F(ExpressionParsingTest, Precedence) {
             make<ConstantExpression>("m"));
     add("$var[0]['1'].m", ast);
 
-    ast = make<LogicalExpression>(Kind::kLogicalXor,
-                                  make<UnaryExpression>(Kind::kUnaryNot,
-                                      make<ArithmeticExpression>(Kind::kMultiply,
+    ast = LogicalExpression::makeXor(pool,
+                                  UnaryExpression::makeNot(pool,
+                                      ArithmeticExpression::makeMultiply(pool,
                                           make<AttributeExpression>(
                                               make<LabelAttributeExpression>(
                                                   make<LabelExpression>("a"),
@@ -453,10 +461,10 @@ TEST_F(ExpressionParsingTest, Precedence) {
                                                   make<ConstantExpression>("q")),
                                               make<LabelExpression>("r")),
                                           make<LabelExpression>("s")))),
-                                  make<RelationalExpression>(Kind::kRelIn,
+                                  RelationalExpression::makeIn(pool,
                                       make<InputPropertyExpression>("m"),
                                       make<ListExpression>(
-                                          &(*(new ExpressionList))
+                                          &(*(ExpressionList::make(pool)))
                                           .add(make<ConstantExpression>(1))
                                           .add(make<ConstantExpression>(2))
                                           .add(make<ConstantExpression>(3)))));

--- a/src/parser/test/ExpressionParsingTest.cpp
+++ b/src/parser/test/ExpressionParsingTest.cpp
@@ -68,7 +68,7 @@ protected:
 
 protected:
     using Kind = Expression::Kind;
-    using Item = std::pair<std::string, std::unique_ptr<Expression>>;
+    using Item = std::pair<std::string, Expression*>;
     std::vector<Item>                       items_;
     std::unique_ptr<Sentence>               stmt_;
     const Expression                       *expr_;

--- a/src/parser/test/ParserBenchmark.cpp
+++ b/src/parser/test/ParserBenchmark.cpp
@@ -15,6 +15,7 @@ auto complexQuery =  "GO 2 STEPS FROM 123456789 OVER myedge "
                      "WHERE alias.prop1 + alias.prop2 * alias.prop3 > alias.prop4 AND "
                      "alias.prop5 == alias.prop6 YIELD 1 AS first, 2 AS second";
 
+auto qctx = std::make_unique<nebula::graph::QueryContext>();
 
 size_t SimpleQuery(size_t iters, size_t nrThreads) {
     constexpr size_t ops = 500000UL;
@@ -23,7 +24,7 @@ size_t SimpleQuery(size_t iters, size_t nrThreads) {
         auto n = iters * ops;
         for (auto i = 0UL; i < n; i++) {
             // static thread_local GQLParser parser;
-            GQLParser parser;
+            GQLParser parser(qctx.get());
             auto result = parser.parse(simpleQuery);
             folly::doNotOptimizeAway(result);
         }
@@ -47,7 +48,7 @@ size_t ComplexQuery(size_t iters, size_t nrThreads) {
         auto n = iters * ops;
         for (auto i = 0UL; i < n; i++) {
             // static thread_local GQLParser parser;
-            GQLParser parser;
+            GQLParser parser(qctx.get());
             auto result = parser.parse(complexQuery);
             folly::doNotOptimizeAway(result);
         }
@@ -86,12 +87,12 @@ int
 main(int argc, char **argv) {
     gflags::ParseCommandLineFlags(&argc, &argv, true);
     {
-        GQLParser parser;
+        GQLParser parser(qctx.get());
         auto result = parser.parse(simpleQuery);
         CHECK(result.ok()) << result.status();
     }
     {
-        GQLParser parser;
+        GQLParser parser(qctx.get());
         auto result = parser.parse(complexQuery);
         CHECK(result.ok()) << result.status();
     }

--- a/src/parser/test/ParserTest.cpp
+++ b/src/parser/test/ParserTest.cpp
@@ -11,15 +11,31 @@
 
 namespace nebula {
 
-static StatusOr<std::unique_ptr<Sentence>> parse(const std::string &query) {
-    GQLParser parser;
-    auto result = parser.parse(query);
-    NG_RETURN_IF_ERROR(result);
-    NG_RETURN_IF_ERROR(graph::AstUtils::reprAstCheck(*result.value()));
-    return result;
-}
+using graph::QueryContext;
+class ParserTest : public ::testing::Test {
+public:
+    void SetUp() override {
+        qctx_ = std::make_unique<graph::QueryContext>();
+    }
+    void TearDown() override {
+        qctx_.reset();
+    }
 
-TEST(Parser, TestSchemaCreation) {
+protected:
+    StatusOr<std::unique_ptr<Sentence>> parse(const std::string& query) {
+        auto* qctx = qctx_.get();
+        GQLParser parser(qctx);
+        auto result = parser.parse(query);
+        NG_RETURN_IF_ERROR(result);
+        NG_RETURN_IF_ERROR(graph::AstUtils::reprAstCheck(*result.value(), qctx));
+        return result;
+    }
+
+protected:
+    std::unique_ptr<QueryContext> qctx_;
+};
+
+TEST_F(ParserTest, TestSchemaCreation) {
     // All type
     {
         std::string query = "CREATE TAG person(name STRING, age INT8, count INT16, "
@@ -78,7 +94,7 @@ TEST(Parser, TestSchemaCreation) {
     }
 }
 
-TEST(Parser, Go) {
+TEST_F(ParserTest, Go) {
     {
         std::string query = "GO FROM \"1\" OVER friend";
         auto result = parse(query);
@@ -155,7 +171,7 @@ TEST(Parser, Go) {
     }
 }
 
-TEST(Parser, SpaceOperation) {
+TEST_F(ParserTest, SpaceOperation) {
     {
         std::string query = "CREATE SPACE default_space(partition_num=9, replica_factor=3)";
         auto result = parse(query);
@@ -259,7 +275,7 @@ TEST(Parser, SpaceOperation) {
     }
 }
 
-TEST(Parser, TagOperation) {
+TEST_F(ParserTest, TagOperation) {
     {
         std::string query = "CREATE TAG person(name string, age int, "
                             "married bool, salary double)";
@@ -347,7 +363,7 @@ TEST(Parser, TagOperation) {
     }
 }
 
-TEST(Parser, EdgeOperation) {
+TEST_F(ParserTest, EdgeOperation) {
     {
         std::string query = "CREATE EDGE e1(name string, age int, "
                             "married bool, salary double)";
@@ -429,7 +445,7 @@ TEST(Parser, EdgeOperation) {
     }
 }
 // Column space format test, expected SyntaxError
-TEST(Parser, ColumnSpacesTest) {
+TEST_F(ParserTest, ColumnSpacesTest) {
     {
         std::string query = "CREATE TAG person(name, age, married bool)";
         auto result = parse(query);
@@ -490,7 +506,7 @@ TEST(Parser, ColumnSpacesTest) {
     }
 }
 
-TEST(Parser, IndexOperation) {
+TEST_F(ParserTest, IndexOperation) {
     {
         std::string query = "CREATE TAG INDEX empty_field_index ON person()";
         auto result = parse(query);
@@ -626,7 +642,7 @@ TEST(Parser, IndexOperation) {
     }
 }
 
-TEST(Parser, Set) {
+TEST_F(ParserTest, Set) {
     {
         std::string query = "GO FROM \"1\" OVER friend INTERSECT "
                             "GO FROM \"2\" OVER friend";
@@ -677,7 +693,7 @@ TEST(Parser, Set) {
     }
 }
 
-TEST(Parser, Pipe) {
+TEST_F(ParserTest, Pipe) {
     {
         std::string query = "GO FROM \"1\" OVER friend | "
                             "GO FROM \"2\" OVER friend | "
@@ -694,7 +710,7 @@ TEST(Parser, Pipe) {
     }
 }
 
-TEST(Parser, InsertVertex) {
+TEST_F(ParserTest, InsertVertex) {
     {
         std::string query = "INSERT VERTEX person(name,age,married,salary,create_time) "
                             "VALUES \"Tom\":(\"Tom\", 30, true, 3.14, 1551331900)";
@@ -780,7 +796,7 @@ TEST(Parser, InsertVertex) {
     }
 }
 
-TEST(Parser, UpdateVertex) {
+TEST_F(ParserTest, UpdateVertex) {
     {
         std::string query = "UPDATE VERTEX \"12345\" "
                             "SET person.name=\"Tome\", person.age=30, "
@@ -863,7 +879,7 @@ TEST(Parser, UpdateVertex) {
     }
 }
 
-TEST(Parser, InsertEdge) {
+TEST_F(ParserTest, InsertEdge) {
     {
         std::string query = "INSERT EDGE transfer(amount, time_) "
                             "VALUES \"12345\"->\"54321\":(3.75, 1537408527)";
@@ -924,7 +940,7 @@ TEST(Parser, InsertEdge) {
     }
 }
 
-TEST(Parser, UpdateEdge) {
+TEST_F(ParserTest, UpdateEdge) {
     {
         std::string query = "UPDATE EDGE \"12345\" -> \"54321\" OF transfer "
                             "SET amount=3.14, time_=1537408527";
@@ -986,7 +1002,7 @@ TEST(Parser, UpdateEdge) {
     }
 }
 
-TEST(Parser, DeleteVertex) {
+TEST_F(ParserTest, DeleteVertex) {
     {
         std::string query = "DELETE VERTEX \"12345\"";
         auto result = parse(query);
@@ -1025,7 +1041,7 @@ TEST(Parser, DeleteVertex) {
     }
 }
 
-TEST(Parser, DeleteEdge) {
+TEST_F(ParserTest, DeleteEdge) {
     {
         std::string query = "DELETE EDGE transfer \"12345\" -> \"5432\"";
         auto result = parse(query);
@@ -1053,7 +1069,7 @@ TEST(Parser, DeleteEdge) {
     }
 }
 
-TEST(Parser, FetchVertex) {
+TEST_F(ParserTest, FetchVertex) {
     {
         std::string query = "FETCH PROP ON person \"1\"";
         auto result = parse(query);
@@ -1153,7 +1169,7 @@ TEST(Parser, FetchVertex) {
     }
 }
 
-TEST(Parser, FetchEdge) {
+TEST_F(ParserTest, FetchEdge) {
     {
         std::string query = "FETCH PROP ON transfer \"12345\" -> \"54321\"";
         auto result = parse(query);
@@ -1193,7 +1209,7 @@ TEST(Parser, FetchEdge) {
     }
 }
 
-TEST(Parser, Lookup) {
+TEST_F(ParserTest, Lookup) {
     {
         std::string query = "LOOKUP ON person";
         auto result = parse(query);
@@ -1222,7 +1238,7 @@ TEST(Parser, Lookup) {
     }
 }
 
-TEST(Parser, subgraph) {
+TEST_F(ParserTest, subgraph) {
     {
         std::string query = "GET SUBGRAPH FROM \"TOM\"";
         auto result = parse(query);
@@ -1275,7 +1291,7 @@ TEST(Parser, subgraph) {
     }
 }
 
-TEST(Parser, AdminOperation) {
+TEST_F(ParserTest, AdminOperation) {
     {
         std::string query = "SHOW HOSTS";
         auto result = parse(query);
@@ -1383,7 +1399,7 @@ TEST(Parser, AdminOperation) {
     }
 }
 
-TEST(Parser, UserOperation) {
+TEST_F(ParserTest, UserOperation) {
     {
         std::string query = "CREATE USER user1";
         auto result = parse(query);
@@ -1495,7 +1511,7 @@ TEST(Parser, UserOperation) {
     }
 }
 
-TEST(Parser, UnreservedKeywords) {
+TEST_F(ParserTest, UnreservedKeywords) {
     {
         std::string query = "CREATE TAG tag1(space string, spaces string, "
                             "email string, password string, roles string, uuid int, "
@@ -1552,7 +1568,7 @@ TEST(Parser, UnreservedKeywords) {
     }
 }
 
-TEST(Parser, Annotation) {
+TEST_F(ParserTest, Annotation) {
     {
         std::string query = "show spaces /* test comment....";
         auto result = parse(query);
@@ -1595,7 +1611,7 @@ TEST(Parser, Annotation) {
     }
 }
 
-TEST(Parser, DownloadAndIngest) {
+TEST_F(ParserTest, DownloadAndIngest) {
     {
         std::string query = "DOWNLOAD HDFS \"hdfs://127.0.0.1:9090/data\"";
         auto result = parse(query);
@@ -1608,7 +1624,7 @@ TEST(Parser, DownloadAndIngest) {
     }
 }
 
-TEST(Parser, Agg) {
+TEST_F(ParserTest, Agg) {
     {
         std::string query = "ORDER BY $-.id";
         auto result = parse(query);
@@ -1658,7 +1674,7 @@ TEST(Parser, Agg) {
     }
 }
 
-TEST(Parser, ReentrantRecoveryFromFailure) {
+TEST_F(ParserTest, ReentrantRecoveryFromFailure) {
     {
         std::string query = "USE dumy tag_name";
         ASSERT_FALSE(parse(query).ok());
@@ -1670,7 +1686,7 @@ TEST(Parser, ReentrantRecoveryFromFailure) {
     }
 }
 
-TEST(Parser, IllegalCharacter) {
+TEST_F(ParserTest, IllegalCharacter) {
     {
         std::string query = "USE space；";
         ASSERT_FALSE(parse(query).ok());
@@ -1681,7 +1697,7 @@ TEST(Parser, IllegalCharacter) {
     }
 }
 
-TEST(Parser, Distinct) {
+TEST_F(ParserTest, Distinct) {
     {
         std::string query = "GO FROM \"1\" OVER friend "
                             "YIELD DISTINCT friend.name as name, friend.age as age";
@@ -1704,7 +1720,7 @@ TEST(Parser, Distinct) {
     }
 }
 
-TEST(Parser, ConfigOperation) {
+TEST_F(ParserTest, ConfigOperation) {
     {
         std::string query = "SHOW CONFIGS";
         auto result = parse(query);
@@ -1765,7 +1781,7 @@ TEST(Parser, ConfigOperation) {
     }
 }
 
-TEST(Parser, BalanceOperation) {
+TEST_F(ParserTest, BalanceOperation) {
     {
         std::string query = "BALANCE LEADER";
         auto result = parse(query);
@@ -1803,7 +1819,7 @@ TEST(Parser, BalanceOperation) {
     }
 }
 
-TEST(Parser, CrashByFuzzer) {
+TEST_F(ParserTest, CrashByFuzzer) {
     {
         std::string query = ";YIELD\nI41( ,1)GEGE.INGEST";
         auto result = parse(query);
@@ -1811,7 +1827,7 @@ TEST(Parser, CrashByFuzzer) {
     }
 }
 
-TEST(Parser, FindPath) {
+TEST_F(ParserTest, FindPath) {
     {
         std::string query = "FIND SHORTEST PATH FROM \"1\" TO \"2\" OVER like";
         auto result = parse(query);
@@ -1834,7 +1850,7 @@ TEST(Parser, FindPath) {
     }
 }
 
-TEST(Parser, Limit) {
+TEST_F(ParserTest, Limit) {
     {
         std::string query = "GO FROM \"1\" OVER work | LIMIT 1";
         auto result = parse(query);
@@ -1858,7 +1874,7 @@ TEST(Parser, Limit) {
     }
 }
 
-TEST(Parser, GroupBy) {
+TEST_F(ParserTest, GroupBy) {
     // All fun succeed
     {
         std::string query = "GO FROM \"1\" OVER work "
@@ -1948,7 +1964,7 @@ TEST(Parser, GroupBy) {
     }
 }
 
-TEST(Parser, ErrorMsg) {
+TEST_F(ParserTest, ErrorMsg) {
     {
         std::string query = "CREATE SPACE " + std::string(4097, 'A');
         auto result = parse(query);
@@ -2099,7 +2115,7 @@ TEST(Parser, ErrorMsg) {
     }
 }
 
-TEST(Parser, UseReservedKeyword) {
+TEST_F(ParserTest, UseReservedKeyword) {
     {
         std::string query = "CREATE TAG tag()";
         auto result = parse(query);
@@ -2130,7 +2146,7 @@ TEST(Parser, UseReservedKeyword) {
     }
 }
 
-TEST(Parser, TypeCast) {
+TEST_F(ParserTest, TypeCast) {
     {
         std::string query = "YIELD (INT)\"123\"";
         auto result = parse(query);
@@ -2218,7 +2234,7 @@ TEST(Parser, TypeCast) {
     }
 }
 
-TEST(Parser, Match) {
+TEST_F(ParserTest, Match) {
     {
         std::string query = "MATCH () -- () RETURN *";
         auto result = parse(query);
@@ -2441,7 +2457,7 @@ TEST(Parser, Match) {
     }
 }
 
-TEST(Parser, MatchErrorCheck) {
+TEST_F(ParserTest, MatchErrorCheck) {
     {
         std::string query = "MATCH (v:player) WHERE count(v)>1 RETURN v";
         auto result = parse(query);
@@ -2452,7 +2468,7 @@ TEST(Parser, MatchErrorCheck) {
     }
 }
 
-TEST(Parser, MatchMultipleTags) {
+TEST_F(ParserTest, MatchMultipleTags) {
     {
         std::string query = "MATCH (a:person:player) --> (b) RETURN *";
         auto result = parse(query);
@@ -2482,7 +2498,7 @@ TEST(Parser, MatchMultipleTags) {
     }
 }
 
-TEST(Parser, MatchListSubscriptRange) {
+TEST_F(ParserTest, MatchListSubscriptRange) {
     {
         std::string query = "WITH [0, 1, 2] AS list RETURN list[0..] AS l";
         auto result = parse(query);
@@ -2500,7 +2516,7 @@ TEST(Parser, MatchListSubscriptRange) {
     }
 }
 
-TEST(Parser, Zone) {
+TEST_F(ParserTest, Zone) {
     {
         std::string query = "SHOW GROUPS";
         auto result = parse(query);
@@ -2573,7 +2589,7 @@ TEST(Parser, Zone) {
     }
 }
 
-TEST(Parser, FullText) {
+TEST_F(ParserTest, FullText) {
     {
         std::string query = "LOOKUP ON t1 WHERE PREFIX(t1.c1, \"a\")";
         auto result = parse(query);
@@ -2711,7 +2727,7 @@ TEST(Parser, FullText) {
     }
 }
 
-TEST(Parser, FullTextServiceTest) {
+TEST_F(ParserTest, FullTextServiceTest) {
     {
         std::string query = "ADD LISTENER ELASTICSEARCH 127.0.0.1:12000";
         auto result = parse(query);
@@ -2764,23 +2780,23 @@ TEST(Parser, FullTextServiceTest) {
         ASSERT_FALSE(result.ok());
     }
     {
-        GQLParser parser;
+        // GQLParser parser(qctx.get());
         std::string query = "SHOW SESSIONS";
-        auto result = parser.parse(query);
+        auto result = parse(query);
         ASSERT_TRUE(result.ok()) << result.status();
         ASSERT_EQ(result.value()->toString(), "SHOW SESSIONS");
     }
     {
-        GQLParser parser;
+        // GQLParser parser(qctx.get());
         std::string query = "SHOW SESSION 123";
-        auto result = parser.parse(query);
+        auto result = parse(query);
         ASSERT_TRUE(result.ok()) << result.status();
         ASSERT_EQ(result.value()->toString(), "SHOW SESSION 123");
     }
 }
 
-TEST(Parser, JobTest) {
-    auto checkTest = [] (const std::string& query, const std::string expectedStr) {
+TEST_F(ParserTest, JobTest) {
+    auto checkTest = [&] (const std::string& query, const std::string expectedStr) {
         auto result = parse(query);
         ASSERT_TRUE(result.ok()) << query << ":" << result.status();
         ASSERT_EQ(result.value()->toString(), expectedStr);

--- a/src/parser/test/ParserTest.cpp
+++ b/src/parser/test/ParserTest.cpp
@@ -2796,7 +2796,7 @@ TEST_F(ParserTest, FullTextServiceTest) {
 }
 
 TEST_F(ParserTest, JobTest) {
-    auto checkTest = [&] (const std::string& query, const std::string expectedStr) {
+    auto checkTest = [&, this] (const std::string& query, const std::string expectedStr) {
         auto result = parse(query);
         ASSERT_TRUE(result.ok()) << query << ":" << result.status();
         ASSERT_EQ(result.value()->toString(), expectedStr);

--- a/src/parser/test/fuzzing/ParserFuzzer.cpp
+++ b/src/parser/test/fuzzing/ParserFuzzer.cpp
@@ -8,7 +8,8 @@
 #include "parser/GQLParser.h"
 
 extern "C" int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size) {
-    nebula::GQLParser parser;
+    nebula::graph::QueryContext qctx;
+    nebula::GQLParser parser(&qctx);
     const char* ptr = reinterpret_cast<const char*>(data);
     std::string query = {ptr, size};
     auto result = parser.parse(query);

--- a/src/planner/match/Expand.cpp
+++ b/src/planner/match/Expand.cpp
@@ -68,18 +68,20 @@ std::unique_ptr<std::vector<storage::cpp2::EdgeProp>> Expand::genEdgeProps(const
     return edgeProps;
 }
 
-static Expression* mergePathColumnsExpr(const std::string& lcol, const std::string& rcol) {
-    auto expr = std::make_unique<PathBuildExpression>();
-    expr->add(ExpressionUtils::inputPropExpr(lcol));
-    expr->add(ExpressionUtils::inputPropExpr(rcol));
-    return expr.release();
+static Expression* mergePathColumnsExpr(ObjectPool* pool,
+                                        const std::string& lcol,
+                                        const std::string& rcol) {
+    auto expr = PathBuildExpression::make(pool);
+    expr->add(InputPropertyExpression::make(pool, lcol));
+    expr->add(InputPropertyExpression::make(pool, rcol));
+    return expr;
 }
 
-static Expression* buildPathExpr() {
-    auto expr = std::make_unique<PathBuildExpression>();
-    expr->add(std::make_unique<VertexExpression>());
-    expr->add(std::make_unique<EdgeExpression>());
-    return expr.release();
+static Expression* buildPathExpr(ObjectPool* pool) {
+    auto expr = PathBuildExpression::make(pool);
+    expr->add(VertexExpression::make(pool));
+    expr->add(EdgeExpression::make(pool));
+    return expr;
 }
 
 Status Expand::doExpand(const NodeInfo& node, const EdgeInfo& edge, SubPlan* plan) {
@@ -105,7 +107,7 @@ Status Expand::expandSteps(const NodeInfo& node, const EdgeInfo& edge, SubPlan* 
         NG_RETURN_IF_ERROR(MatchSolver::appendFetchVertexPlan(node.filter,
                                                               matchCtx_->space,
                                                               matchCtx_->qctx,
-                                                              initialExpr_.release(),
+                                                              initialExpr_,
                                                               inputVar_,
                                                               subplan));
     } else {   // Case 1 to n steps
@@ -167,22 +169,22 @@ Status Expand::expandStep(const EdgeInfo& edge,
                           const Expression* nodeFilter,
                           SubPlan* plan) {
     auto qctx = matchCtx_->qctx;
-
+    auto* pool = qctx->objPool();
     // Extract dst vid from input project node which output dataset format is: [v1,e1,...,vn,en]
     SubPlan curr;
     curr.root = dep;
-    MatchSolver::extractAndDedupVidColumn(qctx, initialExpr_.release(), dep, inputVar, curr);
+    MatchSolver::extractAndDedupVidColumn(qctx, initialExpr_, dep, inputVar, curr);
     // [GetNeighbors]
     auto gn = GetNeighbors::make(qctx, curr.root, matchCtx_->space.id);
-    auto srcExpr = ExpressionUtils::inputPropExpr(kVid);
-    gn->setSrc(qctx->objPool()->add(srcExpr.release()));
+    auto srcExpr = InputPropertyExpression::make(pool, kVid);
+    gn->setSrc(qctx->objPool()->add(srcExpr));
     gn->setVertexProps(genVertexProps());
     gn->setEdgeProps(genEdgeProps(edge));
     gn->setEdgeDirection(edge.direction);
 
     PlanNode* root = gn;
     if (nodeFilter != nullptr) {
-        auto* newFilter = MatchSolver::rewriteLabel2Vertex(nodeFilter);
+        auto* newFilter = MatchSolver::rewriteLabel2Vertex(qctx, nodeFilter);
         qctx->objPool()->add(newFilter);
         auto filterNode = Filter::make(matchCtx_->qctx, root, newFilter);
         filterNode->setColNames(root->colNames());
@@ -190,7 +192,7 @@ Status Expand::expandStep(const EdgeInfo& edge,
     }
 
     if (edge.filter != nullptr) {
-        auto* newFilter = MatchSolver::rewriteLabel2Edge(edge.filter);
+        auto* newFilter = MatchSolver::rewriteLabel2Edge(qctx, edge.filter);
         qctx->objPool()->add(newFilter);
         auto filterNode = Filter::make(qctx, root, newFilter);
         filterNode->setColNames(root->colNames());
@@ -198,7 +200,7 @@ Status Expand::expandStep(const EdgeInfo& edge,
     }
 
     auto listColumns = saveObject(new YieldColumns);
-    listColumns->addColumn(new YieldColumn(buildPathExpr(), kPathStr));
+    listColumns->addColumn(new YieldColumn(buildPathExpr(pool), kPathStr));
     // [Project]
     root = Project::make(qctx, root, listColumns);
     root->setColNames({kPathStr});
@@ -222,7 +224,7 @@ Status Expand::collectData(const PlanNode* joinLeft,
     plan->tail = join;
 
     auto columns = saveObject(new YieldColumns);
-    auto listExpr = mergePathColumnsExpr(lpath, rpath);
+    auto listExpr = mergePathColumnsExpr(qctx->objPool(), lpath, rpath);
     columns->addColumn(new YieldColumn(listExpr));
     // [Project]
     auto project = Project::make(qctx, join, columns);
@@ -237,19 +239,19 @@ Status Expand::collectData(const PlanNode* joinLeft,
 
 Status Expand::filterDatasetByPathLength(const EdgeInfo& edge, PlanNode* input, SubPlan* plan) {
     auto qctx = matchCtx_->qctx;
+    auto* pool = qctx->objPool();
 
     // Filter rows whose edges number less than min hop
-    auto args = std::make_unique<ArgumentList>();
+    auto args = ArgumentList::make(pool);
     // Expr: length(relationships(p)) >= minHop
-    auto pathExpr = ExpressionUtils::inputPropExpr(kPathStr);
+    auto pathExpr = InputPropertyExpression::make(pool, kPathStr);
     args->addArgument(std::move(pathExpr));
-    auto edgeExpr = std::make_unique<FunctionCallExpression>("length", args.release());
+    auto edgeExpr = FunctionCallExpression::make(pool, "length", args);
     auto minHop = edge.range == nullptr ? 1 : edge.range->min();
-    auto minHopExpr = std::make_unique<ConstantExpression>(minHop);
-    auto expr = std::make_unique<RelationalExpression>(
-        Expression::Kind::kRelGE, edgeExpr.release(), minHopExpr.release());
+    auto minHopExpr = ConstantExpression::make(pool, minHop);
+    auto expr = RelationalExpression::makeGE(pool, edgeExpr, minHopExpr);
 
-    auto filter = Filter::make(qctx, input, saveObject(expr.release()));
+    auto filter = Filter::make(qctx, input, saveObject(expr));
     filter->setColNames(input->colNames());
     plan->root = filter;
     return Status::OK();
@@ -260,16 +262,18 @@ Expression* Expand::buildExpandCondition(const std::string& lastStepResult,
                                          int64_t startIndex,
                                          int64_t maxHop) const {
     VLOG(1) << "match expand maxHop: " << maxHop;
+    auto pool = matchCtx_->qctx->objPool();
     auto loopSteps = matchCtx_->qctx->vctx()->anonVarGen()->getVar();
     matchCtx_->qctx->ectx()->setValue(loopSteps, startIndex);
     // ++loopSteps{startIndex} << maxHop
-    auto stepCondition = ExpressionUtils::stepCondition(loopSteps, maxHop);
+    auto stepCondition = ExpressionUtils::stepCondition(pool, loopSteps, maxHop);
     // lastStepResult == empty || size(lastStepReult) != 0
-    auto* eqEmpty = ExpressionUtils::Eq(new VariableExpression(lastStepResult),
-                                        new ConstantExpression(Value()));
-    auto neZero = ExpressionUtils::neZeroCondition(lastStepResult);
-    auto* existValCondition = ExpressionUtils::Or(eqEmpty, neZero.release());
-    return ExpressionUtils::And(stepCondition.release(), existValCondition);
+    auto* eqEmpty = RelationalExpression::makeEQ(pool,
+                                                 VariableExpression::make(pool, lastStepResult),
+                                                 ConstantExpression::make(pool, Value()));
+    auto neZero = ExpressionUtils::neZeroCondition(pool, lastStepResult);
+    auto* existValCondition = LogicalExpression::makeOr(pool, eqEmpty, neZero);
+    return LogicalExpression::makeAnd(pool, stepCondition, existValCondition);
 }
 
 }   // namespace graph

--- a/src/planner/match/Expand.cpp
+++ b/src/planner/match/Expand.cpp
@@ -107,7 +107,7 @@ Status Expand::expandSteps(const NodeInfo& node, const EdgeInfo& edge, SubPlan* 
         NG_RETURN_IF_ERROR(MatchSolver::appendFetchVertexPlan(node.filter,
                                                               matchCtx_->space,
                                                               matchCtx_->qctx,
-                                                              initialExpr_,
+                                                              &initialExpr_,
                                                               inputVar_,
                                                               subplan));
     } else {   // Case 1 to n steps
@@ -172,7 +172,7 @@ Status Expand::expandStep(const EdgeInfo& edge,
     // Extract dst vid from input project node which output dataset format is: [v1,e1,...,vn,en]
     SubPlan curr;
     curr.root = dep;
-    MatchSolver::extractAndDedupVidColumn(qctx, initialExpr_, dep, inputVar, curr);
+    MatchSolver::extractAndDedupVidColumn(qctx, &initialExpr_, dep, inputVar, curr);
     // [GetNeighbors]
     auto gn = GetNeighbors::make(qctx, curr.root, matchCtx_->space.id);
     auto srcExpr = InputPropertyExpression::make(pool, kVid);
@@ -242,7 +242,7 @@ Status Expand::filterDatasetByPathLength(const EdgeInfo& edge, PlanNode* input, 
     auto args = ArgumentList::make(pool);
     // Expr: length(relationships(p)) >= minHop
     auto pathExpr = InputPropertyExpression::make(pool, kPathStr);
-    args->addArgument(std::move(pathExpr));
+    args->addArgument(pathExpr);
     auto edgeExpr = FunctionCallExpression::make(pool, "length", args);
     auto minHop = edge.range == nullptr ? 1 : edge.range->min();
     auto minHopExpr = ConstantExpression::make(pool, minHop);

--- a/src/planner/match/Expand.h
+++ b/src/planner/match/Expand.h
@@ -74,7 +74,7 @@ private:
     std::unique_ptr<std::vector<storage::cpp2::EdgeProp>> genEdgeProps(const EdgeInfo &edge);
 
     MatchClauseContext*                 matchCtx_;
-    Expression*                         initialExpr_;
+    Expression*                         initialExpr_{nullptr};
     bool                                reversely_{false};
     PlanNode*                           dependency_{nullptr};
     std::string                         inputVar_;

--- a/src/planner/match/Expand.h
+++ b/src/planner/match/Expand.h
@@ -20,8 +20,8 @@ namespace graph {
  */
 class Expand final {
 public:
-    Expand(MatchClauseContext* matchCtx, std::unique_ptr<Expression> initialExpr)
-        : matchCtx_(matchCtx), initialExpr_(std::move(initialExpr)) {}
+    Expand(MatchClauseContext* matchCtx, Expression* initialExpr)
+        : matchCtx_(matchCtx), initialExpr_(initialExpr) {}
 
     Expand* reversely() {
         reversely_ = true;
@@ -74,7 +74,7 @@ private:
     std::unique_ptr<std::vector<storage::cpp2::EdgeProp>> genEdgeProps(const EdgeInfo &edge);
 
     MatchClauseContext*                 matchCtx_;
-    std::unique_ptr<Expression>         initialExpr_;
+    Expression*                         initialExpr_;
     bool                                reversely_{false};
     PlanNode*                           dependency_{nullptr};
     std::string                         inputVar_;

--- a/src/planner/match/InnerJoinStrategy.cpp
+++ b/src/planner/match/InnerJoinStrategy.cpp
@@ -21,19 +21,19 @@ PlanNode* InnerJoinStrategy::joinDataSet(const PlanNode* left, const PlanNode* r
     Expression* buildExpr = nullptr;
     if (leftPos_ == JoinPos::kStart) {
         auto& leftKey = left->colNames().front();
-        buildExpr = MatchSolver::getStartVidInPath(leftKey);
+        buildExpr = MatchSolver::getStartVidInPath(qctx_, leftKey);
     } else {
         auto& leftKey = left->colNames().back();
-        buildExpr = MatchSolver::getEndVidInPath(leftKey);
+        buildExpr = MatchSolver::getEndVidInPath(qctx_, leftKey);
     }
 
     Expression* probeExpr = nullptr;
     if (rightPos_ == JoinPos::kStart) {
         auto& rightKey = right->colNames().front();
-        probeExpr = MatchSolver::getStartVidInPath(rightKey);
+        probeExpr = MatchSolver::getStartVidInPath(qctx_, rightKey);
     } else {
         auto& rightKey = right->colNames().back();
-        probeExpr = MatchSolver::getEndVidInPath(rightKey);
+        probeExpr = MatchSolver::getEndVidInPath(qctx_, rightKey);
     }
 
     qctx_->objPool()->add(buildExpr);

--- a/src/planner/match/InnerJoinStrategy.cpp
+++ b/src/planner/match/InnerJoinStrategy.cpp
@@ -36,8 +36,6 @@ PlanNode* InnerJoinStrategy::joinDataSet(const PlanNode* left, const PlanNode* r
         probeExpr = MatchSolver::getEndVidInPath(qctx_, rightKey);
     }
 
-    qctx_->objPool()->add(buildExpr);
-    qctx_->objPool()->add(probeExpr);
     auto join = InnerJoin::make(qctx_,
                                const_cast<PlanNode*>(right),
                                {left->outputVar(), 0},

--- a/src/planner/match/LabelIndexSeek.cpp
+++ b/src/planner/match/LabelIndexSeek.cpp
@@ -88,10 +88,11 @@ StatusOr<SubPlan> LabelIndexSeek::transformNode(NodeContext* nodeCtx) {
     // This if-block is a patch for or-filter-embeding to avoid OOM,
     // and it should be converted to an `optRule` after the match validator is refactored
     auto& whereCtx = matchClauseCtx->where;
+    auto* pool = matchClauseCtx->qctx->objPool();
     if (whereCtx && whereCtx->filter) {
         auto* filter = whereCtx->filter;
         const auto& nodeAlias = nodeCtx->info->alias;
-        auto* objPool = matchClauseCtx->qctx->objPool();
+
         if (filter->kind() == Expression::Kind::kLogicalOr) {
             auto labelExprs = ExpressionUtils::collectAll(filter, {Expression::Kind::kLabel});
             bool labelMatched = true;
@@ -106,7 +107,7 @@ StatusOr<SubPlan> LabelIndexSeek::transformNode(NodeContext* nodeCtx) {
                 auto flattenFilter = ExpressionUtils::flattenInnerLogicalExpr(filter);
                 DCHECK_EQ(flattenFilter->kind(), Expression::Kind::kLogicalOr);
                 auto& filterItems =
-                    static_cast<LogicalExpression*>(flattenFilter.get())->operands();
+                    static_cast<LogicalExpression*>(flattenFilter)->operands();
                 auto canBeEmbeded = [](Expression::Kind k) -> bool {
                     return k == Expression::Kind::kRelEQ || k == Expression::Kind::kRelLT ||
                            k == Expression::Kind::kRelLE || k == Expression::Kind::kRelGT ||
@@ -120,8 +121,8 @@ StatusOr<SubPlan> LabelIndexSeek::transformNode(NodeContext* nodeCtx) {
                     }
                 }
                 if (canBeEmbeded2IndexScan) {
-                    auto* srcFilter = objPool->add(
-                        ExpressionUtils::rewriteLabelAttr2TagProp(flattenFilter.get()));
+                    auto* srcFilter =
+                        ExpressionUtils::rewriteLabelAttr2TagProp(pool, flattenFilter);
                     storage::cpp2::IndexQueryContext ctx;
                     ctx.set_filter(Expression::encode(*srcFilter));
                     auto context =
@@ -134,7 +135,7 @@ StatusOr<SubPlan> LabelIndexSeek::transformNode(NodeContext* nodeCtx) {
         }
     }
     // initialize start expression in project node
-    nodeCtx->initialExpr.reset(ExpressionUtils::newVarPropExpr(kVid));
+    nodeCtx->initialExpr = VariablePropertyExpression::make(pool, kVid);
     return plan;
 }
 
@@ -165,7 +166,9 @@ StatusOr<SubPlan> LabelIndexSeek::transformEdge(EdgeContext* edgeCtx) {
             columnsName.emplace_back(kDst);
             break;
     }
-    auto scan = IndexScan::make(matchClauseCtx->qctx,
+
+    auto* qctx = matchClauseCtx->qctx;
+    auto scan = IndexScan::make(qctx,
                                 nullptr,
                                 matchClauseCtx->space.id,
                                 std::move(contexts),
@@ -176,26 +179,25 @@ StatusOr<SubPlan> LabelIndexSeek::transformEdge(EdgeContext* edgeCtx) {
     plan.tail = scan;
     plan.root = scan;
 
+    auto* pool = qctx->objPool();
     if (edgeCtx->scanInfo.direction == MatchEdge::Direction::BOTH) {
         // merge the src,dst to one column
-        auto *yieldColumns = matchClauseCtx->qctx->objPool()->makeAndAdd<YieldColumns>();
-        auto *exprList = new ExpressionList();
-        exprList->add(new ColumnExpression(0));  // src
-        exprList->add(new ColumnExpression(1));  // dst
-        yieldColumns->addColumn(new YieldColumn(new ListExpression(exprList)));
-        auto *project = Project::make(matchClauseCtx->qctx,
-                                      scan,
-                                      yieldColumns);
+        auto* yieldColumns = pool->makeAndAdd<YieldColumns>();
+        auto* exprList = ExpressionList::make(pool);
+        exprList->add(ColumnExpression::make(pool, 0));   // src
+        exprList->add(ColumnExpression::make(pool, 1));   // dst
+        yieldColumns->addColumn(new YieldColumn(ListExpression::make(pool, exprList)));
+        auto* project = Project::make(qctx, scan, yieldColumns);
         project->setColNames({kVid});
 
-        auto* unwindExpr = matchClauseCtx->qctx->objPool()->add(new ColumnExpression(0));
+        auto* unwindExpr = ColumnExpression::make(pool, 0);
         auto* unwind = Unwind::make(matchClauseCtx->qctx, project, unwindExpr, kVid);
         unwind->setColNames({"vidList", kVid});
         plan.root = unwind;
     }
 
     // initialize start expression in project node
-    edgeCtx->initialExpr.reset(ExpressionUtils::newVarPropExpr(kVid));
+    edgeCtx->initialExpr = VariablePropertyExpression::make(pool, kVid);
     return plan;
 }
 

--- a/src/planner/match/LabelIndexSeek.cpp
+++ b/src/planner/match/LabelIndexSeek.cpp
@@ -135,7 +135,7 @@ StatusOr<SubPlan> LabelIndexSeek::transformNode(NodeContext* nodeCtx) {
         }
     }
     // initialize start expression in project node
-    nodeCtx->initialExpr = VariablePropertyExpression::make(pool, kVid);
+    nodeCtx->initialExpr = VariablePropertyExpression::make(pool, "", kVid);
     return plan;
 }
 
@@ -197,7 +197,7 @@ StatusOr<SubPlan> LabelIndexSeek::transformEdge(EdgeContext* edgeCtx) {
     }
 
     // initialize start expression in project node
-    edgeCtx->initialExpr = VariablePropertyExpression::make(pool, kVid);
+    edgeCtx->initialExpr = VariablePropertyExpression::make(pool, "", kVid);
     return plan;
 }
 

--- a/src/planner/match/MatchClausePlanner.cpp
+++ b/src/planner/match/MatchClausePlanner.cpp
@@ -179,7 +179,7 @@ Status MatchClausePlanner::leftExpandFromNode(const std::vector<NodeInfo>& nodeI
         nodeInfos.front().filter,
         matchClauseCtx->space,
         matchClauseCtx->qctx,
-        edgeInfos.empty() ? initialExpr_->clone().release() : nullptr,
+        edgeInfos.empty() ? initialExpr_->clone() : nullptr,
         subplan));
     if (!edgeInfos.empty()) {
         auto right = subplan.root;
@@ -227,7 +227,7 @@ Status MatchClausePlanner::rightExpandFromNode(const std::vector<NodeInfo>& node
         nodeInfos.back().filter,
         matchClauseCtx->space,
         matchClauseCtx->qctx,
-        edgeInfos.empty() ? initialExpr_->clone().release() : nullptr,
+        edgeInfos.empty() ? initialExpr_->clone() : nullptr,
         subplan));
     if (!edgeInfos.empty()) {
         auto right = subplan.root;
@@ -265,12 +265,14 @@ Status MatchClausePlanner::projectColumnsBySymbols(MatchClauseContext* matchClau
         auto& nodeInfo = nodeInfos[i];
         if (!nodeInfo.alias.empty() && !nodeInfo.anonymous) {
             if (i >= startIndex) {
-                columns->addColumn(buildVertexColumn(inColNames[i - startIndex], nodeInfo.alias));
-            } else if (startIndex == (nodeInfos.size() - 1)) {
-                columns->addColumn(buildVertexColumn(inColNames[startIndex - i], nodeInfo.alias));
-            } else {
                 columns->addColumn(
-                    buildVertexColumn(inColNames[nodeInfos.size() - i], nodeInfo.alias));
+                    buildVertexColumn(matchClauseCtx, inColNames[i - startIndex], nodeInfo.alias));
+            } else if (startIndex == (nodeInfos.size() - 1)) {
+                columns->addColumn(
+                    buildVertexColumn(matchClauseCtx, inColNames[startIndex - i], nodeInfo.alias));
+            } else {
+                columns->addColumn(buildVertexColumn(
+                    matchClauseCtx, inColNames[nodeInfos.size() - i], nodeInfo.alias));
             }
             colNames.emplace_back(nodeInfo.alias);
         }
@@ -283,11 +285,14 @@ Status MatchClausePlanner::projectColumnsBySymbols(MatchClauseContext* matchClau
         auto& edgeInfo = edgeInfos[i];
         if (!edgeInfo.alias.empty() && !edgeInfo.anonymous) {
             if (i >= startIndex) {
-                columns->addColumn(buildEdgeColumn(inColNames[i - startIndex], edgeInfo));
+                columns->addColumn(
+                    buildEdgeColumn(matchClauseCtx, inColNames[i - startIndex], edgeInfo));
             } else if (startIndex == (nodeInfos.size() - 1)) {
-                columns->addColumn(buildEdgeColumn(inColNames[edgeInfos.size() - 1 - i], edgeInfo));
+                columns->addColumn(buildEdgeColumn(
+                    matchClauseCtx, inColNames[edgeInfos.size() - 1 - i], edgeInfo));
             } else {
-                columns->addColumn(buildEdgeColumn(inColNames[edgeInfos.size() - i], edgeInfo));
+                columns->addColumn(
+                    buildEdgeColumn(matchClauseCtx, inColNames[edgeInfos.size() - i], edgeInfo));
             }
             colNames.emplace_back(edgeInfo.alias);
         }
@@ -302,7 +307,8 @@ Status MatchClausePlanner::projectColumnsBySymbols(MatchClauseContext* matchClau
         return alias.second == AliasType::kPath;
     });
     std::string alias = iter != aliases.end() ? iter->first : qctx->vctx()->anonColGen()->getCol();
-    columns->addColumn(buildPathColumn(alias, startIndex, inColNames, nodeInfos.size()));
+    columns->addColumn(
+        buildPathColumn(matchClauseCtx, alias, startIndex, inColNames, nodeInfos.size()));
     colNames.emplace_back(alias);
 
     auto project = Project::make(qctx, input, columns);
@@ -313,35 +319,41 @@ Status MatchClausePlanner::projectColumnsBySymbols(MatchClauseContext* matchClau
     return Status::OK();
 }
 
-YieldColumn* MatchClausePlanner::buildVertexColumn(const std::string& colName,
+YieldColumn* MatchClausePlanner::buildVertexColumn(MatchClauseContext* matchClauseCtx,
+                                                   const std::string& colName,
                                                    const std::string& alias) const {
-    auto colExpr = ExpressionUtils::inputPropExpr(colName);
+    auto* pool = matchClauseCtx->qctx->objPool();
+    auto colExpr = InputPropertyExpression::make(pool, colName);
     // startNode(path) => head node of path
-    auto args = std::make_unique<ArgumentList>();
+    auto args = ArgumentList::make(pool);
     args->addArgument(std::move(colExpr));
-    auto firstVertexExpr = std::make_unique<FunctionCallExpression>("startNode", args.release());
-    return new YieldColumn(firstVertexExpr.release(), alias);
+    auto firstVertexExpr = FunctionCallExpression::make(pool, "startNode", args);
+    return new YieldColumn(firstVertexExpr, alias);
 }
 
-YieldColumn* MatchClausePlanner::buildEdgeColumn(const std::string& colName, EdgeInfo& edge) const {
-    auto colExpr = ExpressionUtils::inputPropExpr(colName);
+YieldColumn* MatchClausePlanner::buildEdgeColumn(MatchClauseContext* matchClauseCtx,
+                                                 const std::string& colName,
+                                                 EdgeInfo& edge) const {
+    auto* pool = matchClauseCtx->qctx->objPool();
+    auto colExpr = InputPropertyExpression::make(pool, colName);
     // relationships(p)
-    auto args = std::make_unique<ArgumentList>();
+    auto args = ArgumentList::make(pool);
     args->addArgument(std::move(colExpr));
-    auto relExpr = std::make_unique<FunctionCallExpression>("relationships", args.release());
+    auto relExpr = FunctionCallExpression::make(pool, "relationships", args);
     Expression* expr = nullptr;
     if (edge.range != nullptr) {
-        expr = relExpr.release();
+        expr = relExpr;
     } else {
         // Get first edge in path list [e1, e2, ...]
-        auto idxExpr = std::make_unique<ConstantExpression>(0);
-        auto subExpr = std::make_unique<SubscriptExpression>(relExpr.release(), idxExpr.release());
-        expr = subExpr.release();
+        auto idxExpr = ConstantExpression::make(pool, 0);
+        auto subExpr = SubscriptExpression::make(pool, relExpr, idxExpr);
+        expr = subExpr;
     }
     return new YieldColumn(expr, edge.alias);
 }
 
-YieldColumn* MatchClausePlanner::buildPathColumn(const std::string& alias,
+YieldColumn* MatchClausePlanner::buildPathColumn(MatchClauseContext* matchClauseCtx,
+                                                 const std::string& alias,
                                                  size_t startIndex,
                                                  const std::vector<std::string> colNames,
                                                  size_t nodeInfoSize) const {
@@ -355,31 +367,31 @@ YieldColumn* MatchClausePlanner::buildPathColumn(const std::string& alias,
     } else {
         bound = colSize - startIndex;
     }
-
-    auto rightExpandPath = std::make_unique<PathBuildExpression>();
+    auto* pool = matchClauseCtx->qctx->objPool();
+    auto rightExpandPath = PathBuildExpression::make(pool);
     for (size_t i = 0; i < bound; ++i) {
-        rightExpandPath->add(ExpressionUtils::inputPropExpr(colNames[i]));
+        rightExpandPath->add(InputPropertyExpression::make(pool, colNames[i]));
     }
 
-    auto leftExpandPath = std::make_unique<PathBuildExpression>();
+    auto leftExpandPath = PathBuildExpression::make(pool);
     for (size_t i = bound; i < colNames.size(); ++i) {
-        leftExpandPath->add(ExpressionUtils::inputPropExpr(colNames[i]));
+        leftExpandPath->add(InputPropertyExpression::make(pool, colNames[i]));
     }
 
-    auto finalPath = std::make_unique<PathBuildExpression>();
+    auto finalPath = PathBuildExpression::make(pool);
     if (leftExpandPath->size() != 0) {
-        auto args = new ArgumentList();
+        auto args = ArgumentList::make(pool);
         args->addArgument(std::move(leftExpandPath));
-        auto reversePath = std::make_unique<FunctionCallExpression>("reversePath", args);
+        auto reversePath = FunctionCallExpression::make(pool, "reversePath", args);
         if (rightExpandPath->size() == 0) {
-            return new YieldColumn(reversePath.release(), alias);
+            return new YieldColumn(reversePath, alias);
         }
         finalPath->add(std::move(reversePath));
     }
     if (rightExpandPath->size() != 0) {
         finalPath->add(std::move(rightExpandPath));
     }
-    return new YieldColumn(finalPath.release(), alias);
+    return new YieldColumn(finalPath, alias);
 }
 
 Status MatchClausePlanner::appendFilterPlan(MatchClauseContext* matchClauseCtx, SubPlan& subplan) {

--- a/src/planner/match/MatchClausePlanner.cpp
+++ b/src/planner/match/MatchClausePlanner.cpp
@@ -326,7 +326,7 @@ YieldColumn* MatchClausePlanner::buildVertexColumn(MatchClauseContext* matchClau
     auto colExpr = InputPropertyExpression::make(pool, colName);
     // startNode(path) => head node of path
     auto args = ArgumentList::make(pool);
-    args->addArgument(std::move(colExpr));
+    args->addArgument(colExpr);
     auto firstVertexExpr = FunctionCallExpression::make(pool, "startNode", args);
     return new YieldColumn(firstVertexExpr, alias);
 }
@@ -338,7 +338,7 @@ YieldColumn* MatchClausePlanner::buildEdgeColumn(MatchClauseContext* matchClause
     auto colExpr = InputPropertyExpression::make(pool, colName);
     // relationships(p)
     auto args = ArgumentList::make(pool);
-    args->addArgument(std::move(colExpr));
+    args->addArgument(colExpr);
     auto relExpr = FunctionCallExpression::make(pool, "relationships", args);
     Expression* expr = nullptr;
     if (edge.range != nullptr) {
@@ -381,15 +381,15 @@ YieldColumn* MatchClausePlanner::buildPathColumn(MatchClauseContext* matchClause
     auto finalPath = PathBuildExpression::make(pool);
     if (leftExpandPath->size() != 0) {
         auto args = ArgumentList::make(pool);
-        args->addArgument(std::move(leftExpandPath));
+        args->addArgument(leftExpandPath);
         auto reversePath = FunctionCallExpression::make(pool, "reversePath", args);
         if (rightExpandPath->size() == 0) {
             return new YieldColumn(reversePath, alias);
         }
-        finalPath->add(std::move(reversePath));
+        finalPath->add(reversePath);
     }
     if (rightExpandPath->size() != 0) {
-        finalPath->add(std::move(rightExpandPath));
+        finalPath->add(rightExpandPath);
     }
     return new YieldColumn(finalPath, alias);
 }

--- a/src/planner/match/MatchClausePlanner.cpp
+++ b/src/planner/match/MatchClausePlanner.cpp
@@ -175,12 +175,13 @@ Status MatchClausePlanner::leftExpandFromNode(const std::vector<NodeInfo>& nodeI
 
     VLOG(1) << subplan;
     auto left = subplan.root;
-    NG_RETURN_IF_ERROR(MatchSolver::appendFetchVertexPlan(
-        nodeInfos.front().filter,
-        matchClauseCtx->space,
-        matchClauseCtx->qctx,
-        edgeInfos.empty() ? initialExpr_->clone() : nullptr,
-        subplan));
+    auto* initialExprCopy = initialExpr_->clone();
+    NG_RETURN_IF_ERROR(
+        MatchSolver::appendFetchVertexPlan(nodeInfos.front().filter,
+                                           matchClauseCtx->space,
+                                           matchClauseCtx->qctx,
+                                           edgeInfos.empty() ? &initialExprCopy : nullptr,
+                                           subplan));
     if (!edgeInfos.empty()) {
         auto right = subplan.root;
         VLOG(1) << "left: " << folly::join(",", left->colNames())
@@ -223,12 +224,13 @@ Status MatchClausePlanner::rightExpandFromNode(const std::vector<NodeInfo>& node
 
     VLOG(1) << subplan;
     auto left = subplan.root;
-    NG_RETURN_IF_ERROR(MatchSolver::appendFetchVertexPlan(
-        nodeInfos.back().filter,
-        matchClauseCtx->space,
-        matchClauseCtx->qctx,
-        edgeInfos.empty() ? initialExpr_->clone() : nullptr,
-        subplan));
+    auto* initialExprCopy = initialExpr_->clone();
+    NG_RETURN_IF_ERROR(
+        MatchSolver::appendFetchVertexPlan(nodeInfos.back().filter,
+                                           matchClauseCtx->space,
+                                           matchClauseCtx->qctx,
+                                           edgeInfos.empty() ? &initialExprCopy : nullptr,
+                                           subplan));
     if (!edgeInfos.empty()) {
         auto right = subplan.root;
         VLOG(1) << "left: " << folly::join(",", left->colNames())

--- a/src/planner/match/MatchClausePlanner.h
+++ b/src/planner/match/MatchClausePlanner.h
@@ -81,7 +81,7 @@ private:
     Status appendFilterPlan(MatchClauseContext* matchClauseCtx, SubPlan& subplan);
 
 private:
-    Expression* initialExpr_;
+    Expression* initialExpr_{nullptr};
 };
 }  // namespace graph
 }  // namespace nebula

--- a/src/planner/match/MatchClausePlanner.h
+++ b/src/planner/match/MatchClausePlanner.h
@@ -64,11 +64,16 @@ private:
                                    size_t startIndex,
                                    SubPlan& plan);
 
-    YieldColumn* buildVertexColumn(const std::string& colName, const std::string& alias) const;
+    YieldColumn* buildVertexColumn(MatchClauseContext* matchClauseCtx,
+                                   const std::string& colName,
+                                   const std::string& alias) const;
 
-    YieldColumn* buildEdgeColumn(const std::string& colName, EdgeInfo& edge) const;
+    YieldColumn* buildEdgeColumn(MatchClauseContext* matchClauseCtx,
+                                 const std::string& colName,
+                                 EdgeInfo& edge) const;
 
-    YieldColumn* buildPathColumn(const std::string& alias,
+    YieldColumn* buildPathColumn(MatchClauseContext* matchClauseCtx,
+                                 const std::string& alias,
                                  size_t startIndex,
                                  const std::vector<std::string> colNames,
                                  size_t nodeInfoSize) const;
@@ -76,7 +81,7 @@ private:
     Status appendFilterPlan(MatchClauseContext* matchClauseCtx, SubPlan& subplan);
 
 private:
-    std::unique_ptr<Expression> initialExpr_;
+    Expression* initialExpr_;
 };
 }  // namespace graph
 }  // namespace nebula

--- a/src/planner/match/MatchSolver.cpp
+++ b/src/planner/match/MatchSolver.cpp
@@ -17,63 +17,70 @@
 
 namespace nebula {
 namespace graph {
-Expression* MatchSolver::rewriteLabel2Vertex(const Expression* expr) {
+Expression* MatchSolver::rewriteLabel2Vertex(QueryContext* qctx, const Expression* expr) {
     auto matcher = [](const Expression* e) -> bool {
         return e->kind() == Expression::Kind::kLabel ||
                e->kind() == Expression::Kind::kLabelAttribute;
     };
-    auto rewriter = [](const Expression* e) -> Expression* {
+    auto rewriter = [&qctx](const Expression* e) -> Expression* {
         DCHECK(e->kind() == Expression::Kind::kLabelAttribute ||
                e->kind() == Expression::Kind::kLabel);
         if (e->kind() == Expression::Kind::kLabelAttribute) {
             auto la = static_cast<const LabelAttributeExpression*>(e);
-            return new AttributeExpression(new VertexExpression(), la->right()->clone().release());
+            return AttributeExpression::make(
+                qctx->objPool(), VertexExpression::make(qctx->objPool()), la->right()->clone());
         }
-        return new VertexExpression();
+        return VertexExpression::make(qctx->objPool());
     };
 
     return RewriteVisitor::transform(expr, std::move(matcher), std::move(rewriter));
 }
 
-Expression* MatchSolver::rewriteLabel2Edge(const Expression* expr) {
+Expression* MatchSolver::rewriteLabel2Edge(QueryContext* qctx, const Expression* expr) {
     auto matcher = [](const Expression* e) -> bool {
         return e->kind() == Expression::Kind::kLabel ||
                e->kind() == Expression::Kind::kLabelAttribute;
     };
-    auto rewriter = [](const Expression* e) -> Expression* {
+    auto rewriter = [&qctx](const Expression* e) -> Expression* {
         DCHECK(e->kind() == Expression::Kind::kLabelAttribute ||
                e->kind() == Expression::Kind::kLabel);
         if (e->kind() == Expression::Kind::kLabelAttribute) {
             auto la = static_cast<const LabelAttributeExpression*>(e);
-            return new AttributeExpression(new EdgeExpression(), la->right()->clone().release());
+            return AttributeExpression::make(qctx->objPool(),
+                                             EdgeExpression::make(qctx->objPool()),
+                                             la->right()->clone());
         }
-        return new EdgeExpression();
+        return EdgeExpression::make(qctx->objPool());
     };
 
     return RewriteVisitor::transform(expr, std::move(matcher), std::move(rewriter));
 }
 
-Expression* MatchSolver::rewriteLabel2VarProp(const Expression* expr) {
+Expression* MatchSolver::rewriteLabel2VarProp(QueryContext* qctx, const Expression* expr) {
     auto matcher = [](const Expression* e) -> bool {
         return e->kind() == Expression::Kind::kLabel ||
                e->kind() == Expression::Kind::kLabelAttribute;
     };
-    auto rewriter = [](const Expression* e) -> Expression* {
+    auto rewriter = [&qctx](const Expression* e) -> Expression* {
         DCHECK(e->kind() == Expression::Kind::kLabelAttribute ||
                e->kind() == Expression::Kind::kLabel);
         if (e->kind() == Expression::Kind::kLabelAttribute) {
             auto* la = static_cast<const LabelAttributeExpression*>(e);
-            auto* var = new VariablePropertyExpression("", la->left()->name());
-            return new AttributeExpression(var, new ConstantExpression(la->right()->value()));
+            auto* var = VariablePropertyExpression::make(qctx->objPool(), "", la->left()->name());
+            return AttributeExpression::make(
+                qctx->objPool(),
+                var,
+                ConstantExpression::make(qctx->objPool(), la->right()->value()));
         }
         auto label = static_cast<const LabelExpression*>(e);
-        return new VariablePropertyExpression("", label->name());
+        return VariablePropertyExpression::make(qctx->objPool(), "", label->name());
     };
 
     return RewriteVisitor::transform(expr, std::move(matcher), std::move(rewriter));
 }
 
-Expression* MatchSolver::doRewrite(const std::unordered_map<std::string, AliasType>& aliases,
+Expression* MatchSolver::doRewrite(QueryContext* qctx,
+                                   const std::unordered_map<std::string, AliasType>& aliases,
                                    const Expression* expr) {
     if (expr->kind() == Expression::Kind::kLabel) {
         auto* labelExpr = static_cast<const LabelExpression*>(expr);
@@ -81,7 +88,7 @@ Expression* MatchSolver::doRewrite(const std::unordered_map<std::string, AliasTy
         DCHECK(alias != aliases.end());
     }
 
-    return rewriteLabel2VarProp(expr);
+    return rewriteLabel2VarProp(qctx, expr);
 }
 
 Expression* MatchSolver::makeIndexFilter(const std::string& label,
@@ -90,17 +97,17 @@ Expression* MatchSolver::makeIndexFilter(const std::string& label,
                                          bool isEdgeProperties) {
     auto makePropExpr = [=, &label](const std::string& prop) -> Expression* {
         if (isEdgeProperties) {
-            return new EdgePropertyExpression(label, prop);
+            return EdgePropertyExpression::make(qctx->objPool(), label, prop);
         }
-        return new TagPropertyExpression(label, prop);
+        return TagPropertyExpression::make(qctx->objPool(), label, prop);
     };
 
-    auto root = qctx->objPool()->makeAndAdd<LogicalExpression>(Expression::Kind::kLogicalAnd);
-    std::vector<std::unique_ptr<Expression>> operands;
+    auto root = LogicalExpression::makeAnd(qctx->objPool());
+    std::vector<Expression*> operands;
     operands.reserve(map->size());
     for (const auto& item : map->items()) {
-        operands.emplace_back(new RelationalExpression(
-            Expression::Kind::kRelEQ, makePropExpr(item.first), item.second->clone().release()));
+        operands.emplace_back(RelationalExpression::makeEQ(
+            qctx->objPool(), makePropExpr(item.first), item.second->clone()));
     }
     root->setOperands(std::move(operands));
     return root;
@@ -127,7 +134,7 @@ Expression* MatchSolver::makeIndexFilter(const std::string& label,
         auto* logic = static_cast<LogicalExpression*>(filter);
         ExpressionUtils::pullAnds(logic);
         for (auto& operand : logic->operands()) {
-            ands.emplace_back(operand.get());
+            ands.emplace_back(operand);
         }
     } else {
         return nullptr;
@@ -161,17 +168,19 @@ Expression* MatchSolver::makeIndexFilter(const std::string& label,
             continue;
         }
 
-        const auto &value = la->right()->value();
-        auto* tpExpr =
-            isEdgeProperties
-                ? static_cast<Expression*>(new EdgePropertyExpression(label, value.getStr()))
-                : static_cast<Expression*>(new TagPropertyExpression(label, value.getStr()));
-        auto *newConstant = constant->clone().release();
+        const auto& value = la->right()->value();
+        auto* tpExpr = isEdgeProperties ? static_cast<Expression*>(EdgePropertyExpression::make(
+                                              qctx->objPool(), label, value.getStr()))
+                                        : static_cast<Expression*>(TagPropertyExpression::make(
+                                              qctx->objPool(), label, value.getStr()));
+        auto* newConstant = constant->clone();
         if (left->kind() == Expression::Kind::kLabelAttribute) {
-            auto* rel = new RelationalExpression(item->kind(), tpExpr, newConstant);
+            auto* rel =
+                RelationalExpression::makeKind(qctx->objPool(), item->kind(), tpExpr, newConstant);
             relationals.emplace_back(rel);
         } else {
-            auto* rel = new RelationalExpression(item->kind(), newConstant, tpExpr);
+            auto* rel =
+                RelationalExpression::makeKind(qctx->objPool(), item->kind(), newConstant, tpExpr);
             relationals.emplace_back(rel);
         }
     }
@@ -183,7 +192,7 @@ Expression* MatchSolver::makeIndexFilter(const std::string& label,
     auto* root = relationals[0];
     for (auto i = 1u; i < relationals.size(); i++) {
         auto* left = root;
-        root = new LogicalExpression(Expression::Kind::kLogicalAnd, left, relationals[i]);
+        root = LogicalExpression::makeAnd(qctx->objPool(), left, relationals[i]);
     }
 
     return qctx->objPool()->add(root);
@@ -196,7 +205,7 @@ void MatchSolver::extractAndDedupVidColumn(QueryContext* qctx,
                                            SubPlan& plan) {
     auto columns = qctx->objPool()->add(new YieldColumns);
     auto* var = qctx->symTable()->getVar(inputVar);
-    Expression* vidExpr = initialExprOrEdgeDstExpr(initialExpr, var->colNames.back());
+    Expression* vidExpr = initialExprOrEdgeDstExpr(qctx, initialExpr, var->colNames.back());
     columns->addColumn(new YieldColumn(vidExpr));
     auto project = Project::make(qctx, dep, columns);
     project->setInputVar(inputVar);
@@ -207,46 +216,51 @@ void MatchSolver::extractAndDedupVidColumn(QueryContext* qctx,
     plan.root = dedup;
 }
 
-Expression* MatchSolver::initialExprOrEdgeDstExpr(Expression* initialExpr,
+Expression* MatchSolver::initialExprOrEdgeDstExpr(QueryContext* qctx,
+                                                  Expression* initialExpr,
                                                   const std::string& vidCol) {
     if (initialExpr != nullptr) {
         return initialExpr;
     } else {
-        return getEndVidInPath(vidCol);
+        return getEndVidInPath(qctx, vidCol);
     }
 }
 
-Expression* MatchSolver::getEndVidInPath(const std::string& colName) {
+Expression* MatchSolver::getEndVidInPath(QueryContext* qctx, const std::string& colName) {
+    auto* pool = qctx->objPool();
     // expr: __Project_2[-1] => path
-    auto columnExpr = ExpressionUtils::inputPropExpr(colName);
+    auto columnExpr = InputPropertyExpression::make(pool, colName);
     // expr: endNode(path) => vn
-    auto args = std::make_unique<ArgumentList>();
+    auto args = ArgumentList::make(pool);
     args->addArgument(std::move(columnExpr));
-    auto endNode = std::make_unique<FunctionCallExpression>("endNode", args.release());
+    auto endNode = FunctionCallExpression::make(pool, "endNode", args);
     // expr: en[_dst] => dst vid
-    auto vidExpr = std::make_unique<ConstantExpression>(kVid);
-    return new AttributeExpression(endNode.release(), vidExpr.release());
+    auto vidExpr = ConstantExpression::make(pool, kVid);
+    return AttributeExpression::make(pool, endNode, vidExpr);
 }
 
-Expression* MatchSolver::getStartVidInPath(const std::string& colName) {
+Expression* MatchSolver::getStartVidInPath(QueryContext *qctx, const std::string& colName) {
+    auto* pool = qctx->objPool();
     // expr: __Project_2[0] => path
-    auto columnExpr = ExpressionUtils::inputPropExpr(colName);
+    auto columnExpr = InputPropertyExpression::make(pool, colName);
     // expr: startNode(path) => v1
-    auto args = std::make_unique<ArgumentList>();
+    auto args = ArgumentList::make(pool);
     args->addArgument(std::move(columnExpr));
-    auto firstVertexExpr = std::make_unique<FunctionCallExpression>("startNode", args.release());
+    auto firstVertexExpr = FunctionCallExpression::make(pool, "startNode", args);
     // expr: v1[_vid] => vid
-    return new AttributeExpression(firstVertexExpr.release(), new ConstantExpression(kVid));
+    return AttributeExpression::make(qctx->objPool(),
+                                     firstVertexExpr,
+                                     ConstantExpression::make(qctx->objPool(), kVid));
 }
 
 PlanNode* MatchSolver::filtPathHasSameEdge(PlanNode* input,
                                            const std::string& column,
                                            QueryContext* qctx) {
-    auto args = std::make_unique<ArgumentList>();
-    args->addArgument(ExpressionUtils::inputPropExpr(column));
-    auto fnCall = std::make_unique<FunctionCallExpression>("hasSameEdgeInPath", args.release());
-    auto pool = qctx->objPool();
-    auto cond = pool->makeAndAdd<UnaryExpression>(Expression::Kind::kUnaryNot, fnCall.release());
+    auto* pool = qctx->objPool();
+    auto args = ArgumentList::make(pool);
+    args->addArgument(InputPropertyExpression::make(pool, column));
+    auto fnCall = FunctionCallExpression::make(pool, "hasSameEdgeInPath", args);
+    auto cond = UnaryExpression::makeNot(pool, fnCall);
     auto filter = Filter::make(qctx, input, cond);
     filter->setColNames(input->colNames());
     return filter;
@@ -267,31 +281,31 @@ Status MatchSolver::appendFetchVertexPlan(const Expression* nodeFilter,
                                           Expression* initialExpr,
                                           std::string inputVar,
                                           SubPlan& plan) {
+    auto* pool = qctx->objPool();
     // [Project && Dedup]
     extractAndDedupVidColumn(qctx, initialExpr, plan.root, inputVar, plan);
-    auto srcExpr = ExpressionUtils::inputPropExpr(kVid);
+    auto srcExpr = InputPropertyExpression::make(pool, kVid);;
     // [Get vertices]
     auto props = SchemaUtil::getAllVertexProp(qctx, space, true);
     NG_RETURN_IF_ERROR(props);
     auto gv = GetVertices::make(qctx,
                                 plan.root,
                                 space.id,
-                                qctx->objPool()->add(srcExpr.release()),
+                                srcExpr,
                                 std::move(props).value(),
                                 {});
 
     PlanNode* root = gv;
     if (nodeFilter != nullptr) {
-        auto* newFilter = MatchSolver::rewriteLabel2Vertex(nodeFilter);
-        qctx->objPool()->add(newFilter);
+        auto* newFilter = MatchSolver::rewriteLabel2Vertex(qctx, nodeFilter);
         root = Filter::make(qctx, root, newFilter);
     }
 
     // Normalize all columns to one
     auto columns = qctx->objPool()->add(new YieldColumns);
-    auto pathExpr = std::make_unique<PathBuildExpression>();
-    pathExpr->add(std::make_unique<VertexExpression>());
-    columns->addColumn(new YieldColumn(pathExpr.release()));
+    auto pathExpr = PathBuildExpression::make(qctx->objPool());
+    pathExpr->add(VertexExpression::make(qctx->objPool()));
+    columns->addColumn(new YieldColumn(pathExpr));
     plan.root = Project::make(qctx, root, columns);
     plan.root->setColNames({kPathStr});
     return Status::OK();

--- a/src/planner/match/MatchSolver.cpp
+++ b/src/planner/match/MatchSolver.cpp
@@ -23,7 +23,7 @@ Expression* MatchSolver::rewriteLabel2Vertex(QueryContext* qctx, const Expressio
         return e->kind() == Expression::Kind::kLabel ||
                e->kind() == Expression::Kind::kLabelAttribute;
     };
-    auto rewriter = [&](const Expression* e) -> Expression* {
+    auto rewriter = [&, pool](const Expression* e) -> Expression* {
         DCHECK(e->kind() == Expression::Kind::kLabelAttribute ||
                e->kind() == Expression::Kind::kLabel);
         if (e->kind() == Expression::Kind::kLabelAttribute) {
@@ -43,7 +43,7 @@ Expression* MatchSolver::rewriteLabel2Edge(QueryContext* qctx, const Expression*
         return e->kind() == Expression::Kind::kLabel ||
                e->kind() == Expression::Kind::kLabelAttribute;
     };
-    auto rewriter = [&](const Expression* e) -> Expression* {
+    auto rewriter = [&pool](const Expression* e) -> Expression* {
         DCHECK(e->kind() == Expression::Kind::kLabelAttribute ||
                e->kind() == Expression::Kind::kLabel);
         if (e->kind() == Expression::Kind::kLabelAttribute) {
@@ -63,7 +63,7 @@ Expression* MatchSolver::rewriteLabel2VarProp(QueryContext* qctx, const Expressi
         return e->kind() == Expression::Kind::kLabel ||
                e->kind() == Expression::Kind::kLabelAttribute;
     };
-    auto rewriter = [&](const Expression* e) -> Expression* {
+    auto rewriter = [&pool](const Expression* e) -> Expression* {
         DCHECK(e->kind() == Expression::Kind::kLabelAttribute ||
                e->kind() == Expression::Kind::kLabel);
         if (e->kind() == Expression::Kind::kLabelAttribute) {

--- a/src/planner/match/MatchSolver.h
+++ b/src/planner/match/MatchSolver.h
@@ -46,13 +46,13 @@ public:
                                        bool isEdgeProperties = false);
 
     static void extractAndDedupVidColumn(QueryContext* qctx,
-                                         Expression* initialExpr,
+                                         Expression** initialExpr,
                                          PlanNode* dep,
                                          const std::string& inputVar,
                                          SubPlan& plan);
 
     static Expression* initialExprOrEdgeDstExpr(QueryContext* qctx,
-                                                Expression* initialExpr,
+                                                Expression** initialExpr,
                                                 const std::string& vidCol);
 
     static Expression* getEndVidInPath(QueryContext* qctx, const std::string& colName);
@@ -66,7 +66,7 @@ public:
     static Status appendFetchVertexPlan(const Expression* nodeFilter,
                                         const SpaceInfo& space,
                                         QueryContext* qctx,
-                                        Expression* initialExpr,
+                                        Expression** initialExpr,
                                         SubPlan& plan);
 
     // In 0 step left expansion case, the result of initial index scan
@@ -74,7 +74,7 @@ public:
     static Status appendFetchVertexPlan(const Expression* nodeFilter,
                                         const SpaceInfo& space,
                                         QueryContext* qctx,
-                                        Expression* initialExpr,
+                                        Expression** initialExpr,
                                         std::string inputVar,
                                         SubPlan& plan);
 };

--- a/src/planner/match/MatchSolver.h
+++ b/src/planner/match/MatchSolver.h
@@ -24,13 +24,14 @@ public:
     MatchSolver() = delete;
     ~MatchSolver() = delete;
 
-    static Expression* rewriteLabel2Vertex(const Expression* expr);
+    static Expression* rewriteLabel2Vertex(QueryContext* qctx, const Expression* expr);
 
-    static Expression* rewriteLabel2Edge(const Expression* expr);
+    static Expression* rewriteLabel2Edge(QueryContext* qctx, const Expression* expr);
 
-    static Expression* rewriteLabel2VarProp(const Expression* expr);
+    static Expression* rewriteLabel2VarProp(QueryContext* qctx, const Expression* expr);
 
-    static Expression* doRewrite(const std::unordered_map<std::string, AliasType>& aliases,
+    static Expression* doRewrite(QueryContext* qctx,
+                                 const std::unordered_map<std::string, AliasType>& aliases,
                                  const Expression* expr);
 
     static Expression* makeIndexFilter(const std::string& label,
@@ -50,11 +51,13 @@ public:
                                          const std::string& inputVar,
                                          SubPlan& plan);
 
-    static Expression* initialExprOrEdgeDstExpr(Expression* initialExpr, const std::string& vidCol);
+    static Expression* initialExprOrEdgeDstExpr(QueryContext* qctx,
+                                                Expression* initialExpr,
+                                                const std::string& vidCol);
 
-    static Expression* getEndVidInPath(const std::string& colName);
+    static Expression* getEndVidInPath(QueryContext* qctx, const std::string& colName);
 
-    static Expression* getStartVidInPath(const std::string& colName);
+    static Expression* getStartVidInPath(QueryContext* qctx, const std::string& colName);
 
     static PlanNode* filtPathHasSameEdge(PlanNode* input,
                                          const std::string& column,

--- a/src/planner/match/PropIndexSeek.cpp
+++ b/src/planner/match/PropIndexSeek.cpp
@@ -83,7 +83,9 @@ StatusOr<SubPlan> PropIndexSeek::transformEdge(EdgeContext* edgeCtx) {
             columnsName.emplace_back(kDst);
             break;
     }
-    auto scan = IndexScan::make(matchClauseCtx->qctx,
+
+    auto* qctx = matchClauseCtx->qctx;
+    auto scan = IndexScan::make(qctx,
                                 nullptr,
                                 matchClauseCtx->space.id,
                                 std::move(contexts),
@@ -94,26 +96,25 @@ StatusOr<SubPlan> PropIndexSeek::transformEdge(EdgeContext* edgeCtx) {
     plan.tail = scan;
     plan.root = scan;
 
+    auto* pool = qctx->objPool();
     if (edgeCtx->scanInfo.direction == MatchEdge::Direction::BOTH) {
         // merge the src,dst to one column
-        auto *yieldColumns = matchClauseCtx->qctx->objPool()->makeAndAdd<YieldColumns>();
-        auto *exprList = new ExpressionList();
-        exprList->add(new ColumnExpression(0));  // src
-        exprList->add(new ColumnExpression(1));  // dst
-        yieldColumns->addColumn(new YieldColumn(new ListExpression(exprList)));
-        auto *project = Project::make(matchClauseCtx->qctx,
-                                      scan,
-                                      yieldColumns);
+        auto* yieldColumns = pool->makeAndAdd<YieldColumns>();
+        auto* exprList = ExpressionList::make(pool);
+        exprList->add(ColumnExpression::make(pool, 0));   // src
+        exprList->add(ColumnExpression::make(pool, 1));   // dst
+        yieldColumns->addColumn(new YieldColumn(ListExpression::make(pool, exprList)));
+        auto* project = Project::make(qctx, scan, yieldColumns);
         project->setColNames({kVid});
 
-        auto* unwindExpr = matchClauseCtx->qctx->objPool()->add(new ColumnExpression(0));
-        auto* unwind = Unwind::make(matchClauseCtx->qctx, project, unwindExpr, kVid);
+        auto* unwindExpr = pool->add(ColumnExpression::make(pool, 0));
+        auto* unwind = Unwind::make(qctx, project, unwindExpr, kVid);
         unwind->setColNames({"vidList", kVid});
         plan.root = unwind;
     }
 
     // initialize start expression in project edge
-    edgeCtx->initialExpr = std::unique_ptr<Expression>(ExpressionUtils::newVarPropExpr(kVid));
+    edgeCtx->initialExpr = VariablePropertyExpression::make(pool, kVid);
     return plan;
 }
 
@@ -181,7 +182,8 @@ StatusOr<SubPlan> PropIndexSeek::transformNode(NodeContext* nodeCtx) {
     plan.root = scan;
 
     // initialize start expression in project node
-    nodeCtx->initialExpr = std::unique_ptr<Expression>(ExpressionUtils::newVarPropExpr(kVid));
+    auto* pool = matchClauseCtx->qctx->objPool();
+    nodeCtx->initialExpr = VariablePropertyExpression::make(pool, kVid);
     return plan;
 }
 

--- a/src/planner/match/PropIndexSeek.cpp
+++ b/src/planner/match/PropIndexSeek.cpp
@@ -107,14 +107,14 @@ StatusOr<SubPlan> PropIndexSeek::transformEdge(EdgeContext* edgeCtx) {
         auto* project = Project::make(qctx, scan, yieldColumns);
         project->setColNames({kVid});
 
-        auto* unwindExpr = pool->add(ColumnExpression::make(pool, 0));
+        auto* unwindExpr = ColumnExpression::make(pool, 0);
         auto* unwind = Unwind::make(qctx, project, unwindExpr, kVid);
         unwind->setColNames({"vidList", kVid});
         plan.root = unwind;
     }
 
     // initialize start expression in project edge
-    edgeCtx->initialExpr = VariablePropertyExpression::make(pool, kVid);
+    edgeCtx->initialExpr = VariablePropertyExpression::make(pool, "", kVid);
     return plan;
 }
 
@@ -183,7 +183,7 @@ StatusOr<SubPlan> PropIndexSeek::transformNode(NodeContext* nodeCtx) {
 
     // initialize start expression in project node
     auto* pool = matchClauseCtx->qctx->objPool();
-    nodeCtx->initialExpr = VariablePropertyExpression::make(pool, kVid);
+    nodeCtx->initialExpr = VariablePropertyExpression::make(pool, "", kVid);
     return plan;
 }
 

--- a/src/planner/match/UnwindClausePlanner.cpp
+++ b/src/planner/match/UnwindClausePlanner.cpp
@@ -27,8 +27,7 @@ StatusOr<SubPlan> UnwindClausePlanner::transform(CypherClauseContextBase* clause
 }
 
 Status UnwindClausePlanner::buildUnwind(UnwindClauseContext* uctx, SubPlan& subPlan) {
-    auto* newUnwindExpr =
-        uctx->qctx->objPool()->add(MatchSolver::doRewrite(*uctx->aliasesUsed, uctx->unwindExpr));
+    auto* newUnwindExpr = MatchSolver::doRewrite(uctx->qctx, *uctx->aliasesUsed, uctx->unwindExpr);
     auto* unwind = Unwind::make(uctx->qctx, nullptr, newUnwindExpr, uctx->alias);
     unwind->setColNames({uctx->alias});
     subPlan.root = unwind;

--- a/src/planner/match/VertexIdSeek.cpp
+++ b/src/planner/match/VertexIdSeek.cpp
@@ -65,7 +65,8 @@ std::pair<std::string, Expression *> VertexIdSeek::listToAnnoVarVid(QueryContext
 
     qctx->ectx()->setResult(input, ResultBuilder().value(Value(std::move(vids))).finish());
 
-    auto *src = new VariablePropertyExpression(input, kVid);
+    auto* pool = qctx->objPool();
+    auto *src = VariablePropertyExpression::make(pool, input, kVid);
     return std::pair<std::string, Expression *>(input, src);
 }
 
@@ -78,7 +79,8 @@ std::pair<std::string, Expression *> VertexIdSeek::constToAnnoVarVid(QueryContex
 
     qctx->ectx()->setResult(input, ResultBuilder().value(Value(std::move(vids))).finish());
 
-    auto *src = new VariablePropertyExpression(input, kVid);
+    auto* pool = qctx->objPool();
+    auto *src = VariablePropertyExpression::make(pool, input, kVid);
     return std::pair<std::string, Expression *>(input, src);
 }
 
@@ -96,7 +98,7 @@ StatusOr<SubPlan> VertexIdSeek::transformNode(NodeContext *nodeCtx) {
     plan.root = passThrough;
     plan.tail = passThrough;
 
-    nodeCtx->initialExpr = std::unique_ptr<Expression>(vidsResult.second);
+    nodeCtx->initialExpr = vidsResult.second;
     return plan;
 }
 

--- a/src/planner/match/WhereClausePlanner.cpp
+++ b/src/planner/match/WhereClausePlanner.cpp
@@ -20,8 +20,7 @@ StatusOr<SubPlan> WhereClausePlanner::transform(CypherClauseContextBase* ctx) {
     auto* wctx = static_cast<WhereClauseContext*>(ctx);
     if (wctx->filter) {
         SubPlan wherePlan;
-        auto* newFilter = MatchSolver::doRewrite(*wctx->aliasesUsed, wctx->filter);
-        wctx->qctx->objPool()->add(newFilter);
+        auto* newFilter = MatchSolver::doRewrite(wctx->qctx, *wctx->aliasesUsed, wctx->filter);
         wherePlan.root = Filter::make(wctx->qctx, nullptr, newFilter, true);
         wherePlan.tail = wherePlan.root;
 

--- a/src/planner/match/YieldClausePlanner.cpp
+++ b/src/planner/match/YieldClausePlanner.cpp
@@ -28,7 +28,8 @@ void YieldClausePlanner::rewriteYieldColumns(const YieldClauseContext* yctx,
                                              YieldColumns* newYields) {
     auto* aliasesUsed = yctx->aliasesUsed;
     for (auto* col : yields->columns()) {
-        newYields->addColumn(new YieldColumn(MatchSolver::doRewrite(*aliasesUsed, col->expr())));
+        newYields->addColumn(
+            new YieldColumn(MatchSolver::doRewrite(yctx->qctx, *aliasesUsed, col->expr())));
     }
 }
 
@@ -38,8 +39,7 @@ void YieldClausePlanner::rewriteGroupExprs(const YieldClauseContext* yctx,
     auto* aliasesUsed = yctx->aliasesUsed;
 
     for (auto* expr : *exprs) {
-        auto* newExpr = MatchSolver::doRewrite(*aliasesUsed, expr);
-        yctx->qctx->objPool()->add(newExpr);
+        auto* newExpr = MatchSolver::doRewrite(yctx->qctx, *aliasesUsed, expr);
         newExprs->emplace_back(newExpr);
     }
 }

--- a/src/planner/ngql/PathPlanner.cpp
+++ b/src/planner/ngql/PathPlanner.cpp
@@ -81,27 +81,31 @@ void PathPlanner::buildStart(Starts& starts, std::string& vidsVar, bool reverse)
 Expression* PathPlanner::singlePairLoopCondition(uint32_t steps, const std::string& pathVar) {
     auto loopSteps = pathCtx_->qctx->vctx()->anonVarGen()->getVar();
     pathCtx_->qctx->ectx()->setValue(loopSteps, 0);
-    auto step = ExpressionUtils::stepCondition(loopSteps, ((steps + 1) / 2));
-    auto empty = ExpressionUtils::equalCondition(pathVar, Value::kEmpty);
-    auto zero = ExpressionUtils::zeroCondition(pathVar);
-    auto* noFound = ExpressionUtils::Or(empty.release(), zero.release());
-    return ExpressionUtils::And(step.release(), noFound);
+    auto* pool = pathCtx_->qctx->objPool();
+
+    auto step = ExpressionUtils::stepCondition(pool, loopSteps, ((steps + 1) / 2));
+    auto empty = ExpressionUtils::equalCondition(pool, pathVar, Value::kEmpty);
+    auto zero = ExpressionUtils::zeroCondition(pool, pathVar);
+    auto* noFound = LogicalExpression::makeOr(pool, empty, zero);
+    return LogicalExpression::makeAnd(pool, step, noFound);
 }
 
 // loopSteps{0} <= (steps + 1) / 2
 Expression* PathPlanner::allPairLoopCondition(uint32_t steps) {
     auto loopSteps = pathCtx_->qctx->vctx()->anonVarGen()->getVar();
     pathCtx_->qctx->ectx()->setValue(loopSteps, 0);
-    return ExpressionUtils::stepCondition(loopSteps, ((steps + 1) / 2)).release();
+    auto* pool = pathCtx_->qctx->objPool();
+    return ExpressionUtils::stepCondition(pool, loopSteps, ((steps + 1) / 2));
 }
 
 // loopSteps{0} <= ((steps + 1) / 2) && (size(pathVar) != 0)
 Expression* PathPlanner::multiPairLoopCondition(uint32_t steps, const std::string& pathVar) {
     auto loopSteps = pathCtx_->qctx->vctx()->anonVarGen()->getVar();
     pathCtx_->qctx->ectx()->setValue(loopSteps, 0);
-    auto step = ExpressionUtils::stepCondition(loopSteps, ((steps + 1) / 2));
-    auto neZero = ExpressionUtils::neZeroCondition(pathVar);
-    return ExpressionUtils::And(step.release(), neZero.release());
+    auto* pool = pathCtx_->qctx->objPool();
+    auto step = ExpressionUtils::stepCondition(pool, loopSteps, ((steps + 1) / 2));
+    auto neZero = ExpressionUtils::neZeroCondition(pool, pathVar);
+    return LogicalExpression::makeAnd(pool, step, neZero);
 }
 
 SubPlan PathPlanner::buildRuntimeVidPlan() {
@@ -132,15 +136,17 @@ SubPlan PathPlanner::buildRuntimeVidPlan() {
 }
 
 PlanNode* PathPlanner::allPairStartVidDataSet(PlanNode* dep, const std::string& inputVar) {
-    // col 0 is vid
-    auto* vid = new YieldColumn(new ColumnExpression(0), kVid);
-    // col 1 is list<path(only contain src)>
-    auto* pathExpr = new PathBuildExpression();
-    pathExpr->add(std::make_unique<ColumnExpression>(0));
+    auto* pool = pathCtx_->qctx->objPool();
 
-    auto* exprList = new ExpressionList();
+    // col 0 is vid
+    auto* vid = new YieldColumn(ColumnExpression::make(pool, 0), kVid);
+    // col 1 is list<path(only contain src)>
+    auto* pathExpr = PathBuildExpression::make(pool);
+    pathExpr->add(ColumnExpression::make(pool, 0));
+
+    auto* exprList = ExpressionList::make(pool);
     exprList->add(pathExpr);
-    auto* listExpr = new ListExpression(exprList);
+    auto* listExpr = ListExpression::make(pool, exprList);
     auto* path = new YieldColumn(listExpr, kPathStr);
 
     auto* columns = pathCtx_->qctx->objPool()->add(new YieldColumns());
@@ -156,19 +162,21 @@ PlanNode* PathPlanner::allPairStartVidDataSet(PlanNode* dep, const std::string& 
 }
 
 PlanNode* PathPlanner::multiPairStartVidDataSet(PlanNode* dep, const std::string& inputVar) {
-    // col 0 is dst
-    auto* dst = new YieldColumn(new ColumnExpression(0), kDst);
-    // col 1 is src
-    auto* src = new YieldColumn(new ColumnExpression(1), kSrc);
-    // col 2 is cost
-    auto* cost = new YieldColumn(new ConstantExpression(0), kCostStr);
-    // col 3 is list<path(only contain dst)>
-    auto* pathExpr = new PathBuildExpression();
-    pathExpr->add(std::make_unique<ColumnExpression>(0));
+    auto* pool = pathCtx_->qctx->objPool();
 
-    auto* exprList = new ExpressionList();
+    // col 0 is dst
+    auto* dst = new YieldColumn(ColumnExpression::make(pool, 0), kDst);
+    // col 1 is src
+    auto* src = new YieldColumn(ColumnExpression::make(pool, 1), kSrc);
+    // col 2 is cost
+    auto* cost = new YieldColumn(ConstantExpression::make(pool, 0), kCostStr);
+    // col 3 is list<path(only contain dst)>
+    auto* pathExpr = PathBuildExpression::make(pool);
+    pathExpr->add(ColumnExpression::make(pool, 0));
+
+    auto* exprList = ExpressionList::make(pool);
     exprList->add(pathExpr);
-    auto* listExpr = new ListExpression(exprList);
+    auto* listExpr = ListExpression::make(pool, exprList);
     auto* path = new YieldColumn(listExpr, kPathStr);
 
     auto* columns = pathCtx_->qctx->objPool()->add(new YieldColumns());
@@ -216,7 +224,8 @@ SubPlan PathPlanner::multiPairLoopDepPlan() {
 PlanNode* PathPlanner::singlePairPath(PlanNode* dep, bool reverse) {
     const auto& vidsVar = reverse ? pathCtx_->toVidsVar : pathCtx_->fromVidsVar;
     auto qctx = pathCtx_->qctx;
-    auto* src = qctx->objPool()->add(new ColumnExpression(0));
+    auto* pool = qctx->objPool();
+    auto* src = ColumnExpression::make(pool, 0);
 
     auto* gn = GetNeighbors::make(qctx, dep, pathCtx_->space.id);
     gn->setSrc(src);
@@ -226,7 +235,7 @@ PlanNode* PathPlanner::singlePairPath(PlanNode* dep, bool reverse) {
 
     PlanNode* pathDep = gn;
     if (pathCtx_->filter != nullptr) {
-        auto* filterExpr = qctx->objPool()->add(pathCtx_->filter->clone().release());
+        auto* filterExpr = pathCtx_->filter->clone();
         auto* filter = Filter::make(qctx, gn, filterExpr);
         pathDep = filter;
     }
@@ -273,7 +282,8 @@ SubPlan PathPlanner::singlePairPlan(PlanNode* dep) {
 PlanNode* PathPlanner::allPairPath(PlanNode* dep, bool reverse) {
     const auto& vidsVar = reverse ? pathCtx_->toVidsVar : pathCtx_->fromVidsVar;
     auto qctx = pathCtx_->qctx;
-    auto* src = qctx->objPool()->add(new ColumnExpression(0));
+    auto* pool = qctx->objPool();
+    auto* src = ColumnExpression::make(pool, 0);
 
     auto* gn = GetNeighbors::make(qctx, dep, pathCtx_->space.id);
     gn->setSrc(src);
@@ -283,7 +293,7 @@ PlanNode* PathPlanner::allPairPath(PlanNode* dep, bool reverse) {
 
     PlanNode* pathDep = gn;
     if (pathCtx_->filter != nullptr) {
-        auto* filterExpr = qctx->objPool()->add(pathCtx_->filter->clone().release());
+        auto* filterExpr = pathCtx_->filter->clone();
         auto* filter = Filter::make(qctx, gn, filterExpr);
         pathDep = filter;
     }
@@ -325,7 +335,8 @@ SubPlan PathPlanner::allPairPlan(PlanNode* dep) {
 PlanNode* PathPlanner::multiPairPath(PlanNode* dep, bool reverse) {
     const auto& vidsVar = reverse ? pathCtx_->toVidsVar : pathCtx_->fromVidsVar;
     auto qctx = pathCtx_->qctx;
-    auto* src = qctx->objPool()->add(new ColumnExpression(0));
+    auto* pool = qctx->objPool();
+    auto* src = ColumnExpression::make(pool, 0);
 
     auto* gn = GetNeighbors::make(qctx, dep, pathCtx_->space.id);
     gn->setSrc(src);
@@ -335,7 +346,7 @@ PlanNode* PathPlanner::multiPairPath(PlanNode* dep, bool reverse) {
 
     PlanNode* pathDep = gn;
     if (pathCtx_->filter != nullptr) {
-        auto* filterExpr = qctx->objPool()->add(pathCtx_->filter->clone().release());
+        auto* filterExpr = pathCtx_->filter->clone();
         auto* filter = Filter::make(qctx, gn, filterExpr);
         pathDep = filter;
     }
@@ -377,11 +388,12 @@ SubPlan PathPlanner::multiPairPlan(PlanNode* dep) {
 
 PlanNode* PathPlanner::buildVertexPlan(PlanNode* dep, const std::string& input) {
     auto qctx = pathCtx_->qctx;
+    auto* pool = qctx->objPool();
 
     // col 0 of the input is path
-    auto args = new ArgumentList();
-    args->addArgument(std::make_unique<ColumnExpression>(0));
-    auto funNodes = new FunctionCallExpression("nodes", args);
+    auto args = ArgumentList::make(pool);
+    args->addArgument(ColumnExpression::make(pool, 0));
+    auto funNodes = FunctionCallExpression::make(pool, "nodes", args);
 
     auto* column = new YieldColumn(funNodes, "nodes");
     auto* columns = qctx->objPool()->add(new YieldColumns());
@@ -392,14 +404,14 @@ PlanNode* PathPlanner::buildVertexPlan(PlanNode* dep, const std::string& input) 
     project->setInputVar(input);
 
     // col 0 of the project->output is [node...]
-    auto* unwindExpr = qctx->objPool()->add(new ColumnExpression(0));
+    auto* unwindExpr = qctx->objPool()->add(ColumnExpression::make(pool, 0));
     auto* unwind = Unwind::make(qctx, project, unwindExpr);
     unwind->setColNames({"nodes"});
 
     // extract vid from vertex, col 0 is vertex
-    auto idArgs = new ArgumentList();
-    idArgs->addArgument(std::make_unique<ColumnExpression>(1));
-    auto* src = qctx->objPool()->add(new FunctionCallExpression("id", idArgs));
+    auto idArgs = ArgumentList::make(pool);
+    idArgs->addArgument(ColumnExpression::make(pool, 1));
+    auto* src = qctx->objPool()->add(FunctionCallExpression::make(pool, "id", idArgs));
     // get all vertexprop
     auto vertexProp = SchemaUtil::getAllVertexProp(qctx, pathCtx_->space, true);
     auto* getVertices = GetVertices::make(
@@ -410,11 +422,11 @@ PlanNode* PathPlanner::buildVertexPlan(PlanNode* dep, const std::string& input) 
 
 PlanNode* PathPlanner::buildEdgePlan(PlanNode* dep, const std::string& input) {
     auto qctx = pathCtx_->qctx;
-
+    auto* pool = qctx->objPool();
     // col 0 of the input is path
-    auto args = new ArgumentList();
-    args->addArgument(std::make_unique<ColumnExpression>(0));
-    auto funEdges = new FunctionCallExpression("relationships", args);
+    auto args = ArgumentList::make(pool);
+    args->addArgument(ColumnExpression::make(pool, 0));
+    auto funEdges = FunctionCallExpression::make(pool, "relationships", args);
 
     auto* column = new YieldColumn(funEdges, "edges");
     auto* columns = qctx->objPool()->add(new YieldColumns());
@@ -425,28 +437,28 @@ PlanNode* PathPlanner::buildEdgePlan(PlanNode* dep, const std::string& input) {
     project->setInputVar(input);
 
     // col 0 of the project->output() is [edge...]
-    auto* unwindExpr = qctx->objPool()->add(new ColumnExpression(0));
+    auto* unwindExpr = qctx->objPool()->add(ColumnExpression::make(pool, 0));
     auto* unwind = Unwind::make(qctx, project, unwindExpr);
     unwind->setColNames({"edges"});
 
     // extract src from edge
-    auto srcArgs = new ArgumentList();
-    srcArgs->addArgument(std::make_unique<ColumnExpression>(1));
-    auto* src = qctx->objPool()->add(new FunctionCallExpression("src", srcArgs));
+    auto srcArgs = ArgumentList::make(pool);
+    srcArgs->addArgument(ColumnExpression::make(pool, 1));
+    auto* src = qctx->objPool()->add(FunctionCallExpression::make(pool, "src", srcArgs));
     // extract dst from edge
-    auto dstArgs = new ArgumentList();
-    dstArgs->addArgument(std::make_unique<ColumnExpression>(1));
-    auto* dst = qctx->objPool()->add(new FunctionCallExpression("dst", dstArgs));
+    auto dstArgs = ArgumentList::make(pool);
+    dstArgs->addArgument(ColumnExpression::make(pool, 1));
+    auto* dst = qctx->objPool()->add(FunctionCallExpression::make(pool, "dst", dstArgs));
     // extract rank from edge
-    auto rankArgs = new ArgumentList();
-    rankArgs->addArgument(std::make_unique<ColumnExpression>(1));
+    auto rankArgs = ArgumentList::make(pool);
+    rankArgs->addArgument(ColumnExpression::make(pool, 1));
     auto* rank =
-        qctx->objPool()->add(new FunctionCallExpression("rank", rankArgs));
+        qctx->objPool()->add(FunctionCallExpression::make(pool, "rank", rankArgs));
     // type
-    auto typeArgs = new ArgumentList();
-    typeArgs->addArgument(std::make_unique<ColumnExpression>(1));
+    auto typeArgs = ArgumentList::make(pool);
+    typeArgs->addArgument(ColumnExpression::make(pool, 1));
     auto* type =
-        qctx->objPool()->add(new FunctionCallExpression("typeid", typeArgs));
+        qctx->objPool()->add(FunctionCallExpression::make(pool, "typeid", typeArgs));
     // prepare edgetype
     auto edgeProp = SchemaUtil::getEdgeProps(qctx, pathCtx_->space, pathCtx_->over.edgeTypes, true);
     auto* getEdge = GetEdges::make(qctx,

--- a/src/planner/ngql/PathPlanner.cpp
+++ b/src/planner/ngql/PathPlanner.cpp
@@ -149,7 +149,7 @@ PlanNode* PathPlanner::allPairStartVidDataSet(PlanNode* dep, const std::string& 
     auto* listExpr = ListExpression::make(pool, exprList);
     auto* path = new YieldColumn(listExpr, kPathStr);
 
-    auto* columns = pathCtx_->qctx->objPool()->add(new YieldColumns());
+    auto* columns = pool->add(new YieldColumns());
     columns->addColumn(vid);
     columns->addColumn(path);
 
@@ -179,7 +179,7 @@ PlanNode* PathPlanner::multiPairStartVidDataSet(PlanNode* dep, const std::string
     auto* listExpr = ListExpression::make(pool, exprList);
     auto* path = new YieldColumn(listExpr, kPathStr);
 
-    auto* columns = pathCtx_->qctx->objPool()->add(new YieldColumns());
+    auto* columns = pool->add(new YieldColumns());
     columns->addColumn(dst);
     columns->addColumn(src);
     columns->addColumn(cost);
@@ -394,7 +394,7 @@ PlanNode* PathPlanner::buildVertexPlan(PlanNode* dep, const std::string& input) 
     auto funNodes = FunctionCallExpression::make(pool, "nodes", args);
 
     auto* column = new YieldColumn(funNodes, "nodes");
-    auto* columns = qctx->objPool()->add(new YieldColumns());
+    auto* columns = pool->add(new YieldColumns());
     columns->addColumn(column);
 
     auto* project = Project::make(qctx, dep, columns);
@@ -427,7 +427,7 @@ PlanNode* PathPlanner::buildEdgePlan(PlanNode* dep, const std::string& input) {
     auto funEdges = FunctionCallExpression::make(pool, "relationships", args);
 
     auto* column = new YieldColumn(funEdges, "edges");
-    auto* columns = qctx->objPool()->add(new YieldColumns());
+    auto* columns = pool->add(new YieldColumns());
     columns->addColumn(column);
 
     auto* project = Project::make(qctx, dep, columns);

--- a/src/planner/plan/Query.cpp
+++ b/src/planner/plan/Query.cpp
@@ -23,7 +23,8 @@ std::unique_ptr<PlanNodeDescription> Explore::explain() const {
     addDescription("space", folly::to<std::string>(space_), desc.get());
     addDescription("dedup", util::toJson(dedup_), desc.get());
     addDescription("limit", folly::to<std::string>(limit_), desc.get());
-    auto filter = filter_.empty() ? filter_ : Expression::decode(filter_)->toString();
+    auto filter =
+        filter_.empty() ? filter_ : Expression::decode(qctx_->objPool(), filter_)->toString();
     addDescription("filter", filter, desc.get());
     addDescription("orderBy", folly::toJson(util::toJson(orderBy_)), desc.get());
     return desc;
@@ -66,7 +67,7 @@ PlanNode* GetNeighbors::clone() const {
 void GetNeighbors::cloneMembers(const GetNeighbors& g) {
     Explore::cloneMembers(g);
 
-    setSrc(qctx_->objPool()->add(g.src_->clone().release()));
+    setSrc(qctx_->objPool()->add(g.src_->clone()));
     setEdgeTypes(g.edgeTypes_);
     setEdgeDirection(g.edgeDirection_);
     setRandom(g.random_);
@@ -112,7 +113,7 @@ PlanNode* GetVertices::clone() const {
 void GetVertices::cloneMembers(const GetVertices& gv) {
     Explore::cloneMembers(gv);
 
-    src_ = qctx_->objPool()->add(gv.src()->clone().release());
+    src_ = qctx_->objPool()->add(gv.src()->clone());
 
     if (gv.props_) {
         auto vertexProps = *gv.props_;
@@ -148,10 +149,10 @@ PlanNode* GetEdges::clone() const {
 void GetEdges::cloneMembers(const GetEdges& ge) {
     Explore::cloneMembers(ge);
 
-    src_ = qctx_->objPool()->add(ge.src()->clone().release());
-    type_ = qctx_->objPool()->add(ge.type()->clone().release());
-    ranking_ = qctx_->objPool()->add(ge.ranking()->clone().release());
-    dst_ = qctx_->objPool()->add(ge.dst()->clone().release());
+    src_ = qctx_->objPool()->add(ge.src()->clone());
+    type_ = qctx_->objPool()->add(ge.type()->clone());
+    ranking_ = qctx_->objPool()->add(ge.ranking()->clone());
+    dst_ = qctx_->objPool()->add(ge.dst()->clone());
 
     if (ge.props_) {
         auto edgeProps = *ge.props_;
@@ -218,7 +219,7 @@ PlanNode* Filter::clone() const {
 void Filter::cloneMembers(const Filter& f) {
     SingleInputNode::cloneMembers(f);
 
-    condition_ = qctx_->objPool()->add(f.condition()->clone().release());
+    condition_ = qctx_->objPool()->add(f.condition()->clone());
     needStableFilter_ = f.needStableFilter();
 }
 
@@ -312,7 +313,7 @@ PlanNode* Unwind::clone() const {
 void Unwind::cloneMembers(const Unwind &p) {
     SingleInputNode::cloneMembers(p);
 
-    unwindExpr_ = qctx_->objPool()->add(p.unwindExpr()->clone().release());
+    unwindExpr_ = qctx_->objPool()->add(p.unwindExpr()->clone());
     alias_ = p.alias();
 }
 
@@ -413,10 +414,10 @@ void Aggregate::cloneMembers(const Aggregate& agg) {
     std::vector<Expression*> gKeys;
     std::vector<Expression*> gItems;
     for (auto* expr : agg.groupKeys()) {
-        gKeys.emplace_back(qctx_->objPool()->add(expr->clone().release()));
+        gKeys.emplace_back(expr->clone());
     }
     for (auto* expr : agg.groupItems()) {
-        gItems.emplace_back(qctx_->objPool()->add(expr->clone().release()));
+        gItems.emplace_back(expr->clone());
     }
     groupKeys_ = std::move(gKeys);
     groupItems_ = std::move(gItems);
@@ -522,13 +523,13 @@ void Join::cloneMembers(const Join& j) {
 
     std::vector<Expression*> hKeys;
     for (auto* item : j.hashKeys()) {
-        hKeys.emplace_back(qctx_->objPool()->add(item->clone().release()));
+        hKeys.emplace_back(item->clone());
     }
     hashKeys_ = std::move(hKeys);
 
     std::vector<Expression*> pKeys;
     for (auto* item : j.probeKeys()) {
-        pKeys.emplace_back(qctx_->objPool()->add(item->clone().release()));
+        pKeys.emplace_back(item->clone());
     }
     probeKeys_ = std::move(pKeys);
 }
@@ -604,8 +605,8 @@ PlanNode* Assign::clone() const {
 void Assign::cloneMembers(const Assign& f) {
     SingleInputNode::cloneMembers(f);
 
-    for (const std::pair<std::string, std::unique_ptr<Expression>>& item : f.items()) {
-        std::pair<std::string, std::unique_ptr<Expression>> newItem;
+    for (const std::pair<std::string, Expression*>& item : f.items()) {
+        std::pair<std::string, Expression*> newItem;
         newItem.first = item.first;
         newItem.second = item.second->clone();
         items_.emplace_back(std::move(newItem));

--- a/src/planner/plan/Query.cpp
+++ b/src/planner/plan/Query.cpp
@@ -67,7 +67,7 @@ PlanNode* GetNeighbors::clone() const {
 void GetNeighbors::cloneMembers(const GetNeighbors& g) {
     Explore::cloneMembers(g);
 
-    setSrc(qctx_->objPool()->add(g.src_->clone()));
+    setSrc(g.src_->clone());
     setEdgeTypes(g.edgeTypes_);
     setEdgeDirection(g.edgeDirection_);
     setRandom(g.random_);
@@ -113,7 +113,7 @@ PlanNode* GetVertices::clone() const {
 void GetVertices::cloneMembers(const GetVertices& gv) {
     Explore::cloneMembers(gv);
 
-    src_ = qctx_->objPool()->add(gv.src()->clone());
+    src_ = gv.src()->clone();
 
     if (gv.props_) {
         auto vertexProps = *gv.props_;
@@ -149,10 +149,10 @@ PlanNode* GetEdges::clone() const {
 void GetEdges::cloneMembers(const GetEdges& ge) {
     Explore::cloneMembers(ge);
 
-    src_ = qctx_->objPool()->add(ge.src()->clone());
-    type_ = qctx_->objPool()->add(ge.type()->clone());
-    ranking_ = qctx_->objPool()->add(ge.ranking()->clone());
-    dst_ = qctx_->objPool()->add(ge.dst()->clone());
+    src_ = ge.src()->clone();
+    type_ = ge.type()->clone();
+    ranking_ = ge.ranking()->clone();
+    dst_ = ge.dst()->clone();
 
     if (ge.props_) {
         auto edgeProps = *ge.props_;
@@ -219,7 +219,7 @@ PlanNode* Filter::clone() const {
 void Filter::cloneMembers(const Filter& f) {
     SingleInputNode::cloneMembers(f);
 
-    condition_ = qctx_->objPool()->add(f.condition()->clone());
+    condition_ = f.condition()->clone();
     needStableFilter_ = f.needStableFilter();
 }
 
@@ -313,7 +313,7 @@ PlanNode* Unwind::clone() const {
 void Unwind::cloneMembers(const Unwind &p) {
     SingleInputNode::cloneMembers(p);
 
-    unwindExpr_ = qctx_->objPool()->add(p.unwindExpr()->clone());
+    unwindExpr_ = p.unwindExpr()->clone();
     alias_ = p.alias();
 }
 

--- a/src/planner/plan/Query.h
+++ b/src/planner/plan/Query.h
@@ -701,7 +701,7 @@ private:
     void cloneMembers(const Unwind&);
 
 private:
-    Expression* unwindExpr_;
+    Expression* unwindExpr_{nullptr};
     std::string alias_;
 };
 

--- a/src/planner/plan/Query.h
+++ b/src/planner/plan/Query.h
@@ -1149,7 +1149,7 @@ public:
         return qctx->objPool()->add(new Assign(qctx, input));
     }
 
-    const std::vector<std::pair<std::string, std::unique_ptr<Expression>>>& items() const {
+    const std::vector<std::pair<std::string, Expression*>>& items() const {
         return items_;
     }
 
@@ -1169,7 +1169,7 @@ private:
     void cloneMembers(const Assign&);
 
 private:
-    std::vector<std::pair<std::string, std::unique_ptr<Expression>>> items_;
+    std::vector<std::pair<std::string, Expression*>> items_;
 };
 
 /**

--- a/src/util/AstUtils.h
+++ b/src/util/AstUtils.h
@@ -16,9 +16,9 @@ class AstUtils final {
 public:
     explicit AstUtils(...) = delete;
 
-    static Status reprAstCheck(const Sentence& origin) {
+    static Status reprAstCheck(const Sentence& origin, QueryContext* qctx) {
         auto toString = origin.toString();
-        auto copyResult = GQLParser().parse(toString);
+        auto copyResult = GQLParser(qctx).parse(toString);
         if (!copyResult.ok()) {
             return Status::Error("The repr sentence `%s' can't be parsed, error: `%s'.",
                                  toString.c_str(),

--- a/src/util/ExpressionUtils.cpp
+++ b/src/util/ExpressionUtils.cpp
@@ -225,7 +225,7 @@ Expression *ExpressionUtils::reduceUnaryNotExpr(const Expression *expr, ObjectPo
                    : reducedExpr;
     };
 
-    return pool->add(RewriteVisitor::transform(expr, rootMatcher, rewriter));
+    return RewriteVisitor::transform(expr, rootMatcher, rewriter);
 }
 
 Expression *ExpressionUtils::rewriteRelExpr(const Expression *expr, ObjectPool *pool) {
@@ -292,12 +292,12 @@ Expression *ExpressionUtils::rewriteRelExpr(const Expression *expr, ObjectPool *
             pool, relExpr->kind(), relLeftOperandExpr->clone(), relRightOperandExpr->clone());
     };
 
-    return pool->add(RewriteVisitor::transform(expr, matcher, rewriter));
+    return RewriteVisitor::transform(expr, matcher, rewriter);
 }
 
 Expression *ExpressionUtils::rewriteRelExprHelper(ObjectPool *pool,
                                                   const Expression *expr,
-                                                  Expression *relRightOperandExpr) {
+                                                  Expression *&relRightOperandExpr) {
     // TODO: Support rewrite mul/div expressoion after fixing overflow
     auto matcher = [](const Expression *e) -> bool {
         if (!e->isArithmeticExpr() || e->kind() == Expression::Kind::kMultiply ||
@@ -427,10 +427,11 @@ Expression* ExpressionUtils::flattenInnerLogicalExpr(const Expression *expr) {
 }
 
 // pick the subparts of expression that meet picker's criteria
-void ExpressionUtils::splitFilter(ObjectPool* pool, const Expression *expr,
+void ExpressionUtils::splitFilter(ObjectPool *pool,
+                                  const Expression *expr,
                                   std::function<bool(const Expression *)> picker,
-                                  Expression** filterPicked,
-                                  Expression** filterUnpicked) {
+                                  Expression **filterPicked,
+                                  Expression **filterUnpicked) {
     // Pick the non-LogicalAndExpr directly
     if (expr->kind() != Expression::Kind::kLogicalAnd) {
         if (picker(expr)) {

--- a/src/util/ExpressionUtils.cpp
+++ b/src/util/ExpressionUtils.cpp
@@ -109,82 +109,82 @@ bool ExpressionUtils::isEvaluableExpr(const Expression *expr) {
 }
 
 // rewrite LabelAttr to EdgeProp
-Expression *ExpressionUtils::rewriteLabelAttr2EdgeProp(const Expression *expr) {
+Expression *ExpressionUtils::rewriteLabelAttr2EdgeProp(ObjectPool *pool, const Expression *expr) {
     auto matcher = [](const Expression *e) -> bool {
         return e->kind() == Expression::Kind::kLabelAttribute;
     };
-    auto rewriter = [](const Expression *e) -> Expression * {
+    auto rewriter = [&](const Expression *e) -> Expression * {
         DCHECK_EQ(e->kind(), Expression::Kind::kLabelAttribute);
         auto labelAttrExpr = static_cast<const LabelAttributeExpression *>(e);
         auto leftName = labelAttrExpr->left()->name();
         auto rightName = labelAttrExpr->right()->value().getStr();
-        return new EdgePropertyExpression(leftName, rightName);
+        return EdgePropertyExpression::make(pool, leftName, rightName);
     };
 
     return RewriteVisitor::transform(expr, std::move(matcher), std::move(rewriter));
 }
 
 // rewrite var in VariablePropExpr to another var
-std::unique_ptr<Expression> ExpressionUtils::rewriteInnerVar(const Expression *expr,
-                                                             std::string newVar) {
+Expression *ExpressionUtils::rewriteInnerVar(ObjectPool *pool,
+                                             const Expression *expr,
+                                             std::string newVar) {
     auto matcher = [](const Expression *e) -> bool {
         return e->kind() == Expression::Kind::kVarProperty;
     };
-    auto rewriter = [newVar](const Expression *e) -> Expression * {
+    auto rewriter = [&](const Expression *e) -> Expression * {
         DCHECK_EQ(e->kind(), Expression::Kind::kVarProperty);
         auto varPropExpr = static_cast<const VariablePropertyExpression *>(e);
         auto newProp = varPropExpr->prop();
-        return new VariablePropertyExpression(newVar, newProp);
+        return VariablePropertyExpression::make(pool, newVar, newProp);
     };
 
-    return std::unique_ptr<Expression>(
-        RewriteVisitor::transform(expr, std::move(matcher), std::move(rewriter)));
+    return RewriteVisitor::transform(expr, std::move(matcher), std::move(rewriter));
 }
 
 // rewrite LabelAttr to tagProp
-Expression *ExpressionUtils::rewriteLabelAttr2TagProp(const Expression *expr) {
+Expression *ExpressionUtils::rewriteLabelAttr2TagProp(ObjectPool* pool, const Expression *expr) {
     auto matcher = [](const Expression *e) -> bool {
         return e->kind() == Expression::Kind::kLabelAttribute;
     };
-    auto rewriter = [](const Expression *e) -> Expression * {
+    auto rewriter = [&](const Expression *e) -> Expression * {
         DCHECK_EQ(e->kind(), Expression::Kind::kLabelAttribute);
         auto labelAttrExpr = static_cast<const LabelAttributeExpression *>(e);
         auto leftName = labelAttrExpr->left()->name();
         auto rightName = labelAttrExpr->right()->value().getStr();
-        return new TagPropertyExpression(leftName, rightName);
+        return TagPropertyExpression::make(pool, leftName, rightName);
     };
 
     return RewriteVisitor::transform(expr, std::move(matcher), std::move(rewriter));
 }
 
 // rewrite Agg to VarProp
-Expression *ExpressionUtils::rewriteAgg2VarProp(const Expression *expr) {
+Expression *ExpressionUtils::rewriteAgg2VarProp(ObjectPool *pool, const Expression *expr) {
     auto matcher = [](const Expression *e) -> bool {
         return e->kind() == Expression::Kind::kAggregate;
     };
-    auto rewriter = [](const Expression *e) -> Expression * {
-        return new VariablePropertyExpression("", e->toString());
+    auto rewriter = [&](const Expression *e) -> Expression * {
+        return VariablePropertyExpression::make(pool, "", e->toString());
     };
 
     return RewriteVisitor::transform(expr, std::move(matcher), std::move(rewriter));
 }
 
-StatusOr<Expression *> ExpressionUtils::foldConstantExpr(const Expression *expr,
-                                                         ObjectPool *objPool) {
+StatusOr<Expression *> ExpressionUtils::foldConstantExpr(ObjectPool *objPool,
+                                                         const Expression *expr) {
     auto newExpr = expr->clone();
-    FoldConstantExprVisitor visitor;
+    FoldConstantExprVisitor visitor(objPool);
     newExpr->accept(&visitor);
     if (!visitor.ok()) {
         return std::move(visitor).status();
     }
     if (visitor.canBeFolded()) {
-        auto foldedExpr = visitor.fold(newExpr.get());
+        auto foldedExpr = visitor.fold(newExpr);
         if (!visitor.ok()) {
             return std::move(visitor).status();
         }
-        return objPool->add(foldedExpr);
+        return foldedExpr;
     }
-    return objPool->add(newExpr.release());
+    return newExpr;
 }
 
 Expression *ExpressionUtils::reduceUnaryNotExpr(const Expression *expr, ObjectPool *pool) {
@@ -207,17 +207,17 @@ Expression *ExpressionUtils::reduceUnaryNotExpr(const Expression *expr, ObjectPo
     std::function<Expression *(const Expression *)> rewriter =
         [&](const Expression *e) -> Expression * {
         auto operand = static_cast<const UnaryExpression *>(e)->operand();
-        auto reducedExpr = pool->add(operand->clone().release());
+        auto reducedExpr = operand->clone();
 
         if (reducedExpr->kind() == Expression::Kind::kUnaryNot) {
             auto castedExpr = static_cast<UnaryExpression *>(reducedExpr);
             reducedExpr = castedExpr->operand();
         } else if (reducedExpr->isRelExpr() && reducedExpr->kind() != Expression::Kind::kRelREG) {
             auto castedExpr = static_cast<RelationalExpression *>(reducedExpr);
-            reducedExpr = pool->add(reverseRelExpr(castedExpr).release());
+            reducedExpr = reverseRelExpr(pool, castedExpr);
         } else if (reducedExpr->isLogicalExpr()) {
             auto castedExpr = static_cast<LogicalExpression *>(reducedExpr);
-            reducedExpr = pool->add(reverseLogicalExpr(castedExpr).release());
+            reducedExpr = reverseLogicalExpr(pool, castedExpr);
         }
         // Rewrite the output of rewrite if possible
         return operandMatcher(reducedExpr)
@@ -256,19 +256,17 @@ Expression *ExpressionUtils::rewriteRelExpr(const Expression *expr, ObjectPool *
             auto valType = val.type();
             // Rewrite to null if the expression contains any operand that is null
             if (valType == Value::Type::NULLVALUE) {
-                return rExpr->clone().release();
+                return rExpr->clone();
             }
             if (relExpr->kind() == Expression::Kind::kRelEQ) {
                 if (valType == Value::Type::BOOL) {
-                    return val.getBool() ? lExpr->clone().release()
-                                         : new UnaryExpression(Expression::Kind::kUnaryNot,
-                                                               lExpr->clone().release());
+                    return val.getBool() ? lExpr->clone()
+                                         : UnaryExpression::makeNot(pool, lExpr->clone());
                 }
             } else if (relExpr->kind() == Expression::Kind::kRelNE) {
                 if (valType == Value::Type::BOOL) {
-                    return val.getBool() ? new UnaryExpression(Expression::Kind::kUnaryNot,
-                                                               lExpr->clone().release())
-                                         : lExpr->clone().release();
+                    return val.getBool() ? UnaryExpression::makeNot(pool, lExpr->clone())
+                                         : lExpr->clone();
                 }
             }
         }
@@ -277,7 +275,7 @@ Expression *ExpressionUtils::rewriteRelExpr(const Expression *expr, ObjectPool *
 
     std::function<Expression *(const Expression *)> rewriter =
         [&](const Expression *e) -> Expression * {
-        auto exprCopy = pool->add(e->clone().release());
+        auto exprCopy = e->clone();
         auto relExpr = static_cast<RelationalExpression *>(exprCopy);
         auto lExpr = relExpr->left();
         auto rExpr = relExpr->right();
@@ -289,22 +287,20 @@ Expression *ExpressionUtils::rewriteRelExpr(const Expression *expr, ObjectPool *
         }
         // Move all evaluable expression to the right side
         auto relRightOperandExpr = relExpr->right()->clone();
-        auto relLeftOperandExpr = rewriteRelExprHelper(relExpr->left(), relRightOperandExpr);
-        return new RelationalExpression(relExpr->kind(),
-                                        relLeftOperandExpr->clone().release(),
-                                        relRightOperandExpr->clone().release());
+        auto relLeftOperandExpr = rewriteRelExprHelper(pool, relExpr->left(), relRightOperandExpr);
+        return RelationalExpression::makeKind(
+            pool, relExpr->kind(), relLeftOperandExpr->clone(), relRightOperandExpr->clone());
     };
 
     return pool->add(RewriteVisitor::transform(expr, matcher, rewriter));
 }
 
-Expression *ExpressionUtils::rewriteRelExprHelper(
-    const Expression *expr,
-    std::unique_ptr<Expression> &relRightOperandExpr) {
+Expression *ExpressionUtils::rewriteRelExprHelper(ObjectPool *pool,
+                                                  const Expression *expr,
+                                                  Expression *relRightOperandExpr) {
     // TODO: Support rewrite mul/div expressoion after fixing overflow
     auto matcher = [](const Expression *e) -> bool {
-        if (!e->isArithmeticExpr() ||
-            e->kind() == Expression::Kind::kMultiply ||
+        if (!e->isArithmeticExpr() || e->kind() == Expression::Kind::kMultiply ||
             e->kind() == Expression::Kind::kDivision)
             return false;
         auto arithExpr = static_cast<const ArithmeticExpression *>(e);
@@ -318,21 +314,34 @@ Expression *ExpressionUtils::rewriteRelExprHelper(
 
     auto arithExpr = static_cast<const ArithmeticExpression *>(expr);
     auto kind = getNegatedArithmeticType(arithExpr->kind());
-    auto lexpr = relRightOperandExpr->clone().release();
+    auto lexpr = relRightOperandExpr->clone();
     const Expression *root = nullptr;
     Expression *rexpr = nullptr;
 
     // Use left operand as root
     if (ExpressionUtils::isEvaluableExpr(arithExpr->right())) {
-        rexpr = arithExpr->right()->clone().release();
+        rexpr = arithExpr->right()->clone();
         root = arithExpr->left();
     } else {
-        rexpr = arithExpr->left()->clone().release();
+        rexpr = arithExpr->left()->clone();
         root = arithExpr->right();
     }
+    switch (kind) {
+        case Expression::Kind::kAdd:
+            relRightOperandExpr = ArithmeticExpression::makeAdd(pool, lexpr, rexpr);
+            break;
+        case Expression::Kind::kMinus:
+            relRightOperandExpr = ArithmeticExpression::makeMinus(pool, lexpr, rexpr);
+            break;
+        // Unsupported arithm kind
+        // case Expression::Kind::kMultiply:
+        // case Expression::Kind::kDivision:
+        default:
+            LOG(FATAL) << "Unsupported expression kind: " << static_cast<uint8_t>(kind);
+            break;
+    }
 
-    relRightOperandExpr.reset(new ArithmeticExpression(kind, lexpr, rexpr));
-    return rewriteRelExprHelper(root, relRightOperandExpr);
+    return rewriteRelExprHelper(pool, root, relRightOperandExpr);
 }
 
 StatusOr<Expression*> ExpressionUtils::filterTransform(const Expression *filter, ObjectPool *pool) {
@@ -340,7 +349,7 @@ StatusOr<Expression*> ExpressionUtils::filterTransform(const Expression *filter,
     // Rewrite relational expression
     rewrittenExpr = rewriteRelExpr(rewrittenExpr, pool);
     // Fold constant expression
-    auto constantFoldRes = foldConstantExpr(rewrittenExpr, pool);
+    auto constantFoldRes = foldConstantExpr(pool, rewrittenExpr);
     NG_RETURN_IF_ERROR(constantFoldRes);
     rewrittenExpr = constantFoldRes.value();
     // Reduce Unary expression
@@ -351,7 +360,7 @@ StatusOr<Expression*> ExpressionUtils::filterTransform(const Expression *filter,
 void ExpressionUtils::pullAnds(Expression *expr) {
     DCHECK(expr->kind() == Expression::Kind::kLogicalAnd);
     auto *logic = static_cast<LogicalExpression *>(expr);
-    std::vector<std::unique_ptr<Expression>> operands;
+    std::vector<Expression*> operands;
     pullAndsImpl(logic, operands);
     logic->setOperands(std::move(operands));
 }
@@ -359,163 +368,150 @@ void ExpressionUtils::pullAnds(Expression *expr) {
 void ExpressionUtils::pullOrs(Expression *expr) {
     DCHECK(expr->kind() == Expression::Kind::kLogicalOr);
     auto *logic = static_cast<LogicalExpression *>(expr);
-    std::vector<std::unique_ptr<Expression>> operands;
+    std::vector<Expression*> operands;
     pullOrsImpl(logic, operands);
     logic->setOperands(std::move(operands));
 }
 
 void ExpressionUtils::pullAndsImpl(LogicalExpression *expr,
-                                   std::vector<std::unique_ptr<Expression>> &operands) {
+                                   std::vector<Expression*> &operands) {
     for (auto &operand : expr->operands()) {
         if (operand->kind() != Expression::Kind::kLogicalAnd) {
             operands.emplace_back(std::move(operand));
             continue;
         }
-        pullAndsImpl(static_cast<LogicalExpression *>(operand.get()), operands);
+        pullAndsImpl(static_cast<LogicalExpression *>(operand), operands);
     }
 }
 
 void ExpressionUtils::pullOrsImpl(LogicalExpression *expr,
-                                  std::vector<std::unique_ptr<Expression>> &operands) {
+                                  std::vector<Expression*> &operands) {
     for (auto &operand : expr->operands()) {
         if (operand->kind() != Expression::Kind::kLogicalOr) {
             operands.emplace_back(std::move(operand));
             continue;
         }
-        pullOrsImpl(static_cast<LogicalExpression *>(operand.get()), operands);
+        pullOrsImpl(static_cast<LogicalExpression *>(operand), operands);
     }
 }
 
-std::unique_ptr<Expression> ExpressionUtils::flattenInnerLogicalAndExpr(const Expression *expr) {
+Expression* ExpressionUtils::flattenInnerLogicalAndExpr(const Expression *expr) {
     auto matcher = [](const Expression *e) -> bool {
         return e->kind() == Expression::Kind::kLogicalAnd;
     };
     auto rewriter = [](const Expression *e) -> Expression * {
         pullAnds(const_cast<Expression *>(e));
-        return e->clone().release();
+        return e->clone();
     };
 
-    return std::unique_ptr<Expression>(
-        RewriteVisitor::transform(expr, std::move(matcher), std::move(rewriter)));
+    return RewriteVisitor::transform(expr, std::move(matcher), std::move(rewriter));
 }
 
-std::unique_ptr<Expression> ExpressionUtils::flattenInnerLogicalOrExpr(const Expression *expr) {
+Expression* ExpressionUtils::flattenInnerLogicalOrExpr(const Expression *expr) {
     auto matcher = [](const Expression *e) -> bool {
         return e->kind() == Expression::Kind::kLogicalOr;
     };
     auto rewriter = [](const Expression *e) -> Expression * {
         pullOrs(const_cast<Expression *>(e));
-        return e->clone().release();
+        return e->clone();
     };
 
-    return std::unique_ptr<Expression>(
-        RewriteVisitor::transform(expr, std::move(matcher), std::move(rewriter)));
+    return RewriteVisitor::transform(expr, std::move(matcher), std::move(rewriter));
 }
 
-std::unique_ptr<Expression> ExpressionUtils::flattenInnerLogicalExpr(const Expression *expr) {
+Expression* ExpressionUtils::flattenInnerLogicalExpr(const Expression *expr) {
     auto andFlattenExpr = flattenInnerLogicalAndExpr(expr);
-    auto allFlattenExpr = flattenInnerLogicalOrExpr(andFlattenExpr.get());
+    auto allFlattenExpr = flattenInnerLogicalOrExpr(andFlattenExpr);
 
     return allFlattenExpr;
 }
 
 // pick the subparts of expression that meet picker's criteria
-void ExpressionUtils::splitFilter(const Expression *expr,
+void ExpressionUtils::splitFilter(ObjectPool* pool, const Expression *expr,
                                   std::function<bool(const Expression *)> picker,
-                                  std::unique_ptr<Expression> *filterPicked,
-                                  std::unique_ptr<Expression> *filterUnpicked) {
+                                  Expression** filterPicked,
+                                  Expression** filterUnpicked) {
     // Pick the non-LogicalAndExpr directly
     if (expr->kind() != Expression::Kind::kLogicalAnd) {
         if (picker(expr)) {
-            filterPicked->reset(expr->clone().release());
+            *filterPicked = expr->clone();
         } else {
-            filterUnpicked->reset(expr->clone().release());
+            *filterUnpicked = expr->clone();
         }
         return;
     }
 
     auto flattenExpr = ExpressionUtils::flattenInnerLogicalExpr(expr);
     DCHECK(flattenExpr->kind() == Expression::Kind::kLogicalAnd);
-    auto *logicExpr = static_cast<LogicalExpression *>(flattenExpr.get());
-    auto filterPickedPtr = std::make_unique<LogicalExpression>(Expression::Kind::kLogicalAnd);
-    auto filterUnpickedPtr = std::make_unique<LogicalExpression>(Expression::Kind::kLogicalAnd);
+    auto *logicExpr = static_cast<LogicalExpression *>(flattenExpr);
+    auto filterPickedPtr = LogicalExpression::makeAnd(pool);
+    auto filterUnpickedPtr = LogicalExpression::makeAnd(pool);
 
-    std::vector<std::unique_ptr<Expression>> &operands = logicExpr->operands();
+    std::vector<Expression*> &operands = logicExpr->operands();
     for (auto iter = operands.begin(); iter != operands.end(); ++iter) {
-        if (picker((*iter).get())) {
-            filterPickedPtr->addOperand((*iter)->clone().release());
+        if (picker((*iter))) {
+            filterPickedPtr->addOperand((*iter)->clone());
         } else {
-            filterUnpickedPtr->addOperand((*iter)->clone().release());
+            filterUnpickedPtr->addOperand((*iter)->clone());
         }
     }
     auto foldLogicalExpr = [](const LogicalExpression *e) -> Expression * {
         const auto &ops = e->operands();
         auto size = ops.size();
         if (size > 1) {
-            return e->clone().release();
+            return e->clone();
         } else if (size == 1) {
-            return ops[0]->clone().release();
+            return ops[0]->clone();
         } else {
             return nullptr;
         }
     };
-    filterPicked->reset(foldLogicalExpr(filterPickedPtr.get()));
-    filterUnpicked->reset(foldLogicalExpr(filterUnpickedPtr.get()));
+    *filterPicked = foldLogicalExpr(filterPickedPtr);
+    *filterUnpicked = foldLogicalExpr(filterUnpickedPtr);
 }
 
-VariablePropertyExpression *ExpressionUtils::newVarPropExpr(const std::string &prop,
-                                                            const std::string &var) {
-    return new VariablePropertyExpression(var, prop);
+Expression *ExpressionUtils::pushOrs(ObjectPool *pool, const std::vector<Expression *> &rels) {
+    return pushImpl(pool, Expression::Kind::kLogicalOr, rels);
 }
 
-std::unique_ptr<InputPropertyExpression> ExpressionUtils::inputPropExpr(const std::string &prop) {
-    return std::make_unique<InputPropertyExpression>(prop);
+Expression *ExpressionUtils::pushAnds(ObjectPool *pool, const std::vector<Expression *> &rels) {
+    return pushImpl(pool, Expression::Kind::kLogicalAnd, rels);
 }
 
-std::unique_ptr<Expression> ExpressionUtils::pushOrs(
-    const std::vector<std::unique_ptr<Expression>> &rels) {
-    return pushImpl(Expression::Kind::kLogicalOr, rels);
-}
-
-std::unique_ptr<Expression> ExpressionUtils::pushAnds(
-    const std::vector<std::unique_ptr<Expression>> &rels) {
-    return pushImpl(Expression::Kind::kLogicalAnd, rels);
-}
-
-std::unique_ptr<Expression> ExpressionUtils::pushImpl(
-    Expression::Kind kind,
-    const std::vector<std::unique_ptr<Expression>> &rels) {
+Expression *ExpressionUtils::pushImpl(ObjectPool *pool,
+                                      Expression::Kind kind,
+                                      const std::vector<Expression *> &rels) {
     DCHECK_GT(rels.size(), 1);
     DCHECK(kind == Expression::Kind::kLogicalOr || kind == Expression::Kind::kLogicalAnd);
-    auto root = std::make_unique<LogicalExpression>(kind);
-    root->addOperand(rels[0]->clone().release());
-    root->addOperand(rels[1]->clone().release());
+    auto root = LogicalExpression::makeKind(pool, kind);
+    root->addOperand(rels[0]->clone());
+    root->addOperand(rels[1]->clone());
     for (size_t i = 2; i < rels.size(); i++) {
-        auto l = std::make_unique<LogicalExpression>(kind);
-        l->addOperand(root->clone().release());
-        l->addOperand(rels[i]->clone().release());
+        auto l = LogicalExpression::makeKind(pool, kind);
+        l->addOperand(root->clone());
+        l->addOperand(rels[i]->clone());
         root = std::move(l);
     }
     return root;
 }
 
-std::unique_ptr<Expression> ExpressionUtils::expandExpr(const Expression *expr) {
+Expression *ExpressionUtils::expandExpr(ObjectPool *pool, const Expression *expr) {
     auto kind = expr->kind();
-    std::vector<std::unique_ptr<Expression>> target;
+    std::vector<Expression*> target;
     switch (kind) {
         case Expression::Kind::kLogicalOr: {
             const auto *logic = static_cast<const LogicalExpression *>(expr);
             for (const auto &e : logic->operands()) {
                 if (e->kind() == Expression::Kind::kLogicalAnd) {
-                    target.emplace_back(expandImplAnd(e.get()));
+                    target.emplace_back(expandImplAnd(pool, e));
                 } else {
-                    target.emplace_back(expandExpr(e.get()));
+                    target.emplace_back(expandExpr(pool, e));
                 }
             }
             break;
         }
         case Expression::Kind::kLogicalAnd: {
-            target.emplace_back(expandImplAnd(expr));
+            target.emplace_back(expandImplAnd(pool, expr));
             break;
         }
         default: { return expr->clone(); }
@@ -523,51 +519,51 @@ std::unique_ptr<Expression> ExpressionUtils::expandExpr(const Expression *expr) 
     DCHECK_GT(target.size(), 0);
     if (target.size() == 1) {
         if (target[0]->kind() == Expression::Kind::kLogicalAnd) {
-            const auto *logic = static_cast<const LogicalExpression *>(target[0].get());
+            const auto *logic = static_cast<const LogicalExpression *>(target[0]);
             const auto &ops = logic->operands();
             DCHECK_EQ(ops.size(), 2);
             if (ops[0]->kind() == Expression::Kind::kLogicalOr ||
                 ops[1]->kind() == Expression::Kind::kLogicalOr) {
-                return expandExpr(target[0].get());
+                return expandExpr(pool, target[0]);
             }
         }
         return std::move(target[0]);
     }
-    return pushImpl(kind, target);
+    return pushImpl(pool, kind, target);
 }
 
-std::unique_ptr<Expression> ExpressionUtils::expandImplAnd(const Expression *expr) {
+Expression* ExpressionUtils::expandImplAnd(ObjectPool* pool, const Expression *expr) {
     DCHECK(expr->kind() == Expression::Kind::kLogicalAnd);
     const auto *logic = static_cast<const LogicalExpression *>(expr);
     DCHECK_EQ(logic->operands().size(), 2);
-    std::vector<std::unique_ptr<Expression>> subL;
+    std::vector<Expression*> subL;
     auto &ops = logic->operands();
     if (ops[0]->kind() == Expression::Kind::kLogicalOr) {
-        auto target = expandImplOr(ops[0].get());
+        auto target = expandImplOr(ops[0]);
         for (const auto &e : target) {
-            subL.emplace_back(e->clone().release());
+            subL.emplace_back(e->clone());
         }
     } else {
-        subL.emplace_back(expandExpr(std::move(ops[0]).get()));
+        subL.emplace_back(expandExpr(pool, std::move(ops[0])));
     }
-    std::vector<std::unique_ptr<Expression>> subR;
+    std::vector<Expression*> subR;
     if (ops[1]->kind() == Expression::Kind::kLogicalOr) {
-        auto target = expandImplOr(ops[1].get());
+        auto target = expandImplOr(ops[1]);
         for (const auto &e : target) {
-            subR.emplace_back(e->clone().release());
+            subR.emplace_back(e->clone());
         }
     } else {
-        subR.emplace_back(expandExpr(std::move(ops[1]).get()));
+        subR.emplace_back(expandExpr(pool, std::move(ops[1])));
     }
 
     DCHECK_GT(subL.size(), 0);
     DCHECK_GT(subR.size(), 0);
-    std::vector<std::unique_ptr<Expression>> target;
+    std::vector<Expression*> target;
     for (auto &le : subL) {
         for (auto &re : subR) {
-            auto l = std::make_unique<LogicalExpression>(Expression::Kind::kLogicalAnd);
-            l->addOperand(le->clone().release());
-            l->addOperand(re->clone().release());
+            auto l = LogicalExpression::makeAnd(pool);
+            l->addOperand(le->clone());
+            l->addOperand(re->clone());
             target.emplace_back(std::move(l));
         }
     }
@@ -575,22 +571,22 @@ std::unique_ptr<Expression> ExpressionUtils::expandImplAnd(const Expression *exp
     if (target.size() == 1) {
         return std::move(target[0]);
     }
-    return pushImpl(Expression::Kind::kLogicalOr, target);
+    return pushImpl(pool, Expression::Kind::kLogicalOr, target);
 }
 
-std::vector<std::unique_ptr<Expression>> ExpressionUtils::expandImplOr(const Expression *expr) {
+std::vector<Expression*> ExpressionUtils::expandImplOr(const Expression *expr) {
     DCHECK(expr->kind() == Expression::Kind::kLogicalOr);
     const auto *logic = static_cast<const LogicalExpression *>(expr);
-    std::vector<std::unique_ptr<Expression>> exprs;
+    std::vector<Expression*> exprs;
     auto &ops = logic->operands();
     for (const auto &op : ops) {
         if (op->kind() == Expression::Kind::kLogicalOr) {
-            auto target = expandImplOr(op.get());
+            auto target = expandImplOr(op);
             for (const auto &e : target) {
-                exprs.emplace_back(e->clone().release());
+                exprs.emplace_back(e->clone());
             }
         } else {
-            exprs.emplace_back(op->clone().release());
+            exprs.emplace_back(op->clone());
         }
     }
     return exprs;
@@ -643,13 +639,13 @@ bool ExpressionUtils::findInnerRandFunction(const Expression *expr) {
 }
 
 // Negate the given relational expr
-std::unique_ptr<RelationalExpression> ExpressionUtils::reverseRelExpr(RelationalExpression *expr) {
+RelationalExpression *ExpressionUtils::reverseRelExpr(ObjectPool *pool,
+                                                      RelationalExpression *expr) {
     auto left = static_cast<RelationalExpression *>(expr)->left();
     auto right = static_cast<RelationalExpression *>(expr)->right();
     auto negatedKind = getNegatedRelExprKind(expr->kind());
 
-    return std::make_unique<RelationalExpression>(
-        negatedKind, left->clone().release(), right->clone().release());
+    return RelationalExpression::makeKind(pool, negatedKind, left->clone(), right->clone());
 }
 
 // Return the negation of the given relational kind
@@ -708,8 +704,8 @@ Expression::Kind ExpressionUtils::getNegatedArithmeticType(const Expression::Kin
     }
 }
 
-std::unique_ptr<LogicalExpression> ExpressionUtils::reverseLogicalExpr(LogicalExpression *expr) {
-    std::vector<std::unique_ptr<Expression>> operands;
+LogicalExpression*ExpressionUtils::reverseLogicalExpr(ObjectPool* pool, LogicalExpression *expr) {
+    std::vector<Expression *> operands;
     if (expr->kind() == Expression::Kind::kLogicalAnd) {
         pullAnds(expr);
     } else {
@@ -718,12 +714,11 @@ std::unique_ptr<LogicalExpression> ExpressionUtils::reverseLogicalExpr(LogicalEx
 
     auto &flattenOperands = static_cast<LogicalExpression *>(expr)->operands();
     auto negatedKind = getNegatedLogicalExprKind(expr->kind());
-    auto logic = std::make_unique<LogicalExpression>(negatedKind);
+    auto logic = LogicalExpression::makeKind(pool, negatedKind);
 
     // negate each item in the operands list
     for (auto &operand : flattenOperands) {
-        auto tempExpr =
-            std::make_unique<UnaryExpression>(Expression::Kind::kUnaryNot, operand.release());
+        auto tempExpr = UnaryExpression::makeNot(pool, operand);
         operands.emplace_back(std::move(tempExpr));
     }
     logic->setOperands(std::move(operands));
@@ -746,37 +741,37 @@ Expression::Kind ExpressionUtils::getNegatedLogicalExprKind(const Expression::Ki
 }
 
 // ++loopStep <= steps
-std::unique_ptr<Expression> ExpressionUtils::stepCondition(const std::string &loopStep,
-                                                           uint32_t steps) {
-    return std::make_unique<RelationalExpression>(
-        Expression::Kind::kRelLE,
-        new UnaryExpression(Expression::Kind::kUnaryIncr, new VariableExpression(loopStep)),
-        new ConstantExpression(static_cast<int32_t>(steps)));
+Expression *ExpressionUtils::stepCondition(ObjectPool *pool,
+                                           const std::string &loopStep,
+                                           uint32_t steps) {
+    return RelationalExpression::makeLE(
+        pool,
+        UnaryExpression::makeIncr(pool, VariableExpression::make(pool, loopStep)),
+        ConstantExpression::make(pool, static_cast<int32_t>(steps)));
 }
 
 // size(var) != 0
-std::unique_ptr<Expression> ExpressionUtils::neZeroCondition(const std::string &var) {
-    auto *args = new ArgumentList();
-    args->addArgument(std::make_unique<VariableExpression>(var));
-    return std::make_unique<RelationalExpression>(Expression::Kind::kRelNE,
-                                                  new FunctionCallExpression("size", args),
-                                                  new ConstantExpression(0));
+Expression *ExpressionUtils::neZeroCondition(ObjectPool *pool, const std::string &var) {
+    auto *args = ArgumentList::make(pool);
+    args->addArgument(VariableExpression::make(pool, var));
+    return RelationalExpression::makeNE(
+        pool, FunctionCallExpression::make(pool, "size", args), ConstantExpression::make(pool, 0));
 }
 
 // size(var) == 0
-std::unique_ptr<Expression> ExpressionUtils::zeroCondition(const std::string &var) {
-    auto *args = new ArgumentList();
-    args->addArgument(std::make_unique<VariableExpression>(var));
-    return std::make_unique<RelationalExpression>(Expression::Kind::kRelEQ,
-                                                  new FunctionCallExpression("size", args),
-                                                  new ConstantExpression(0));
+Expression *ExpressionUtils::zeroCondition(ObjectPool *pool, const std::string &var) {
+    auto *args = ArgumentList::make(pool);
+    args->addArgument(VariableExpression::make(pool, var));
+    return RelationalExpression::makeEQ(
+        pool, FunctionCallExpression::make(pool, "size", args), ConstantExpression::make(pool, 0));
 }
 
 // var == value
-std::unique_ptr<Expression> ExpressionUtils::equalCondition(const std::string &var,
-                                                            const Value &value) {
-    return std::make_unique<RelationalExpression>(
-        Expression::Kind::kRelEQ, new VariableExpression(var), new ConstantExpression(value));
+Expression *ExpressionUtils::equalCondition(ObjectPool *pool,
+                                            const std::string &var,
+                                            const Value &value) {
+    return RelationalExpression::makeEQ(
+        pool, VariableExpression::make(pool, var), ConstantExpression::make(pool, value));
 }
 
 }   // namespace graph

--- a/src/util/ExpressionUtils.cpp
+++ b/src/util/ExpressionUtils.cpp
@@ -113,7 +113,7 @@ Expression *ExpressionUtils::rewriteLabelAttr2EdgeProp(ObjectPool *pool, const E
     auto matcher = [](const Expression *e) -> bool {
         return e->kind() == Expression::Kind::kLabelAttribute;
     };
-    auto rewriter = [&](const Expression *e) -> Expression * {
+    auto rewriter = [&pool](const Expression *e) -> Expression * {
         DCHECK_EQ(e->kind(), Expression::Kind::kLabelAttribute);
         auto labelAttrExpr = static_cast<const LabelAttributeExpression *>(e);
         auto leftName = labelAttrExpr->left()->name();
@@ -146,7 +146,7 @@ Expression *ExpressionUtils::rewriteLabelAttr2TagProp(ObjectPool* pool, const Ex
     auto matcher = [](const Expression *e) -> bool {
         return e->kind() == Expression::Kind::kLabelAttribute;
     };
-    auto rewriter = [&](const Expression *e) -> Expression * {
+    auto rewriter = [&pool](const Expression *e) -> Expression * {
         DCHECK_EQ(e->kind(), Expression::Kind::kLabelAttribute);
         auto labelAttrExpr = static_cast<const LabelAttributeExpression *>(e);
         auto leftName = labelAttrExpr->left()->name();
@@ -162,7 +162,7 @@ Expression *ExpressionUtils::rewriteAgg2VarProp(ObjectPool *pool, const Expressi
     auto matcher = [](const Expression *e) -> bool {
         return e->kind() == Expression::Kind::kAggregate;
     };
-    auto rewriter = [&](const Expression *e) -> Expression * {
+    auto rewriter = [&pool](const Expression *e) -> Expression * {
         return VariablePropertyExpression::make(pool, "", e->toString());
     };
 
@@ -196,7 +196,7 @@ Expression *ExpressionUtils::reduceUnaryNotExpr(const Expression *expr, ObjectPo
     };
 
     // Match the root expression
-    auto rootMatcher = [&](const Expression *e) -> bool {
+    auto rootMatcher = [&operandMatcher](const Expression *e) -> bool {
         if (e->kind() == Expression::Kind::kUnaryNot) {
             auto operand = static_cast<const UnaryExpression *>(e)->operand();
             return (operandMatcher(operand));
@@ -230,7 +230,7 @@ Expression *ExpressionUtils::reduceUnaryNotExpr(const Expression *expr, ObjectPo
 
 Expression *ExpressionUtils::rewriteRelExpr(const Expression *expr, ObjectPool *pool) {
     // Match relational expressions containing at least one airthmetic expr
-    auto matcher = [&](const Expression *e) -> bool {
+    auto matcher = [](const Expression *e) -> bool {
         if (e->isRelExpr()) {
             auto relExpr = static_cast<const RelationalExpression *>(e);
             if (isEvaluableExpr(relExpr->right())) {
@@ -247,8 +247,9 @@ Expression *ExpressionUtils::rewriteRelExpr(const Expression *expr, ObjectPool *
     };
 
     // Simplify relational expressions involving boolean literals
-    auto simplifyBoolOperand =
-        [&](RelationalExpression *relExpr, Expression *lExpr, Expression *rExpr) -> Expression * {
+    auto simplifyBoolOperand = [&pool](RelationalExpression *relExpr,
+                                       Expression *lExpr,
+                                       Expression *rExpr) -> Expression * {
         QueryExpressionContext ctx(nullptr);
         if (rExpr->kind() == Expression::Kind::kConstant) {
             auto conExpr = static_cast<ConstantExpression *>(rExpr);

--- a/src/util/ExpressionUtils.h
+++ b/src/util/ExpressionUtils.h
@@ -56,22 +56,24 @@ public:
 
     static bool isEvaluableExpr(const Expression* expr);
 
-    static Expression* rewriteLabelAttr2TagProp(const Expression* expr);
+    static Expression* rewriteLabelAttr2TagProp(ObjectPool* pool, const Expression* expr);
 
-    static Expression* rewriteLabelAttr2EdgeProp(const Expression* expr);
+    static Expression* rewriteLabelAttr2EdgeProp(ObjectPool* pool, const Expression* expr);
 
-    static Expression* rewriteAgg2VarProp(const Expression* expr);
+    static Expression* rewriteAgg2VarProp(ObjectPool* pool, const Expression* expr);
 
-    static std::unique_ptr<Expression> rewriteInnerVar(const Expression* expr,
-                                                       std::string newVar);
+    static Expression* rewriteInnerVar(ObjectPool* pool,
+                                       const Expression* expr,
+                                       std::string newVar);
 
     // Rewrite relational expression, gather evaluable expressions to one side
     static Expression* rewriteRelExpr(const Expression* expr, ObjectPool* pool);
-    static Expression* rewriteRelExprHelper(const Expression* expr,
-                                            std::unique_ptr<Expression>& relRightOperandExpr);
+    static Expression* rewriteRelExprHelper(ObjectPool* pool,
+                                            const Expression* expr,
+                                            Expression* relRightOperandExpr);
 
     // Clone and fold constant expression
-    static StatusOr<Expression*> foldConstantExpr(const Expression* expr, ObjectPool* objPool);
+    static StatusOr<Expression*> foldConstantExpr(ObjectPool* objPool, const Expression* expr);
 
     // Clone and reduce unaryNot expression
     static Expression* reduceUnaryNotExpr(const Expression* expr, ObjectPool* pool);
@@ -80,10 +82,10 @@ public:
     static StatusOr<Expression*> filterTransform(const Expression* expr, ObjectPool* objPool);
 
     // Negate the given logical expr: (A && B) -> (!A || !B)
-    static std::unique_ptr<LogicalExpression> reverseLogicalExpr(LogicalExpression* expr);
+    static LogicalExpression* reverseLogicalExpr(ObjectPool* pool, LogicalExpression* expr);
 
     // Negate the given relational expr: (A > B) -> (A <= B)
-    static std::unique_ptr<RelationalExpression> reverseRelExpr(RelationalExpression* expr);
+    static RelationalExpression* reverseRelExpr(ObjectPool* pool, RelationalExpression* expr);
 
     // Return the negation of the given relational kind
     static Expression::Kind getNegatedRelExprKind(const Expression::Kind kind);
@@ -97,72 +99,54 @@ public:
     static void pullAnds(Expression* expr);
 
     static void pullAndsImpl(LogicalExpression* expr,
-                             std::vector<std::unique_ptr<Expression>>& operands);
+                             std::vector<Expression*>& operands);
 
     static void pullOrs(Expression* expr);
     static void pullOrsImpl(LogicalExpression* expr,
-                            std::vector<std::unique_ptr<Expression>>& operands);
+                            std::vector<Expression*>& operands);
 
-    static VariablePropertyExpression* newVarPropExpr(const std::string& prop,
-                                                      const std::string& var = "");
+    static Expression* pushOrs(ObjectPool* pool, const std::vector<Expression*>& rels);
 
-    static std::unique_ptr<InputPropertyExpression> inputPropExpr(const std::string& prop);
+    static Expression* pushAnds(ObjectPool* pool, const std::vector<Expression*>& rels);
 
-    static std::unique_ptr<Expression> pushOrs(
-        const std::vector<std::unique_ptr<Expression>>& rels);
+    static Expression* pushImpl(ObjectPool* pool,
+                                Expression::Kind kind,
+                                const std::vector<Expression*>& rels);
 
-    static std::unique_ptr<Expression> pushAnds(
-        const std::vector<std::unique_ptr<Expression>>& rels);
+    static Expression* flattenInnerLogicalAndExpr(const Expression* expr);
 
-    static std::unique_ptr<Expression> pushImpl(
-        Expression::Kind kind,
-        const std::vector<std::unique_ptr<Expression>>& rels);
+    static Expression* flattenInnerLogicalOrExpr(const Expression* expr);
 
-    static std::unique_ptr<Expression> flattenInnerLogicalAndExpr(const Expression* expr);
+    static Expression* flattenInnerLogicalExpr(const Expression* expr);
 
-    static std::unique_ptr<Expression> flattenInnerLogicalOrExpr(const Expression* expr);
-
-    static std::unique_ptr<Expression> flattenInnerLogicalExpr(const Expression* expr);
-
-    static void splitFilter(const Expression* expr,
+    static void splitFilter(ObjectPool* pool,
+                            const Expression* expr,
                             std::function<bool(const Expression*)> picker,
-                            std::unique_ptr<Expression>* filterPicked,
-                            std::unique_ptr<Expression>* filterUnpicked);
+                            Expression** filterPicked,
+                            Expression** filterUnpicked);
 
-    static std::unique_ptr<Expression> expandExpr(const Expression* expr);
+    static Expression* expandExpr(ObjectPool* pool, const Expression* expr);
 
-    static std::unique_ptr<Expression> expandImplAnd(const Expression* expr);
+    static Expression* expandImplAnd(ObjectPool* pool, const Expression* expr);
 
-    static std::vector<std::unique_ptr<Expression>> expandImplOr(const Expression* expr);
+    static std::vector<Expression*> expandImplOr(const Expression* expr);
 
     static Status checkAggExpr(const AggregateExpression* aggExpr);
 
     static bool findInnerRandFunction(const Expression *expr);
 
-    static Expression* And(Expression *l, Expression* r) {
-        return new LogicalExpression(Expression::Kind::kLogicalAnd, l, r);
-    }
-
-    static Expression* Or(Expression* l, Expression *r) {
-        return new LogicalExpression(Expression::Kind::kLogicalOr, l, r);
-    }
-
-    static Expression* Eq(Expression* l, Expression *r) {
-        return new RelationalExpression(Expression::Kind::kRelEQ, l, r);
-    }
-
     // loop condition
     // ++loopSteps <= steps
-    static std::unique_ptr<Expression> stepCondition(const std::string& loopStep, uint32_t steps);
+    static Expression* stepCondition(ObjectPool* pool, const std::string& loopStep, uint32_t steps);
 
     // size(var) == 0
-    static std::unique_ptr<Expression> zeroCondition(const std::string& var);
+    static Expression* zeroCondition(ObjectPool* pool, const std::string& var);
 
     // size(var) != 0
-    static std::unique_ptr<Expression> neZeroCondition(const std::string& var);
+    static Expression* neZeroCondition(ObjectPool* pool, const std::string& var);
 
     // var == value
-    static std::unique_ptr<Expression> equalCondition(const std::string& var, const Value& value);
+    static Expression* equalCondition(ObjectPool* pool, const std::string& var, const Value& value);
 };
 
 }   // namespace graph

--- a/src/util/ExpressionUtils.h
+++ b/src/util/ExpressionUtils.h
@@ -70,7 +70,7 @@ public:
     static Expression* rewriteRelExpr(const Expression* expr, ObjectPool* pool);
     static Expression* rewriteRelExprHelper(ObjectPool* pool,
                                             const Expression* expr,
-                                            Expression* relRightOperandExpr);
+                                            Expression*& relRightOperandExpr);
 
     // Clone and fold constant expression
     static StatusOr<Expression*> foldConstantExpr(ObjectPool* objPool, const Expression* expr);

--- a/src/util/FTIndexUtils.cpp
+++ b/src/util/FTIndexUtils.cpp
@@ -94,7 +94,7 @@ StatusOr<std::string> FTIndexUtils::rewriteTSFilter(
     auto tsExpr = static_cast<TextSearchExpression*>(expr);
     std::vector<Expression*> rels;
     for (const auto& row : vRet.value()) {
-        RelationalExpression* relExpr;
+        RelationalExpression* relExpr = nullptr;
         if (isEdge) {
             relExpr = RelationalExpression::makeEQ(
                 pool,

--- a/src/util/FTIndexUtils.cpp
+++ b/src/util/FTIndexUtils.cpp
@@ -76,8 +76,12 @@ FTIndexUtils::dropTSIndex(const std::vector<nebula::plugin::HttpClient>& tsClien
     return Status::Error("drop fulltext index failed : %s", index.c_str());
 }
 
-StatusOr<std::string> FTIndexUtils::rewriteTSFilter(bool isEdge, Expression* expr,
-const std::string& index, const std::vector<nebula::plugin::HttpClient>& tsClients) {
+StatusOr<std::string> FTIndexUtils::rewriteTSFilter(
+    ObjectPool* pool,
+    bool isEdge,
+    Expression* expr,
+    const std::string& index,
+    const std::vector<nebula::plugin::HttpClient>& tsClients) {
     auto vRet = textSearch(expr, index, tsClients);
     if (!vRet.ok()) {
         return Status::SemanticError("Text search error.");
@@ -88,26 +92,26 @@ const std::string& index, const std::vector<nebula::plugin::HttpClient>& tsClien
 
     std::vector<std::string> values;
     auto tsExpr = static_cast<TextSearchExpression*>(expr);
-    std::vector<std::unique_ptr<Expression>> rels;
+    std::vector<Expression*> rels;
     for (const auto& row : vRet.value()) {
-        std::unique_ptr<RelationalExpression> r;
+        RelationalExpression* relExpr;
         if (isEdge) {
-            r = std::make_unique<RelationalExpression>(
-                Expression::Kind::kRelEQ,
-                new EdgePropertyExpression(tsExpr->arg()->from(), tsExpr->arg()->prop()),
-                new ConstantExpression(Value(row)));
+            relExpr = RelationalExpression::makeEQ(
+                pool,
+                EdgePropertyExpression::make(pool, tsExpr->arg()->from(), tsExpr->arg()->prop()),
+                ConstantExpression::make(pool, Value(row)));
         } else {
-            r = std::make_unique<RelationalExpression>(
-                Expression::Kind::kRelEQ,
-                new TagPropertyExpression(tsExpr->arg()->from(), tsExpr->arg()->prop()),
-                new ConstantExpression(Value(row)));
+            relExpr = RelationalExpression::makeEQ(
+                pool,
+                TagPropertyExpression::make(pool, tsExpr->arg()->from(), tsExpr->arg()->prop()),
+                ConstantExpression::make(pool, Value(row)));
         }
-        rels.emplace_back(std::move(r));
+        rels.emplace_back(std::move(relExpr));
     }
     if (rels.size() == 1) {
         return rels[0]->encode();
     }
-    auto newExpr = ExpressionUtils::pushOrs(rels);
+    auto newExpr = ExpressionUtils::pushOrs(pool, rels);
     return newExpr->encode();
 }
 

--- a/src/util/FTIndexUtils.h
+++ b/src/util/FTIndexUtils.h
@@ -38,7 +38,7 @@ public:
                 const std::string& index);
 
     static
-    StatusOr<std::string> rewriteTSFilter(bool isEdge, Expression* expr,
+    StatusOr<std::string> rewriteTSFilter(ObjectPool* pool, bool isEdge, Expression* expr,
         const std::string& index, const std::vector<nebula::plugin::HttpClient>& tsClients);
 
     static

--- a/src/util/ParserUtil.cpp
+++ b/src/util/ParserUtil.cpp
@@ -30,7 +30,7 @@ void ParserUtil::rewriteLC(QueryContext *qctx,
                expr->kind() == Expression::Kind::kLabelAttribute;
     };
 
-    auto rewriter = [&](const Expression *expr) {
+    auto rewriter = [&, pool, newVarName](const Expression *expr) {
         Expression *ret = nullptr;
         if (expr->kind() == Expression::Kind::kLabel) {
             auto *label = static_cast<const LabelExpression *>(expr);

--- a/src/util/ParserUtil.cpp
+++ b/src/util/ParserUtil.cpp
@@ -23,29 +23,32 @@ void ParserUtil::rewriteLC(QueryContext *qctx,
                            const std::string &oldVarName) {
     const auto &newVarName = qctx->vctx()->anonVarGen()->getVar();
     qctx->ectx()->setValue(newVarName, Value());
+    auto *pool = qctx->objPool();
 
     auto matcher = [](const Expression *expr) -> bool {
         return expr->kind() == Expression::Kind::kLabel ||
                expr->kind() == Expression::Kind::kLabelAttribute;
     };
-    auto rewriter = [&oldVarName, &newVarName](const Expression *expr) {
+
+    auto rewriter = [&](const Expression *expr) {
         Expression *ret = nullptr;
         if (expr->kind() == Expression::Kind::kLabel) {
             auto *label = static_cast<const LabelExpression *>(expr);
             if (label->name() == oldVarName) {
-                ret = new VariableExpression(newVarName, true);
+                ret = VariableExpression::make(pool, newVarName, true);
             } else {
-                ret = label->clone().release();
+                ret = label->clone();
             }
         } else {
             DCHECK(expr->kind() == Expression::Kind::kLabelAttribute);
             auto *la = static_cast<const LabelAttributeExpression *>(expr);
             if (la->left()->name() == oldVarName) {
                 const auto &value = la->right()->value();
-                ret = new AttributeExpression(new VariableExpression(newVarName, true),
-                                              new ConstantExpression(value));
+                ret = AttributeExpression::make(pool,
+                                                VariableExpression::make(pool, newVarName, true),
+                                                ConstantExpression::make(pool, value));
             } else {
-                ret = la->clone().release();
+                ret = la->clone();
             }
         }
         return ret;
@@ -72,29 +75,32 @@ void ParserUtil::rewritePred(QueryContext *qctx,
                              const std::string &oldVarName) {
     const auto &newVarName = qctx->vctx()->anonVarGen()->getVar();
     qctx->ectx()->setValue(newVarName, Value());
+    auto *pool = qctx->objPool();
 
     auto matcher = [](const Expression *expr) -> bool {
         return expr->kind() == Expression::Kind::kLabel ||
                expr->kind() == Expression::Kind::kLabelAttribute;
     };
-    auto rewriter = [&oldVarName, &newVarName](const Expression *expr) {
+
+    auto rewriter = [&](const Expression *expr) {
         Expression *ret = nullptr;
         if (expr->kind() == Expression::Kind::kLabel) {
             auto *label = static_cast<const LabelExpression *>(expr);
             if (label->name() == oldVarName) {
-                ret = new VariableExpression(newVarName, true);
+                ret = VariableExpression::make(pool, newVarName, true);
             } else {
-                ret = label->clone().release();
+                ret = label->clone();
             }
         } else {
             DCHECK(expr->kind() == Expression::Kind::kLabelAttribute);
             auto *la = static_cast<const LabelAttributeExpression *>(expr);
             if (la->left()->name() == oldVarName) {
                 const auto &value = la->right()->value();
-                ret = new AttributeExpression(new VariableExpression(newVarName, true),
-                                              new ConstantExpression(value));
+                ret = AttributeExpression::make(pool,
+                                                VariableExpression::make(pool, newVarName, true),
+                                                ConstantExpression::make(pool, value));
             } else {
-                ret = la->clone().release();
+                ret = la->clone();
             }
         }
         return ret;
@@ -117,35 +123,38 @@ void ParserUtil::rewriteReduce(QueryContext *qctx,
     qctx->ectx()->setValue(newAccName, Value());
     const auto &newVarName = qctx->vctx()->anonVarGen()->getVar();
     qctx->ectx()->setValue(newVarName, Value());
+    auto *pool = qctx->objPool();
 
     auto matcher = [](const Expression *expr) -> bool {
         return expr->kind() == Expression::Kind::kLabel ||
                expr->kind() == Expression::Kind::kLabelAttribute;
     };
-    auto rewriter = [oldAccName, newAccName, oldVarName, newVarName](const Expression *expr) {
+    auto rewriter = [&](const Expression *expr) {
         Expression *ret = nullptr;
         if (expr->kind() == Expression::Kind::kLabel) {
             auto *label = static_cast<const LabelExpression *>(expr);
             if (label->name() == oldAccName) {
-                ret = new VariableExpression(newAccName, true);
+                ret = VariableExpression::make(pool, newAccName, true);
             } else if (label->name() == oldVarName) {
-                ret = new VariableExpression(newVarName, true);
+                ret = VariableExpression::make(pool, newVarName, true);
             } else {
-                ret = label->clone().release();
+                ret = label->clone();
             }
         } else {
             DCHECK(expr->kind() == Expression::Kind::kLabelAttribute);
             auto *la = static_cast<const LabelAttributeExpression *>(expr);
             if (la->left()->name() == oldAccName) {
                 const auto &value = la->right()->value();
-                ret = new AttributeExpression(new VariableExpression(newAccName, true),
-                                              new ConstantExpression(value));
+                ret = AttributeExpression::make(pool,
+                                                VariableExpression::make(pool, newAccName, true),
+                                                ConstantExpression::make(pool, value));
             } else if (la->left()->name() == oldVarName) {
                 const auto &value = la->right()->value();
-                ret = new AttributeExpression(new VariableExpression(newVarName, true),
-                                              new ConstantExpression(value));
+                ret = AttributeExpression::make(pool,
+                                                VariableExpression::make(pool, newVarName, true),
+                                                ConstantExpression::make(pool, value));
             } else {
-                ret = la->clone().release();
+                ret = la->clone();
             }
         }
         return ret;

--- a/src/util/QueryUtil.cpp
+++ b/src/util/QueryUtil.cpp
@@ -42,7 +42,7 @@ SubPlan QueryUtil::buildRuntimeInput(QueryContext* qctx, Starts& starts) {
     if (starts.fromType == kVariable) {
         project->setInputVar(starts.userDefinedVarName);
     }
-    starts.src = pool->add(new InputPropertyExpression(kVid));
+    starts.src = InputPropertyExpression::make(pool, kVid);
 
     auto* dedup = Dedup::make(qctx, project);
 
@@ -65,8 +65,9 @@ SubPlan QueryUtil::buildStart(QueryContext* qctx, Starts& starts, std::string& v
 }
 
 PlanNode* QueryUtil::extractDstFromGN(QueryContext* qctx, PlanNode* gn, const std::string& output) {
-    auto* columns = qctx->objPool()->add(new YieldColumns());
-    auto* column = new YieldColumn(new EdgePropertyExpression("*", kDst), kVid);
+    auto pool = qctx->objPool();
+    auto* columns = pool->add(new YieldColumns());
+    auto* column = new YieldColumn(EdgePropertyExpression::make(pool, "*", kDst), kVid);
     columns->addColumn(column);
 
     auto* project = Project::make(qctx, gn, columns);

--- a/src/util/QueryUtil.cpp
+++ b/src/util/QueryUtil.cpp
@@ -26,17 +26,16 @@ void QueryUtil::buildConstantInput(QueryContext *qctx, Starts& starts, std::stri
         ds.rows.emplace_back(std::move(row));
     }
     qctx->ectx()->setResult(vidsVar, ResultBuilder().value(Value(std::move(ds))).finish());
-
+    auto* pool = qctx->objPool();
     // If possible, use column numbers in preference to column names,
-    starts.src = new ColumnExpression(0);
-    qctx->objPool()->add(starts.src);
+    starts.src = ColumnExpression::make(pool, 0);
 }
 
 // static
 SubPlan QueryUtil::buildRuntimeInput(QueryContext* qctx, Starts& starts) {
     auto pool = qctx->objPool();
     auto* columns = pool->add(new YieldColumns());
-    auto* column = new YieldColumn(starts.originalSrc->clone().release(), kVid);
+    auto* column = new YieldColumn(starts.originalSrc->clone(), kVid);
     columns->addColumn(column);
 
     auto* project = Project::make(qctx, nullptr, columns);

--- a/src/util/SchemaUtil.cpp
+++ b/src/util/SchemaUtil.cpp
@@ -55,20 +55,22 @@ Status SchemaUtil::validateProps(const std::vector<SchemaPropItem*> &schemaProps
 }
 
 // static
-std::shared_ptr<const meta::NebulaSchemaProvider>
-SchemaUtil::generateSchemaProvider(const SchemaVer ver, const meta::cpp2::Schema &schema) {
+std::shared_ptr<const meta::NebulaSchemaProvider> SchemaUtil::generateSchemaProvider(
+    ObjectPool *pool,
+    const SchemaVer ver,
+    const meta::cpp2::Schema &schema) {
     auto schemaPtr = std::make_shared<meta::NebulaSchemaProvider>(ver);
     for (auto col : schema.get_columns()) {
         bool hasDef = col.default_value_ref().has_value();
-        std::unique_ptr<Expression> defaultValueExpr;
+        Expression* defaultValueExpr;
         if (hasDef) {
-            defaultValueExpr = Expression::decode(*col.default_value_ref());
+            defaultValueExpr = Expression::decode(pool, *col.default_value_ref());
         }
         schemaPtr->addField(col.get_name(),
                             col.get_type().get_type(),
                             col.type.type_length_ref().value_or(0),
                             col.nullable_ref().value_or(false),
-                            hasDef ? defaultValueExpr.release() : nullptr);
+                            hasDef ? defaultValueExpr : nullptr);
     }
     return schemaPtr;
 }
@@ -160,8 +162,10 @@ StatusOr<DataSet> SchemaUtil::toDescSchema(const meta::cpp2::Schema &schema) {
         auto nullable = col.nullable_ref().has_value() ? *col.nullable_ref() : false;
         row.values.emplace_back(nullable ? "YES" : "NO");
         auto defaultValue = Value::kEmpty;
+        ObjectPool tempPool;
+
         if (col.default_value_ref().has_value()) {
-            auto expr = Expression::decode(*col.default_value_ref());
+            auto expr = Expression::decode(&tempPool, *col.default_value_ref());
             if (expr == nullptr) {
                 LOG(ERROR) << "Internal error: Wrong default value expression.";
                 defaultValue = Value();
@@ -169,7 +173,7 @@ StatusOr<DataSet> SchemaUtil::toDescSchema(const meta::cpp2::Schema &schema) {
             }
             if (expr->kind() == Expression::Kind::kConstant) {
                 QueryExpressionContext ctx;
-                defaultValue = Expression::eval(expr.get(), ctx(nullptr));
+                defaultValue = Expression::eval(expr, ctx(nullptr));
             } else {
                 defaultValue = Value(expr->toString());
             }
@@ -198,8 +202,10 @@ StatusOr<DataSet> SchemaUtil::toShowCreateSchema(bool isTag,
         dataSet.colNames = {"Edge", "Create Edge"};
         createStr = "CREATE EDGE `" + name + "` (\n";
     }
+
     Row row;
     row.emplace_back(name);
+    ObjectPool tempPool;
     for (auto &col : schema.get_columns()) {
         createStr += " `" + col.get_name() + "`";
         createStr += " " + typeToString(col);
@@ -212,7 +218,7 @@ StatusOr<DataSet> SchemaUtil::toShowCreateSchema(bool isTag,
 
         if (col.default_value_ref().has_value()) {
             auto encodeStr = *col.default_value_ref();
-            auto expr = Expression::decode(encodeStr);
+            auto expr = Expression::decode(&tempPool, encodeStr);
             if (expr == nullptr) {
                 LOG(ERROR) << "Internal error: the default value is wrong expression.";
                 continue;

--- a/src/util/SchemaUtil.cpp
+++ b/src/util/SchemaUtil.cpp
@@ -62,7 +62,7 @@ std::shared_ptr<const meta::NebulaSchemaProvider> SchemaUtil::generateSchemaProv
     auto schemaPtr = std::make_shared<meta::NebulaSchemaProvider>(ver);
     for (auto col : schema.get_columns()) {
         bool hasDef = col.default_value_ref().has_value();
-        Expression* defaultValueExpr;
+        Expression* defaultValueExpr = nullptr;
         if (hasDef) {
             defaultValueExpr = Expression::decode(pool, *col.default_value_ref());
         }

--- a/src/util/SchemaUtil.h
+++ b/src/util/SchemaUtil.h
@@ -31,7 +31,7 @@ public:
                                 meta::cpp2::Schema &schema);
 
     static std::shared_ptr<const meta::NebulaSchemaProvider>
-    generateSchemaProvider(const SchemaVer ver, const meta::cpp2::Schema &schema);
+    generateSchemaProvider(ObjectPool* pool, const SchemaVer ver, const meta::cpp2::Schema& schema);
 
     static Status setTTLDuration(SchemaPropItem* schemaProp, meta::cpp2::Schema& schema);
 

--- a/src/util/ToJson.cpp
+++ b/src/util/ToJson.cpp
@@ -89,7 +89,8 @@ folly::dynamic toJson(const meta::cpp2::ColumnDef &column) {
     }
     if (column.default_value_ref().has_value()) {
         graph::QueryExpressionContext ctx;
-        auto value = Expression::decode(*column.default_value_ref());
+        ObjectPool tempPool;
+        auto value = Expression::decode(&tempPool, *column.default_value_ref());
         obj.insert("defaultValue", value->toString());
     }
     return obj;
@@ -245,7 +246,9 @@ folly::dynamic toJson(const storage::cpp2::Expr &expr) {
 folly::dynamic toJson(const storage::cpp2::IndexQueryContext &iqc) {
     folly::dynamic obj = folly::dynamic::object();
     obj.insert("index_id", iqc.get_index_id());
-    auto filter = iqc.get_filter().empty() ? "" : Expression::decode(iqc.get_filter())->toString();
+    ObjectPool tempPool;
+    auto filter =
+        iqc.get_filter().empty() ? "" : Expression::decode(&tempPool, iqc.get_filter())->toString();
     obj.insert("filter", filter);
     obj.insert("columnHints", toJson(iqc.get_column_hints()));
     return obj;

--- a/src/util/test/ExpressionUtilsTest.cpp
+++ b/src/util/test/ExpressionUtilsTest.cpp
@@ -81,7 +81,7 @@ TEST_F(ExpressionUtilsTest, CheckComponent) {
             Value::Type::BOOL,
             new TypeCastingExpression(
                 Value::Type::BOOL,
-                new TypeCastingExpression(Value::Type::BOOL, new ConstantExpression())));
+                new TypeCastingExpression(Value::Type::BOOL, ConstantExpression::make(pool))));
 
         ASSERT_TRUE(ExpressionUtils::isKindOf(root.get(), {Expression::Kind::kTypeCasting}));
         ASSERT_TRUE(ExpressionUtils::hasAny(root.get(), {Expression::Kind::kConstant}));
@@ -141,15 +141,15 @@ TEST_F(ExpressionUtilsTest, CheckComponent) {
         const auto root = std::make_unique<ArithmeticExpression>(
             Expression::Kind::kAdd,
             new ArithmeticExpression(Expression::Kind::kDivision,
-                                     new ConstantExpression(3),
+                                     ConstantExpression::make(pool3),
                                      new ArithmeticExpression(Expression::Kind::kMinus,
-                                                              new ConstantExpression(4),
-                                                              new ConstantExpression(2))),
+                                                              ConstantExpression::make(pool4),
+                                                              ConstantExpression::make(pool2))),
             new ArithmeticExpression(Expression::Kind::kMod,
                                      new ArithmeticExpression(Expression::Kind::kMultiply,
-                                                              new ConstantExpression(3),
-                                                              new ConstantExpression(10)),
-                                     new ConstantExpression(2)));
+                                                              ConstantExpression::make(pool3),
+                                                              ConstantExpression::make(pool10)),
+                                     ConstantExpression::make(pool2)));
 
         ASSERT_TRUE(ExpressionUtils::isKindOf(root.get(), {Expression::Kind::kAdd}));
         ASSERT_TRUE(ExpressionUtils::hasAny(root.get(), {Expression::Kind::kMinus}));
@@ -208,8 +208,8 @@ TEST_F(ExpressionUtilsTest, PullAnds) {
     using Kind = Expression::Kind;
     // true AND false
     {
-        auto *first = new ConstantExpression(true);
-        auto *second = new ConstantExpression(false);
+        auto *first = ConstantExpression::make(pooltrue);
+        auto *second = ConstantExpression::make(poolfalse);
         LogicalExpression expr(Kind::kLogicalAnd, first, second);
         LogicalExpression expected(Kind::kLogicalAnd,
                                    first->clone().release(),
@@ -219,9 +219,9 @@ TEST_F(ExpressionUtilsTest, PullAnds) {
     }
     // true AND false AND true
     {
-        auto *first = new ConstantExpression(true);
-        auto *second = new ConstantExpression(false);
-        auto *third = new ConstantExpression(true);
+        auto *first = ConstantExpression::make(pooltrue);
+        auto *second = ConstantExpression::make(poolfalse);
+        auto *third = ConstantExpression::make(pooltrue);
         LogicalExpression expr(Kind::kLogicalAnd,
                 new LogicalExpression(Kind::kLogicalAnd,
                     first,
@@ -236,9 +236,9 @@ TEST_F(ExpressionUtilsTest, PullAnds) {
     }
     // true AND (false AND true)
     {
-        auto *first = new ConstantExpression(true);
-        auto *second = new ConstantExpression(false);
-        auto *third = new ConstantExpression(true);
+        auto *first = ConstantExpression::make(pooltrue);
+        auto *second = ConstantExpression::make(poolfalse);
+        auto *third = ConstantExpression::make(pooltrue);
         LogicalExpression expr(Kind::kLogicalAnd,
                 first,
                 new LogicalExpression(Kind::kLogicalAnd,
@@ -254,11 +254,11 @@ TEST_F(ExpressionUtilsTest, PullAnds) {
     // (true OR false) AND (true OR false)
     {
         auto *first = new LogicalExpression(Kind::kLogicalOr,
-                new ConstantExpression(true),
-                new ConstantExpression(false));
+                ConstantExpression::make(pooltrue),
+                ConstantExpression::make(poolfalse));
         auto *second = new LogicalExpression(Kind::kLogicalOr,
-                new ConstantExpression(true),
-                new ConstantExpression(false));
+                ConstantExpression::make(pooltrue),
+                ConstantExpression::make(poolfalse));
         LogicalExpression expr(Kind::kLogicalAnd, first, second);
         LogicalExpression expected(Kind::kLogicalAnd);
         expected.addOperand(first->clone().release());
@@ -268,13 +268,13 @@ TEST_F(ExpressionUtilsTest, PullAnds) {
     }
     // true AND ((false AND true) OR false) AND true
     {
-        auto *first = new ConstantExpression(true);
+        auto *first = ConstantExpression::make(pooltrue);
         auto *second = new LogicalExpression(Kind::kLogicalOr,
                 new LogicalExpression(Kind::kLogicalAnd,
-                    new ConstantExpression(false),
-                    new ConstantExpression(true)),
-                new ConstantExpression(false));
-        auto *third = new ConstantExpression(true);
+                    ConstantExpression::make(poolfalse),
+                    ConstantExpression::make(pooltrue)),
+                ConstantExpression::make(poolfalse));
+        auto *third = ConstantExpression::make(pooltrue);
         LogicalExpression expr(Kind::kLogicalAnd,
                 new LogicalExpression(Kind::kLogicalAnd, first, second), third);
         LogicalExpression expected(Kind::kLogicalAnd);
@@ -290,8 +290,8 @@ TEST_F(ExpressionUtilsTest, PullOrs) {
     using Kind = Expression::Kind;
     // true OR false
     {
-        auto *first = new ConstantExpression(true);
-        auto *second = new ConstantExpression(false);
+        auto *first = ConstantExpression::make(pooltrue);
+        auto *second = ConstantExpression::make(poolfalse);
         LogicalExpression expr(Kind::kLogicalOr, first, second);
         LogicalExpression expected(Kind::kLogicalOr,
                 first->clone().release(),
@@ -301,9 +301,9 @@ TEST_F(ExpressionUtilsTest, PullOrs) {
     }
     // true OR false OR true
     {
-        auto *first = new ConstantExpression(true);
-        auto *second = new ConstantExpression(false);
-        auto *third = new ConstantExpression(true);
+        auto *first = ConstantExpression::make(pooltrue);
+        auto *second = ConstantExpression::make(poolfalse);
+        auto *third = ConstantExpression::make(pooltrue);
         LogicalExpression expr(Kind::kLogicalOr,
                 new LogicalExpression(Kind::kLogicalOr, first, second), third);
         LogicalExpression expected(Kind::kLogicalOr);
@@ -315,9 +315,9 @@ TEST_F(ExpressionUtilsTest, PullOrs) {
     }
     // true OR (false OR true)
     {
-        auto *first = new ConstantExpression(true);
-        auto *second = new ConstantExpression(false);
-        auto *third = new ConstantExpression(true);
+        auto *first = ConstantExpression::make(pooltrue);
+        auto *second = ConstantExpression::make(poolfalse);
+        auto *third = ConstantExpression::make(pooltrue);
         LogicalExpression expr(Kind::kLogicalOr,
                 first,
                 new LogicalExpression(Kind::kLogicalOr, second, third));
@@ -331,11 +331,11 @@ TEST_F(ExpressionUtilsTest, PullOrs) {
     // (true AND false) OR (true AND false)
     {
         auto *first = new LogicalExpression(Kind::kLogicalAnd,
-                new ConstantExpression(true),
-                new ConstantExpression(false));
+                ConstantExpression::make(pooltrue),
+                ConstantExpression::make(poolfalse));
         auto *second = new LogicalExpression(Kind::kLogicalAnd,
-                new ConstantExpression(true),
-                new ConstantExpression(false));
+                ConstantExpression::make(pooltrue),
+                ConstantExpression::make(poolfalse));
         LogicalExpression expr(Kind::kLogicalOr, first, second);
         LogicalExpression expected(Kind::kLogicalOr,
                 first->clone().release(),
@@ -345,13 +345,13 @@ TEST_F(ExpressionUtilsTest, PullOrs) {
     }
     // true OR ((false OR true) AND false) OR true
     {
-        auto *first = new ConstantExpression(true);
+        auto *first = ConstantExpression::make(pooltrue);
         auto *second = new LogicalExpression(Kind::kLogicalAnd,
                 new LogicalExpression(Kind::kLogicalOr,
-                    new ConstantExpression(false),
-                    new ConstantExpression(true)),
-                new ConstantExpression(false));
-        auto *third = new ConstantExpression(true);
+                    ConstantExpression::make(poolfalse),
+                    ConstantExpression::make(pooltrue)),
+                ConstantExpression::make(poolfalse));
+        auto *third = ConstantExpression::make(pooltrue);
         LogicalExpression expr(Kind::kLogicalOr,
                 new LogicalExpression(Kind::kLogicalOr, first, second), third);
         LogicalExpression expected(Kind::kLogicalOr);
@@ -364,13 +364,14 @@ TEST_F(ExpressionUtilsTest, PullOrs) {
 }
 
 TEST_F(ExpressionUtilsTest, pushOrs) {
-    std::vector<std::unique_ptr<Expression>> rels;
+    std::vector<Expression *> rels;
     for (int16_t i = 0; i < 5; i++) {
         auto r = std::make_unique<RelationalExpression>(
             Expression::Kind::kRelEQ,
-            new LabelAttributeExpression(new LabelExpression(folly::stringPrintf("tag%d", i)),
-                                         new ConstantExpression(folly::stringPrintf("col%d", i))),
-            new ConstantExpression(Value(folly::stringPrintf("val%d", i))));
+            new LabelAttributeExpression(
+                new LabelExpression(folly::stringPrintf("tag%d", i)),
+                ConstantExpression::make(poolfolly::stringPrintf("col%d", i))),
+            ConstantExpression::make(poolValue(folly::stringPrintf("val%d", i))));
         rels.emplace_back(std::move(r));
     }
     auto t = ExpressionUtils::pushOrs(rels);
@@ -383,13 +384,14 @@ TEST_F(ExpressionUtilsTest, pushOrs) {
 }
 
 TEST_F(ExpressionUtilsTest, pushAnds) {
-    std::vector<std::unique_ptr<Expression>> rels;
+    std::vector<Expression *> rels;
     for (int16_t i = 0; i < 5; i++) {
         auto r = std::make_unique<RelationalExpression>(
             Expression::Kind::kRelEQ,
-            new LabelAttributeExpression(new LabelExpression(folly::stringPrintf("tag%d", i)),
-                                         new ConstantExpression(folly::stringPrintf("col%d", i))),
-            new ConstantExpression(Value(folly::stringPrintf("val%d", i))));
+            new LabelAttributeExpression(
+                new LabelExpression(folly::stringPrintf("tag%d", i)),
+                ConstantExpression::make(poolfolly::stringPrintf("col%d", i))),
+            ConstantExpression::make(poolValue(folly::stringPrintf("val%d", i))));
         rels.emplace_back(std::move(r));
     }
     auto t = ExpressionUtils::pushAnds(rels);
@@ -405,9 +407,9 @@ TEST_F(ExpressionUtilsTest, flattenInnerLogicalExpr) {
     using Kind = Expression::Kind;
     // true AND false AND true
     {
-        auto *first = new ConstantExpression(true);
-        auto *second = new ConstantExpression(false);
-        auto *third = new ConstantExpression(true);
+        auto *first = ConstantExpression::make(pooltrue);
+        auto *second = ConstantExpression::make(poolfalse);
+        auto *third = ConstantExpression::make(pooltrue);
         LogicalExpression expr(Kind::kLogicalAnd,
                 new LogicalExpression(Kind::kLogicalAnd,
                     first,
@@ -422,9 +424,9 @@ TEST_F(ExpressionUtilsTest, flattenInnerLogicalExpr) {
     }
     // true OR false OR true
     {
-        auto *first = new ConstantExpression(true);
-        auto *second = new ConstantExpression(false);
-        auto *third = new ConstantExpression(true);
+        auto *first = ConstantExpression::make(pooltrue);
+        auto *second = ConstantExpression::make(poolfalse);
+        auto *third = ConstantExpression::make(pooltrue);
         LogicalExpression expr(Kind::kLogicalOr,
                 new LogicalExpression(Kind::kLogicalOr,
                     first,
@@ -439,17 +441,17 @@ TEST_F(ExpressionUtilsTest, flattenInnerLogicalExpr) {
     }
     // (true OR false OR true)==(true AND false AND true)
     {
-        auto *or1 = new ConstantExpression(true);
-        auto *or2 = new ConstantExpression(false);
-        auto *or3 = new ConstantExpression(true);
+        auto *or1 = ConstantExpression::make(pooltrue);
+        auto *or2 = ConstantExpression::make(poolfalse);
+        auto *or3 = ConstantExpression::make(pooltrue);
         auto* logicOrExpr = new LogicalExpression(Kind::kLogicalOr,
                 new LogicalExpression(Kind::kLogicalOr,
                     or1,
                     or2),
                 or3);
-        auto *and1 = new ConstantExpression(false);
-        auto *and2 = new ConstantExpression(false);
-        auto *and3 = new ConstantExpression(true);
+        auto *and1 = ConstantExpression::make(poolfalse);
+        auto *and2 = ConstantExpression::make(poolfalse);
+        auto *and3 = ConstantExpression::make(pooltrue);
         auto* logicAndExpr = new LogicalExpression(Kind::kLogicalAnd,
                 new LogicalExpression(Kind::kLogicalAnd,
                     and1,
@@ -472,17 +474,17 @@ TEST_F(ExpressionUtilsTest, flattenInnerLogicalExpr) {
     }
     // (true OR false OR true) AND (true AND false AND true)
     {
-        auto *or1 = new ConstantExpression(true);
-        auto *or2 = new ConstantExpression(false);
-        auto *or3 = new ConstantExpression(true);
+        auto *or1 = ConstantExpression::make(pooltrue);
+        auto *or2 = ConstantExpression::make(poolfalse);
+        auto *or3 = ConstantExpression::make(pooltrue);
         auto* logicOrExpr = new LogicalExpression(Kind::kLogicalOr,
                 new LogicalExpression(Kind::kLogicalOr,
                     or1,
                     or2),
                 or3);
-        auto *and1 = new ConstantExpression(false);
-        auto *and2 = new ConstantExpression(false);
-        auto *and3 = new ConstantExpression(true);
+        auto *and1 = ConstantExpression::make(poolfalse);
+        auto *and2 = ConstantExpression::make(poolfalse);
+        auto *and3 = ConstantExpression::make(pooltrue);
         auto* logicAndExpr = new LogicalExpression(Kind::kLogicalAnd,
                 new LogicalExpression(Kind::kLogicalAnd,
                     and1,
@@ -509,11 +511,11 @@ TEST_F(ExpressionUtilsTest, splitFilter) {
     using Kind = Expression::Kind;
     {
         // true AND false AND true
-        auto *first = new ConstantExpression(true);
-        auto *second = new ConstantExpression(false);
-        auto *third = new ConstantExpression(true);
-        LogicalExpression expr(
-            Kind::kLogicalAnd, new LogicalExpression(Kind::kLogicalAnd, first, second), third);
+        auto *first = ConstantExpression::make(pool, true);
+        auto *second = ConstantExpression::make(pool, false);
+        auto *third = ConstantExpression::make(pooltrue);
+        auto expr = *LogicalExpression::makeAnd(
+            pool, LogicalExpression::makeAnd(pool, first, second), third);
         LogicalExpression expected1(Kind::kLogicalAnd);
         expected1.addOperand(first->clone().release());
         expected1.addOperand(third->clone().release());
@@ -523,8 +525,8 @@ TEST_F(ExpressionUtilsTest, splitFilter) {
             if (v.type() != Value::Type::BOOL) return false;
             return v.getBool();
         };
-        std::unique_ptr<Expression> newExpr1;
-        std::unique_ptr<Expression> newExpr2;
+        Expression* newExpr1;
+        Expression* newExpr2;
         ExpressionUtils::splitFilter(&expr, picker, &newExpr1, &newExpr2);
         ASSERT_EQ(expected1, *newExpr1);
         ASSERT_EQ(*second, *newExpr2);
@@ -538,15 +540,15 @@ TEST_F(ExpressionUtilsTest, splitFilter) {
             if (v.type() != Value::Type::BOOL) return false;
             return v.getBool();
         };
-        std::unique_ptr<Expression> newExpr1;
-        std::unique_ptr<Expression> newExpr2;
+        Expression* newExpr1;
+        Expression* newExpr2;
         ExpressionUtils::splitFilter(expr.get(), picker, &newExpr1, &newExpr2);
         ASSERT_EQ(*expr, *newExpr1);
         ASSERT_EQ(nullptr, newExpr2);
     }
 }
 
-std::unique_ptr<Expression> parse(const std::string& expr) {
+Expression* parse(const std::string& expr) {
     std::string query = "LOOKUP on t1 WHERE " + expr;
     GQLParser parser;
     auto result = parser.parse(std::move(query));

--- a/src/util/test/ExpressionUtilsTest.cpp
+++ b/src/util/test/ExpressionUtilsTest.cpp
@@ -8,67 +8,93 @@
 #include "common/expression/ArithmeticExpression.h"
 #include "common/expression/ConstantExpression.h"
 #include "common/expression/TypeCastingExpression.h"
-#include "util/ExpressionUtils.h"
 #include "parser/GQLParser.h"
+#include "util/ExpressionUtils.h"
 
 namespace nebula {
 namespace graph {
 
-class ExpressionUtilsTest : public ::testing::Test {};
+using graph::QueryContext;
+
+class ExpressionUtilsTest : public ::testing::Test {
+protected:
+    void SetUp() override {
+        qctx_ = std::make_unique<QueryContext>();
+        pool = qctx_->objPool();
+    }
+
+    void TearDown() override {
+        qctx_.reset();
+    }
+
+    Expression *parse(const std::string &expr) {
+        std::string query = "LOOKUP on t1 WHERE " + expr;
+        GQLParser parser(qctx_.get());
+        auto result = parser.parse(std::move(query));
+        CHECK(result.ok()) << result.status();
+        auto stmt = std::move(result).value();
+        auto *seq = static_cast<SequentialSentences *>(stmt.get());
+        auto *lookup = static_cast<LookupSentence *>(seq->sentences()[0]);
+        return lookup->whereClause()->filter()->clone();
+    }
+
+protected:
+    std::unique_ptr<QueryContext> qctx_;
+    ObjectPool *pool;
+};
 
 TEST_F(ExpressionUtilsTest, CheckComponent) {
     {
         // single node
-        const auto root = std::make_unique<ConstantExpression>();
+        const auto root = ConstantExpression::make(pool);
 
-        ASSERT_TRUE(ExpressionUtils::isKindOf(root.get(), {Expression::Kind::kConstant}));
-        ASSERT_TRUE(ExpressionUtils::hasAny(root.get(), {Expression::Kind::kConstant}));
+        ASSERT_TRUE(ExpressionUtils::isKindOf(root, {Expression::Kind::kConstant}));
+        ASSERT_TRUE(ExpressionUtils::hasAny(root, {Expression::Kind::kConstant}));
 
-        ASSERT_TRUE(ExpressionUtils::isKindOf(
-            root.get(), {Expression::Kind::kConstant, Expression::Kind::kAdd}));
-        ASSERT_TRUE(ExpressionUtils::hasAny(root.get(),
-                                            {Expression::Kind::kConstant, Expression::Kind::kAdd}));
+        ASSERT_TRUE(
+            ExpressionUtils::isKindOf(root, {Expression::Kind::kConstant, Expression::Kind::kAdd}));
+        ASSERT_TRUE(
+            ExpressionUtils::hasAny(root, {Expression::Kind::kConstant, Expression::Kind::kAdd}));
 
-        ASSERT_FALSE(ExpressionUtils::isKindOf(root.get(), {Expression::Kind::kAdd}));
-        ASSERT_FALSE(ExpressionUtils::hasAny(root.get(), {Expression::Kind::kAdd}));
+        ASSERT_FALSE(ExpressionUtils::isKindOf(root, {Expression::Kind::kAdd}));
+        ASSERT_FALSE(ExpressionUtils::hasAny(root, {Expression::Kind::kAdd}));
 
-        ASSERT_FALSE(ExpressionUtils::isKindOf(
-            root.get(), {Expression::Kind::kDivision, Expression::Kind::kAdd}));
+        ASSERT_FALSE(
+            ExpressionUtils::isKindOf(root, {Expression::Kind::kDivision, Expression::Kind::kAdd}));
         ASSERT_FALSE(ExpressionUtils::hasAny(
-            root.get(), {Expression::Kind::kDstProperty, Expression::Kind::kAdd}));
+            root, {Expression::Kind::kDstProperty, Expression::Kind::kAdd}));
 
         // find
-        const Expression *found =
-            ExpressionUtils::findAny(root.get(), {Expression::Kind::kConstant});
-        ASSERT_EQ(found, root.get());
+        const Expression *found = ExpressionUtils::findAny(root, {Expression::Kind::kConstant});
+        ASSERT_EQ(found, root);
 
         found = ExpressionUtils::findAny(
-            root.get(),
+            root,
             {Expression::Kind::kConstant, Expression::Kind::kAdd, Expression::Kind::kEdgeProperty});
-        ASSERT_EQ(found, root.get());
+        ASSERT_EQ(found, root);
 
-        found = ExpressionUtils::findAny(root.get(), {Expression::Kind::kEdgeDst});
+        found = ExpressionUtils::findAny(root, {Expression::Kind::kEdgeDst});
         ASSERT_EQ(found, nullptr);
 
         found = ExpressionUtils::findAny(
-            root.get(), {Expression::Kind::kEdgeRank, Expression::Kind::kInputProperty});
+            root, {Expression::Kind::kEdgeRank, Expression::Kind::kInputProperty});
         ASSERT_EQ(found, nullptr);
 
         // find all
-        const auto willFoundAll = std::vector<const Expression *>{root.get()};
+        const auto willFoundAll = std::vector<const Expression *>{root};
         std::vector<const Expression *> founds =
-            ExpressionUtils::collectAll(root.get(), {Expression::Kind::kConstant});
+            ExpressionUtils::collectAll(root, {Expression::Kind::kConstant});
         ASSERT_EQ(founds, willFoundAll);
 
         founds = ExpressionUtils::collectAll(
-            root.get(),
+            root,
             {Expression::Kind::kAdd, Expression::Kind::kConstant, Expression::Kind::kEdgeDst});
         ASSERT_EQ(founds, willFoundAll);
 
-        founds = ExpressionUtils::collectAll(root.get(), {Expression::Kind::kSrcProperty});
+        founds = ExpressionUtils::collectAll(root, {Expression::Kind::kSrcProperty});
         ASSERT_TRUE(founds.empty());
 
-        founds = ExpressionUtils::collectAll(root.get(),
+        founds = ExpressionUtils::collectAll(root,
                                              {Expression::Kind::kUnaryNegate,
                                               Expression::Kind::kEdgeDst,
                                               Expression::Kind::kEdgeDst});
@@ -77,43 +103,45 @@ TEST_F(ExpressionUtilsTest, CheckComponent) {
 
     {
         // list like
-        const auto root = std::make_unique<TypeCastingExpression>(
+        const auto root = TypeCastingExpression::make(
+            pool,
             Value::Type::BOOL,
-            new TypeCastingExpression(
+            TypeCastingExpression::make(
+                pool,
                 Value::Type::BOOL,
-                new TypeCastingExpression(Value::Type::BOOL, ConstantExpression::make(pool))));
+                TypeCastingExpression::make(
+                    pool, Value::Type::BOOL, ConstantExpression::make(pool))));
 
-        ASSERT_TRUE(ExpressionUtils::isKindOf(root.get(), {Expression::Kind::kTypeCasting}));
-        ASSERT_TRUE(ExpressionUtils::hasAny(root.get(), {Expression::Kind::kConstant}));
+        ASSERT_TRUE(ExpressionUtils::isKindOf(root, {Expression::Kind::kTypeCasting}));
+        ASSERT_TRUE(ExpressionUtils::hasAny(root, {Expression::Kind::kConstant}));
 
         ASSERT_TRUE(ExpressionUtils::isKindOf(
-            root.get(), {Expression::Kind::kTypeCasting, Expression::Kind::kAdd}));
+            root, {Expression::Kind::kTypeCasting, Expression::Kind::kAdd}));
         ASSERT_TRUE(ExpressionUtils::hasAny(
-            root.get(), {Expression::Kind::kTypeCasting, Expression::Kind::kAdd}));
+            root, {Expression::Kind::kTypeCasting, Expression::Kind::kAdd}));
 
-        ASSERT_FALSE(ExpressionUtils::isKindOf(root.get(), {Expression::Kind::kAdd}));
-        ASSERT_FALSE(ExpressionUtils::hasAny(root.get(), {Expression::Kind::kAdd}));
+        ASSERT_FALSE(ExpressionUtils::isKindOf(root, {Expression::Kind::kAdd}));
+        ASSERT_FALSE(ExpressionUtils::hasAny(root, {Expression::Kind::kAdd}));
 
-        ASSERT_FALSE(ExpressionUtils::isKindOf(
-            root.get(), {Expression::Kind::kDivision, Expression::Kind::kAdd}));
+        ASSERT_FALSE(
+            ExpressionUtils::isKindOf(root, {Expression::Kind::kDivision, Expression::Kind::kAdd}));
         ASSERT_FALSE(ExpressionUtils::hasAny(
-            root.get(), {Expression::Kind::kDstProperty, Expression::Kind::kAdd}));
+            root, {Expression::Kind::kDstProperty, Expression::Kind::kAdd}));
 
         // found
-        const Expression *found =
-            ExpressionUtils::findAny(root.get(), {Expression::Kind::kTypeCasting});
-        ASSERT_EQ(found, root.get());
+        const Expression *found = ExpressionUtils::findAny(root, {Expression::Kind::kTypeCasting});
+        ASSERT_EQ(found, root);
 
-        found = ExpressionUtils::findAny(root.get(),
+        found = ExpressionUtils::findAny(root,
                                          {Expression::Kind::kFunctionCall,
                                           Expression::Kind::kTypeCasting,
                                           Expression::Kind::kLogicalAnd});
-        ASSERT_EQ(found, root.get());
+        ASSERT_EQ(found, root);
 
-        found = ExpressionUtils::findAny(root.get(), {Expression::Kind::kDivision});
+        found = ExpressionUtils::findAny(root, {Expression::Kind::kDivision});
         ASSERT_EQ(found, nullptr);
 
-        found = ExpressionUtils::findAny(root.get(),
+        found = ExpressionUtils::findAny(root,
                                          {Expression::Kind::kLogicalXor,
                                           Expression::Kind::kRelGE,
                                           Expression::Kind::kEdgeProperty});
@@ -121,66 +149,66 @@ TEST_F(ExpressionUtilsTest, CheckComponent) {
 
         // found all
         std::vector<const Expression *> founds =
-            ExpressionUtils::collectAll(root.get(), {Expression::Kind::kConstant});
+            ExpressionUtils::collectAll(root, {Expression::Kind::kConstant});
         ASSERT_EQ(founds.size(), 1);
 
         founds = ExpressionUtils::collectAll(
-            root.get(), {Expression::Kind::kFunctionCall, Expression::Kind::kTypeCasting});
+            root, {Expression::Kind::kFunctionCall, Expression::Kind::kTypeCasting});
         ASSERT_EQ(founds.size(), 3);
 
-        founds = ExpressionUtils::collectAll(root.get(), {Expression::Kind::kAdd});
+        founds = ExpressionUtils::collectAll(root, {Expression::Kind::kAdd});
         ASSERT_TRUE(founds.empty());
 
         founds = ExpressionUtils::collectAll(
-            root.get(), {Expression::Kind::kRelLE, Expression::Kind::kDstProperty});
+            root, {Expression::Kind::kRelLE, Expression::Kind::kDstProperty});
         ASSERT_TRUE(founds.empty());
     }
 
     {
         // tree like
-        const auto root = std::make_unique<ArithmeticExpression>(
-            Expression::Kind::kAdd,
-            new ArithmeticExpression(Expression::Kind::kDivision,
-                                     ConstantExpression::make(pool3),
-                                     new ArithmeticExpression(Expression::Kind::kMinus,
-                                                              ConstantExpression::make(pool4),
-                                                              ConstantExpression::make(pool2))),
-            new ArithmeticExpression(Expression::Kind::kMod,
-                                     new ArithmeticExpression(Expression::Kind::kMultiply,
-                                                              ConstantExpression::make(pool3),
-                                                              ConstantExpression::make(pool10)),
-                                     ConstantExpression::make(pool2)));
+        const auto root = ArithmeticExpression::makeAdd(
+            pool,
+            ArithmeticExpression::makeDivision(
+                pool,
+                ConstantExpression::make(pool, 3),
+                ArithmeticExpression::makeMinus(
+                    pool, ConstantExpression::make(pool, 4), ConstantExpression::make(pool, 2))),
+            ArithmeticExpression::makeMod(
+                pool,
+                ArithmeticExpression::makeMultiply(
+                    pool, ConstantExpression::make(pool, 3), ConstantExpression::make(pool, 10)),
+                ConstantExpression::make(pool, 2)));
 
-        ASSERT_TRUE(ExpressionUtils::isKindOf(root.get(), {Expression::Kind::kAdd}));
-        ASSERT_TRUE(ExpressionUtils::hasAny(root.get(), {Expression::Kind::kMinus}));
+        ASSERT_TRUE(ExpressionUtils::isKindOf(root, {Expression::Kind::kAdd}));
+        ASSERT_TRUE(ExpressionUtils::hasAny(root, {Expression::Kind::kMinus}));
 
         ASSERT_TRUE(ExpressionUtils::isKindOf(
-            root.get(), {Expression::Kind::kTypeCasting, Expression::Kind::kAdd}));
+            root, {Expression::Kind::kTypeCasting, Expression::Kind::kAdd}));
         ASSERT_TRUE(ExpressionUtils::hasAny(
-            root.get(), {Expression::Kind::kLabelAttribute, Expression::Kind::kDivision}));
+            root, {Expression::Kind::kLabelAttribute, Expression::Kind::kDivision}));
 
-        ASSERT_FALSE(ExpressionUtils::isKindOf(root.get(), {Expression::Kind::kConstant}));
-        ASSERT_FALSE(ExpressionUtils::hasAny(root.get(), {Expression::Kind::kFunctionCall}));
+        ASSERT_FALSE(ExpressionUtils::isKindOf(root, {Expression::Kind::kConstant}));
+        ASSERT_FALSE(ExpressionUtils::hasAny(root, {Expression::Kind::kFunctionCall}));
 
         ASSERT_FALSE(ExpressionUtils::isKindOf(
-            root.get(), {Expression::Kind::kDivision, Expression::Kind::kEdgeProperty}));
+            root, {Expression::Kind::kDivision, Expression::Kind::kEdgeProperty}));
         ASSERT_FALSE(ExpressionUtils::hasAny(
-            root.get(), {Expression::Kind::kDstProperty, Expression::Kind::kLogicalAnd}));
+            root, {Expression::Kind::kDstProperty, Expression::Kind::kLogicalAnd}));
 
         // found
-        const Expression *found = ExpressionUtils::findAny(root.get(), {Expression::Kind::kAdd});
-        ASSERT_EQ(found, root.get());
+        const Expression *found = ExpressionUtils::findAny(root, {Expression::Kind::kAdd});
+        ASSERT_EQ(found, root);
 
-        found = ExpressionUtils::findAny(root.get(),
+        found = ExpressionUtils::findAny(root,
                                          {Expression::Kind::kFunctionCall,
                                           Expression::Kind::kRelLE,
                                           Expression::Kind::kMultiply});
         ASSERT_NE(found, nullptr);
 
-        found = ExpressionUtils::findAny(root.get(), {Expression::Kind::kInputProperty});
+        found = ExpressionUtils::findAny(root, {Expression::Kind::kInputProperty});
         ASSERT_EQ(found, nullptr);
 
-        found = ExpressionUtils::findAny(root.get(),
+        found = ExpressionUtils::findAny(root,
                                          {Expression::Kind::kLogicalXor,
                                           Expression::Kind::kEdgeRank,
                                           Expression::Kind::kUnaryNot});
@@ -188,176 +216,157 @@ TEST_F(ExpressionUtilsTest, CheckComponent) {
 
         // found all
         std::vector<const Expression *> founds =
-            ExpressionUtils::collectAll(root.get(), {Expression::Kind::kConstant});
+            ExpressionUtils::collectAll(root, {Expression::Kind::kConstant});
         ASSERT_EQ(founds.size(), 6);
 
         founds = ExpressionUtils::collectAll(
-            root.get(), {Expression::Kind::kDivision, Expression::Kind::kMinus});
+            root, {Expression::Kind::kDivision, Expression::Kind::kMinus});
         ASSERT_EQ(founds.size(), 2);
 
-        founds = ExpressionUtils::collectAll(root.get(), {Expression::Kind::kEdgeDst});
+        founds = ExpressionUtils::collectAll(root, {Expression::Kind::kEdgeDst});
         ASSERT_TRUE(founds.empty());
 
         founds = ExpressionUtils::collectAll(
-            root.get(), {Expression::Kind::kLogicalAnd, Expression::Kind::kUnaryNegate});
+            root, {Expression::Kind::kLogicalAnd, Expression::Kind::kUnaryNegate});
         ASSERT_TRUE(founds.empty());
     }
 }
 
 TEST_F(ExpressionUtilsTest, PullAnds) {
-    using Kind = Expression::Kind;
     // true AND false
     {
-        auto *first = ConstantExpression::make(pooltrue);
-        auto *second = ConstantExpression::make(poolfalse);
-        LogicalExpression expr(Kind::kLogicalAnd, first, second);
-        LogicalExpression expected(Kind::kLogicalAnd,
-                                   first->clone().release(),
-                                   second->clone().release());
+        auto *first = ConstantExpression::make(pool, true);
+        auto *second = ConstantExpression::make(pool, false);
+        auto expr = *LogicalExpression::makeAnd(pool, first, second);
+        auto expected = *LogicalExpression::makeAnd(pool, first->clone(), second->clone());
         ExpressionUtils::pullAnds(&expr);
         ASSERT_EQ(expected, expr);
     }
     // true AND false AND true
     {
-        auto *first = ConstantExpression::make(pooltrue);
-        auto *second = ConstantExpression::make(poolfalse);
-        auto *third = ConstantExpression::make(pooltrue);
-        LogicalExpression expr(Kind::kLogicalAnd,
-                new LogicalExpression(Kind::kLogicalAnd,
-                    first,
-                    second),
-                third);
-        LogicalExpression expected(Kind::kLogicalAnd);
-        expected.addOperand(first->clone().release());
-        expected.addOperand(second->clone().release());
-        expected.addOperand(third->clone().release());
+        auto *first = ConstantExpression::make(pool, true);
+        auto *second = ConstantExpression::make(pool, false);
+        auto *third = ConstantExpression::make(pool, true);
+        auto expr = *LogicalExpression::makeAnd(
+            pool, LogicalExpression::makeAnd(pool, first, second), third);
+        auto expected = *LogicalExpression::makeAnd(pool);
+        expected.addOperand(first->clone());
+        expected.addOperand(second->clone());
+        expected.addOperand(third->clone());
         ExpressionUtils::pullAnds(&expr);
         ASSERT_EQ(expected, expr);
     }
     // true AND (false AND true)
     {
-        auto *first = ConstantExpression::make(pooltrue);
-        auto *second = ConstantExpression::make(poolfalse);
-        auto *third = ConstantExpression::make(pooltrue);
-        LogicalExpression expr(Kind::kLogicalAnd,
-                first,
-                new LogicalExpression(Kind::kLogicalAnd,
-                    second,
-                    third));
-        LogicalExpression expected(Kind::kLogicalAnd);
-        expected.addOperand(first->clone().release());
-        expected.addOperand(second->clone().release());
-        expected.addOperand(third->clone().release());
+        auto *first = ConstantExpression::make(pool, true);
+        auto *second = ConstantExpression::make(pool, false);
+        auto *third = ConstantExpression::make(pool, true);
+        auto expr = *LogicalExpression::makeAnd(
+            pool, first, LogicalExpression::makeAnd(pool, second, third));
+        auto expected = *LogicalExpression::makeAnd(pool);
+        expected.addOperand(first->clone());
+        expected.addOperand(second->clone());
+        expected.addOperand(third->clone());
         ExpressionUtils::pullAnds(&expr);
         ASSERT_EQ(expected, expr);
     }
     // (true OR false) AND (true OR false)
     {
-        auto *first = new LogicalExpression(Kind::kLogicalOr,
-                ConstantExpression::make(pooltrue),
-                ConstantExpression::make(poolfalse));
-        auto *second = new LogicalExpression(Kind::kLogicalOr,
-                ConstantExpression::make(pooltrue),
-                ConstantExpression::make(poolfalse));
-        LogicalExpression expr(Kind::kLogicalAnd, first, second);
-        LogicalExpression expected(Kind::kLogicalAnd);
-        expected.addOperand(first->clone().release());
-        expected.addOperand(second->clone().release());
+        auto *first = LogicalExpression::makeOr(
+            pool, ConstantExpression::make(pool, true), ConstantExpression::make(pool, false));
+        auto *second = LogicalExpression::makeOr(
+            pool, ConstantExpression::make(pool, true), ConstantExpression::make(pool, false));
+        auto expr = *LogicalExpression::makeAnd(pool, first, second);
+        auto expected = *LogicalExpression::makeAnd(pool);
+        expected.addOperand(first->clone());
+        expected.addOperand(second->clone());
         ExpressionUtils::pullAnds(&expr);
         ASSERT_EQ(expected, expr);
     }
     // true AND ((false AND true) OR false) AND true
     {
-        auto *first = ConstantExpression::make(pooltrue);
-        auto *second = new LogicalExpression(Kind::kLogicalOr,
-                new LogicalExpression(Kind::kLogicalAnd,
-                    ConstantExpression::make(poolfalse),
-                    ConstantExpression::make(pooltrue)),
-                ConstantExpression::make(poolfalse));
-        auto *third = ConstantExpression::make(pooltrue);
-        LogicalExpression expr(Kind::kLogicalAnd,
-                new LogicalExpression(Kind::kLogicalAnd, first, second), third);
-        LogicalExpression expected(Kind::kLogicalAnd);
-        expected.addOperand(first->clone().release());
-        expected.addOperand(second->clone().release());
-        expected.addOperand(third->clone().release());
+        auto *first = ConstantExpression::make(pool, true);
+        auto *second = LogicalExpression::makeOr(
+            pool,
+            LogicalExpression::makeAnd(
+                pool, ConstantExpression::make(pool, false), ConstantExpression::make(pool, true)),
+            ConstantExpression::make(pool, false));
+        auto *third = ConstantExpression::make(pool, true);
+        auto expr = *LogicalExpression::makeAnd(
+            pool, LogicalExpression::makeAnd(pool, first, second), third);
+        auto expected = *LogicalExpression::makeAnd(pool);
+        expected.addOperand(first->clone());
+        expected.addOperand(second->clone());
+        expected.addOperand(third->clone());
         ExpressionUtils::pullAnds(&expr);
         ASSERT_EQ(expected, expr);
     }
 }
 
 TEST_F(ExpressionUtilsTest, PullOrs) {
-    using Kind = Expression::Kind;
     // true OR false
     {
-        auto *first = ConstantExpression::make(pooltrue);
-        auto *second = ConstantExpression::make(poolfalse);
-        LogicalExpression expr(Kind::kLogicalOr, first, second);
-        LogicalExpression expected(Kind::kLogicalOr,
-                first->clone().release(),
-                second->clone().release());
+        auto *first = ConstantExpression::make(pool, true);
+        auto *second = ConstantExpression::make(pool, false);
+        auto expr = *LogicalExpression::makeOr(pool, first, second);
+        auto expected = *LogicalExpression::makeOr(pool, first->clone(), second->clone());
         ExpressionUtils::pullOrs(&expr);
         ASSERT_EQ(expected, expr);
     }
     // true OR false OR true
     {
-        auto *first = ConstantExpression::make(pooltrue);
-        auto *second = ConstantExpression::make(poolfalse);
-        auto *third = ConstantExpression::make(pooltrue);
-        LogicalExpression expr(Kind::kLogicalOr,
-                new LogicalExpression(Kind::kLogicalOr, first, second), third);
-        LogicalExpression expected(Kind::kLogicalOr);
-        expected.addOperand(first->clone().release());
-        expected.addOperand(second->clone().release());
-        expected.addOperand(third->clone().release());
+        auto *first = ConstantExpression::make(pool, true);
+        auto *second = ConstantExpression::make(pool, false);
+        auto *third = ConstantExpression::make(pool, true);
+        auto expr =
+            *LogicalExpression::makeOr(pool, LogicalExpression::makeOr(pool, first, second), third);
+        auto expected = *LogicalExpression::makeOr(pool);
+        expected.addOperand(first->clone());
+        expected.addOperand(second->clone());
+        expected.addOperand(third->clone());
         ExpressionUtils::pullOrs(&expr);
         ASSERT_EQ(expected, expr);
     }
     // true OR (false OR true)
     {
-        auto *first = ConstantExpression::make(pooltrue);
-        auto *second = ConstantExpression::make(poolfalse);
-        auto *third = ConstantExpression::make(pooltrue);
-        LogicalExpression expr(Kind::kLogicalOr,
-                first,
-                new LogicalExpression(Kind::kLogicalOr, second, third));
-        LogicalExpression expected(Kind::kLogicalOr);
-        expected.addOperand(first->clone().release());
-        expected.addOperand(second->clone().release());
-        expected.addOperand(third->clone().release());
+        auto *first = ConstantExpression::make(pool, true);
+        auto *second = ConstantExpression::make(pool, false);
+        auto *third = ConstantExpression::make(pool, true);
+        auto expr =
+            *LogicalExpression::makeOr(pool, first, LogicalExpression::makeOr(pool, second, third));
+        auto expected = *LogicalExpression::makeOr(pool);
+        expected.addOperand(first->clone());
+        expected.addOperand(second->clone());
+        expected.addOperand(third->clone());
         ExpressionUtils::pullOrs(&expr);
         ASSERT_EQ(expected, expr);
     }
     // (true AND false) OR (true AND false)
     {
-        auto *first = new LogicalExpression(Kind::kLogicalAnd,
-                ConstantExpression::make(pooltrue),
-                ConstantExpression::make(poolfalse));
-        auto *second = new LogicalExpression(Kind::kLogicalAnd,
-                ConstantExpression::make(pooltrue),
-                ConstantExpression::make(poolfalse));
-        LogicalExpression expr(Kind::kLogicalOr, first, second);
-        LogicalExpression expected(Kind::kLogicalOr,
-                first->clone().release(),
-                second->clone().release());
+        auto *first = LogicalExpression::makeAnd(
+            pool, ConstantExpression::make(pool, true), ConstantExpression::make(pool, false));
+        auto *second = LogicalExpression::makeAnd(
+            pool, ConstantExpression::make(pool, true), ConstantExpression::make(pool, false));
+        auto expr = *LogicalExpression::makeOr(pool, first, second);
+        auto expected = *LogicalExpression::makeOr(pool, first->clone(), second->clone());
         ExpressionUtils::pullOrs(&expr);
         ASSERT_EQ(expected, expr);
     }
     // true OR ((false OR true) AND false) OR true
     {
-        auto *first = ConstantExpression::make(pooltrue);
-        auto *second = new LogicalExpression(Kind::kLogicalAnd,
-                new LogicalExpression(Kind::kLogicalOr,
-                    ConstantExpression::make(poolfalse),
-                    ConstantExpression::make(pooltrue)),
-                ConstantExpression::make(poolfalse));
-        auto *third = ConstantExpression::make(pooltrue);
-        LogicalExpression expr(Kind::kLogicalOr,
-                new LogicalExpression(Kind::kLogicalOr, first, second), third);
-        LogicalExpression expected(Kind::kLogicalOr);
-        expected.addOperand(first->clone().release());
-        expected.addOperand(second->clone().release());
-        expected.addOperand(third->clone().release());
+        auto *first = ConstantExpression::make(pool, true);
+        auto *second = LogicalExpression::makeAnd(
+            pool,
+            LogicalExpression::makeOr(
+                pool, ConstantExpression::make(pool, false), ConstantExpression::make(pool, true)),
+            ConstantExpression::make(pool, false));
+        auto *third = ConstantExpression::make(pool, true);
+        auto expr =
+            *LogicalExpression::makeOr(pool, LogicalExpression::makeOr(pool, first, second), third);
+        auto expected = *LogicalExpression::makeOr(pool);
+        expected.addOperand(first->clone());
+        expected.addOperand(second->clone());
+        expected.addOperand(third->clone());
         ExpressionUtils::pullOrs(&expr);
         ASSERT_EQ(expected, expr);
     }
@@ -366,15 +375,16 @@ TEST_F(ExpressionUtilsTest, PullOrs) {
 TEST_F(ExpressionUtilsTest, pushOrs) {
     std::vector<Expression *> rels;
     for (int16_t i = 0; i < 5; i++) {
-        auto r = std::make_unique<RelationalExpression>(
-            Expression::Kind::kRelEQ,
-            new LabelAttributeExpression(
-                new LabelExpression(folly::stringPrintf("tag%d", i)),
-                ConstantExpression::make(poolfolly::stringPrintf("col%d", i))),
-            ConstantExpression::make(poolValue(folly::stringPrintf("val%d", i))));
+        auto r = RelationalExpression::makeEQ(
+            pool,
+            LabelAttributeExpression::make(
+                pool,
+                LabelExpression::make(pool, folly::stringPrintf("tag%d", i)),
+                ConstantExpression::make(pool, folly::stringPrintf("col%d", i))),
+            ConstantExpression::make(pool, Value(folly::stringPrintf("val%d", i))));
         rels.emplace_back(std::move(r));
     }
-    auto t = ExpressionUtils::pushOrs(rels);
+    auto t = ExpressionUtils::pushOrs(pool, rels);
     auto expected = std::string("(((((tag0.col0==\"val0\") OR "
                                 "(tag1.col1==\"val1\")) OR "
                                 "(tag2.col2==\"val2\")) OR "
@@ -386,15 +396,16 @@ TEST_F(ExpressionUtilsTest, pushOrs) {
 TEST_F(ExpressionUtilsTest, pushAnds) {
     std::vector<Expression *> rels;
     for (int16_t i = 0; i < 5; i++) {
-        auto r = std::make_unique<RelationalExpression>(
-            Expression::Kind::kRelEQ,
-            new LabelAttributeExpression(
-                new LabelExpression(folly::stringPrintf("tag%d", i)),
-                ConstantExpression::make(poolfolly::stringPrintf("col%d", i))),
-            ConstantExpression::make(poolValue(folly::stringPrintf("val%d", i))));
+        auto r = RelationalExpression::makeEQ(
+            pool,
+            LabelAttributeExpression::make(
+                pool,
+                LabelExpression::make(pool, folly::stringPrintf("tag%d", i)),
+                ConstantExpression::make(pool, folly::stringPrintf("col%d", i))),
+            ConstantExpression::make(pool, Value(folly::stringPrintf("val%d", i))));
         rels.emplace_back(std::move(r));
     }
-    auto t = ExpressionUtils::pushAnds(rels);
+    auto t = ExpressionUtils::pushAnds(pool, rels);
     auto expected = std::string("(((((tag0.col0==\"val0\") AND "
                                 "(tag1.col1==\"val1\")) AND "
                                 "(tag2.col2==\"val2\")) AND "
@@ -404,103 +415,84 @@ TEST_F(ExpressionUtilsTest, pushAnds) {
 }
 
 TEST_F(ExpressionUtilsTest, flattenInnerLogicalExpr) {
-    using Kind = Expression::Kind;
     // true AND false AND true
     {
-        auto *first = ConstantExpression::make(pooltrue);
-        auto *second = ConstantExpression::make(poolfalse);
-        auto *third = ConstantExpression::make(pooltrue);
-        LogicalExpression expr(Kind::kLogicalAnd,
-                new LogicalExpression(Kind::kLogicalAnd,
-                    first,
-                    second),
-                third);
-        LogicalExpression expected(Kind::kLogicalAnd);
-        expected.addOperand(first->clone().release());
-        expected.addOperand(second->clone().release());
-        expected.addOperand(third->clone().release());
+        auto *first = ConstantExpression::make(pool, true);
+        auto *second = ConstantExpression::make(pool, false);
+        auto *third = ConstantExpression::make(pool, true);
+        auto expr = *LogicalExpression::makeAnd(
+            pool, LogicalExpression::makeAnd(pool, first, second), third);
+        auto expected = *LogicalExpression::makeAnd(pool);
+        expected.addOperand(first->clone());
+        expected.addOperand(second->clone());
+        expected.addOperand(third->clone());
         auto newExpr = ExpressionUtils::flattenInnerLogicalExpr(&expr);
         ASSERT_EQ(expected, *newExpr);
     }
     // true OR false OR true
     {
-        auto *first = ConstantExpression::make(pooltrue);
-        auto *second = ConstantExpression::make(poolfalse);
-        auto *third = ConstantExpression::make(pooltrue);
-        LogicalExpression expr(Kind::kLogicalOr,
-                new LogicalExpression(Kind::kLogicalOr,
-                    first,
-                    second),
-                third);
-        LogicalExpression expected(Kind::kLogicalOr);
-        expected.addOperand(first->clone().release());
-        expected.addOperand(second->clone().release());
-        expected.addOperand(third->clone().release());
+        auto *first = ConstantExpression::make(pool, true);
+        auto *second = ConstantExpression::make(pool, false);
+        auto *third = ConstantExpression::make(pool, true);
+        auto expr =
+            *LogicalExpression::makeOr(pool, LogicalExpression::makeOr(pool, first, second), third);
+        auto expected = *LogicalExpression::makeOr(pool);
+        expected.addOperand(first->clone());
+        expected.addOperand(second->clone());
+        expected.addOperand(third->clone());
         auto newExpr = ExpressionUtils::flattenInnerLogicalExpr(&expr);
         ASSERT_EQ(expected, *newExpr);
     }
     // (true OR false OR true)==(true AND false AND true)
     {
-        auto *or1 = ConstantExpression::make(pooltrue);
-        auto *or2 = ConstantExpression::make(poolfalse);
-        auto *or3 = ConstantExpression::make(pooltrue);
-        auto* logicOrExpr = new LogicalExpression(Kind::kLogicalOr,
-                new LogicalExpression(Kind::kLogicalOr,
-                    or1,
-                    or2),
-                or3);
-        auto *and1 = ConstantExpression::make(poolfalse);
-        auto *and2 = ConstantExpression::make(poolfalse);
-        auto *and3 = ConstantExpression::make(pooltrue);
-        auto* logicAndExpr = new LogicalExpression(Kind::kLogicalAnd,
-                new LogicalExpression(Kind::kLogicalAnd,
-                    and1,
-                    and2),
-                and3);
-        RelationalExpression expr(Kind::kRelEQ, logicOrExpr, logicAndExpr);
+        auto *or1 = ConstantExpression::make(pool, true);
+        auto *or2 = ConstantExpression::make(pool, false);
+        auto *or3 = ConstantExpression::make(pool, true);
+        auto *logicOrExpr =
+            LogicalExpression::makeOr(pool, LogicalExpression::makeOr(pool, or1, or2), or3);
+        auto *and1 = ConstantExpression::make(pool, false);
+        auto *and2 = ConstantExpression::make(pool, false);
+        auto *and3 = ConstantExpression::make(pool, true);
+        auto *logicAndExpr =
+            LogicalExpression::makeAnd(pool, LogicalExpression::makeAnd(pool, and1, and2), and3);
+        auto expr = *RelationalExpression ::makeEQ(pool, logicOrExpr, logicAndExpr);
 
-        auto* logicOrFlatten = new LogicalExpression(Kind::kLogicalOr);
-        logicOrFlatten->addOperand(or1->clone().release());
-        logicOrFlatten->addOperand(or2->clone().release());
-        logicOrFlatten->addOperand(or3->clone().release());
-        auto* logicAndFlatten = new LogicalExpression(Kind::kLogicalAnd);
-        logicAndFlatten->addOperand(and1->clone().release());
-        logicAndFlatten->addOperand(and2->clone().release());
-        logicAndFlatten->addOperand(and3->clone().release());
-        RelationalExpression expected(Kind::kRelEQ, logicOrFlatten, logicAndFlatten);
+        auto *logicOrFlatten = LogicalExpression::makeOr(pool);
+        logicOrFlatten->addOperand(or1->clone());
+        logicOrFlatten->addOperand(or2->clone());
+        logicOrFlatten->addOperand(or3->clone());
+        auto *logicAndFlatten = LogicalExpression::makeAnd(pool);
+        logicAndFlatten->addOperand(and1->clone());
+        logicAndFlatten->addOperand(and2->clone());
+        logicAndFlatten->addOperand(and3->clone());
+        auto expected = *RelationalExpression ::makeEQ(pool, logicOrFlatten, logicAndFlatten);
 
         auto newExpr = ExpressionUtils::flattenInnerLogicalExpr(&expr);
         ASSERT_EQ(expected, *newExpr);
     }
     // (true OR false OR true) AND (true AND false AND true)
     {
-        auto *or1 = ConstantExpression::make(pooltrue);
-        auto *or2 = ConstantExpression::make(poolfalse);
-        auto *or3 = ConstantExpression::make(pooltrue);
-        auto* logicOrExpr = new LogicalExpression(Kind::kLogicalOr,
-                new LogicalExpression(Kind::kLogicalOr,
-                    or1,
-                    or2),
-                or3);
-        auto *and1 = ConstantExpression::make(poolfalse);
-        auto *and2 = ConstantExpression::make(poolfalse);
-        auto *and3 = ConstantExpression::make(pooltrue);
-        auto* logicAndExpr = new LogicalExpression(Kind::kLogicalAnd,
-                new LogicalExpression(Kind::kLogicalAnd,
-                    and1,
-                    and2),
-                and3);
-        LogicalExpression expr(Kind::kLogicalAnd, logicOrExpr, logicAndExpr);
+        auto *or1 = ConstantExpression::make(pool, true);
+        auto *or2 = ConstantExpression::make(pool, false);
+        auto *or3 = ConstantExpression::make(pool, true);
+        auto *logicOrExpr =
+            LogicalExpression::makeOr(pool, LogicalExpression::makeOr(pool, or1, or2), or3);
+        auto *and1 = ConstantExpression::make(pool, false);
+        auto *and2 = ConstantExpression::make(pool, false);
+        auto *and3 = ConstantExpression::make(pool, true);
+        auto *logicAndExpr =
+            LogicalExpression::makeAnd(pool, LogicalExpression::makeAnd(pool, and1, and2), and3);
+        auto expr = *LogicalExpression::makeAnd(pool, logicOrExpr, logicAndExpr);
 
-        auto* logicOrFlatten = new LogicalExpression(Kind::kLogicalOr);
-        logicOrFlatten->addOperand(or1->clone().release());
-        logicOrFlatten->addOperand(or2->clone().release());
-        logicOrFlatten->addOperand(or3->clone().release());
-        LogicalExpression expected(Kind::kLogicalAnd);
+        auto *logicOrFlatten = LogicalExpression::makeOr(pool);
+        logicOrFlatten->addOperand(or1->clone());
+        logicOrFlatten->addOperand(or2->clone());
+        logicOrFlatten->addOperand(or3->clone());
+        auto expected = *LogicalExpression::makeAnd(pool);
         expected.addOperand(logicOrFlatten);
-        expected.addOperand(and1->clone().release());
-        expected.addOperand(and2->clone().release());
-        expected.addOperand(and3->clone().release());
+        expected.addOperand(and1->clone());
+        expected.addOperand(and2->clone());
+        expected.addOperand(and3->clone());
 
         auto newExpr = ExpressionUtils::flattenInnerLogicalExpr(&expr);
         ASSERT_EQ(expected, *newExpr);
@@ -513,104 +505,93 @@ TEST_F(ExpressionUtilsTest, splitFilter) {
         // true AND false AND true
         auto *first = ConstantExpression::make(pool, true);
         auto *second = ConstantExpression::make(pool, false);
-        auto *third = ConstantExpression::make(pooltrue);
+        auto *third = ConstantExpression::make(pool, true);
         auto expr = *LogicalExpression::makeAnd(
             pool, LogicalExpression::makeAnd(pool, first, second), third);
-        LogicalExpression expected1(Kind::kLogicalAnd);
-        expected1.addOperand(first->clone().release());
-        expected1.addOperand(third->clone().release());
+        auto expected1 = *LogicalExpression::makeAnd(pool);
+        expected1.addOperand(first->clone());
+        expected1.addOperand(third->clone());
         auto picker = [](const Expression *e) {
             if (e->kind() != Kind::kConstant) return false;
             auto &v = static_cast<const ConstantExpression *>(e)->value();
             if (v.type() != Value::Type::BOOL) return false;
             return v.getBool();
         };
-        Expression* newExpr1;
-        Expression* newExpr2;
-        ExpressionUtils::splitFilter(&expr, picker, &newExpr1, &newExpr2);
+        Expression *newExpr1 = nullptr;
+        Expression *newExpr2 = nullptr;
+        ExpressionUtils::splitFilter(pool, &expr, picker, &newExpr1, &newExpr2);
         ASSERT_EQ(expected1, *newExpr1);
         ASSERT_EQ(*second, *newExpr2);
     }
     {
         // true
-        auto expr = std::make_unique<ConstantExpression>(true);
+        auto expr = ConstantExpression::make(pool, true);
         auto picker = [](const Expression *e) {
             if (e->kind() != Kind::kConstant) return false;
             auto &v = static_cast<const ConstantExpression *>(e)->value();
             if (v.type() != Value::Type::BOOL) return false;
             return v.getBool();
         };
-        Expression* newExpr1;
-        Expression* newExpr2;
-        ExpressionUtils::splitFilter(expr.get(), picker, &newExpr1, &newExpr2);
+        Expression *newExpr1;
+        Expression *newExpr2;
+        ExpressionUtils::splitFilter(pool, expr, picker, &newExpr1, &newExpr2);
         ASSERT_EQ(*expr, *newExpr1);
         ASSERT_EQ(nullptr, newExpr2);
     }
 }
 
-Expression* parse(const std::string& expr) {
-    std::string query = "LOOKUP on t1 WHERE " + expr;
-    GQLParser parser;
-    auto result = parser.parse(std::move(query));
-    CHECK(result.ok()) << result.status();
-    auto stmt = std::move(result).value();
-    auto *seq = static_cast<SequentialSentences *>(stmt.get());
-    auto *lookup = static_cast<LookupSentence *>(seq->sentences()[0]);
-    return lookup->whereClause()->filter()->clone();
-}
-
 TEST_F(ExpressionUtilsTest, expandExpression) {
     {
         auto filter = parse("t1.c1 == 1");
-        auto target = ExpressionUtils::expandExpr(filter.get());
+        auto target = ExpressionUtils::expandExpr(pool, filter);
         auto expected = "(t1.c1==1)";
         ASSERT_EQ(expected, target->toString());
     }
     {
         auto filter = parse("t1.c1 == 1 and t1.c2 == 2");
-        auto target = ExpressionUtils::expandExpr(filter.get());
+        auto target = ExpressionUtils::expandExpr(pool, filter);
         auto expected = "((t1.c1==1) AND (t1.c2==2))";
         ASSERT_EQ(expected, target->toString());
     }
     {
         auto filter = parse("t1.c1 == 1 and t1.c2 == 2 and t1.c3 == 3");
-        auto target = ExpressionUtils::expandExpr(filter.get());
+        auto target = ExpressionUtils::expandExpr(pool, filter);
         auto expected = "(((t1.c1==1) AND (t1.c2==2)) AND (t1.c3==3))";
         ASSERT_EQ(expected, target->toString());
     }
     {
         auto filter = parse("t1.c1 == 1 or t1.c2 == 2");
-        auto target = ExpressionUtils::expandExpr(filter.get());
+        auto target = ExpressionUtils::expandExpr(pool, filter);
         auto expected = "((t1.c1==1) OR (t1.c2==2))";
         ASSERT_EQ(expected, target->toString());
     }
     {
         auto filter = parse("t1.c1 == 1 or t1.c2 == 2 or t1.c3 == 3");
-        auto target = ExpressionUtils::expandExpr(filter.get());
+        auto target = ExpressionUtils::expandExpr(pool, filter);
         auto expected = "(((t1.c1==1) OR (t1.c2==2)) OR (t1.c3==3))";
         ASSERT_EQ(expected, target->toString());
     }
     {
         auto filter = parse("t1.c1 == 1 and t1.c2 == 2 or t1.c1 == 3");
-        auto target = ExpressionUtils::expandExpr(filter.get());
+        auto target = ExpressionUtils::expandExpr(pool, filter);
         auto expected = "(((t1.c1==1) AND (t1.c2==2)) OR (t1.c1==3))";
         ASSERT_EQ(expected, target->toString());
     }
     {
         auto filter = parse("t1.c1 == 1 or t1.c2 == 2 and t1.c1 == 3");
-        auto target = ExpressionUtils::expandExpr(filter.get());
+        auto target = ExpressionUtils::expandExpr(pool, filter);
         auto expected = "((t1.c1==1) OR ((t1.c2==2) AND (t1.c1==3)))";
         ASSERT_EQ(expected, target->toString());
     }
     {
         auto filter = parse("(t1.c1 == 1 or t1.c2 == 2) and t1.c3 == 3");
-        auto target = ExpressionUtils::expandExpr(filter.get());
+        auto target = ExpressionUtils::expandExpr(pool, filter);
         auto expected = "(((t1.c1==1) AND (t1.c3==3)) OR ((t1.c2==2) AND (t1.c3==3)))";
         ASSERT_EQ(expected, target->toString());
     }
     {
         auto filter = parse("(t1.c1 == 1 or t1.c2 == 2) and t1.c3 == 3 or t1.c4 == 4");
-        auto target = ExpressionUtils::expandExpr(filter.get());
+        auto target = ExpressionUtils::expandExpr(pool, filter);
         auto expected = "((((t1.c1==1) AND (t1.c3==3)) OR "
                         "((t1.c2==2) AND (t1.c3==3))) OR "
                         "(t1.c4==4))";
@@ -618,7 +599,7 @@ TEST_F(ExpressionUtilsTest, expandExpression) {
     }
     {
         auto filter = parse("(t1.c1 == 1 or t1.c2 == 2) and (t1.c3 == 3 or t1.c4 == 4)");
-        auto target = ExpressionUtils::expandExpr(filter.get());
+        auto target = ExpressionUtils::expandExpr(pool, filter);
         auto expected = "(((((t1.c1==1) AND (t1.c3==3)) OR "
                         "((t1.c1==1) AND (t1.c4==4))) OR "
                         "((t1.c2==2) AND (t1.c3==3))) OR "
@@ -628,7 +609,7 @@ TEST_F(ExpressionUtilsTest, expandExpression) {
     {
         auto filter = parse("(t1.c1 == 1 or t1.c2 == 2 or t1.c3 == 3 or t1.c4 == 4) "
                             "and t1.c5 == 5");
-        auto target = ExpressionUtils::expandExpr(filter.get());
+        auto target = ExpressionUtils::expandExpr(pool, filter);
         auto expected = "(((((t1.c1==1) AND (t1.c5==5)) OR "
                         "((t1.c2==2) AND (t1.c5==5))) OR "
                         "((t1.c3==3) AND (t1.c5==5))) OR "
@@ -637,21 +618,21 @@ TEST_F(ExpressionUtilsTest, expandExpression) {
     }
     {
         auto filter = parse("(t1.c1 == 1 or t1.c2 == 2) and t1.c4 == 4 and t1.c5 == 5");
-        auto target = ExpressionUtils::expandExpr(filter.get());
+        auto target = ExpressionUtils::expandExpr(pool, filter);
         auto expected = "((((t1.c1==1) AND (t1.c4==4)) AND (t1.c5==5)) OR "
                         "(((t1.c2==2) AND (t1.c4==4)) AND (t1.c5==5)))";
         ASSERT_EQ(expected, target->toString());
     }
     {
         auto filter = parse("t1.c1 == 1 and (t1.c2 == 2 or t1.c4 == 4) and t1.c5 == 5");
-        auto target = ExpressionUtils::expandExpr(filter.get());
+        auto target = ExpressionUtils::expandExpr(pool, filter);
         auto expected = "((((t1.c1==1) AND (t1.c2==2)) AND (t1.c5==5)) OR "
                         "(((t1.c1==1) AND (t1.c4==4)) AND (t1.c5==5)))";
         ASSERT_EQ(expected, target->toString());
     }
     {
         auto filter = parse("t1.c1 == 1 and t1.c2 == 2 and (t1.c4 == 4 or t1.c5 == 5)");
-        auto target = ExpressionUtils::expandExpr(filter.get());
+        auto target = ExpressionUtils::expandExpr(pool, filter);
         auto expected = "((((t1.c1==1) AND (t1.c2==2)) AND (t1.c4==4)) OR "
                         "(((t1.c1==1) AND (t1.c2==2)) AND (t1.c5==5)))";
         ASSERT_EQ(expected, target->toString());
@@ -660,7 +641,7 @@ TEST_F(ExpressionUtilsTest, expandExpression) {
         auto filter = parse("(t1.c1 == 1 or t1.c2 == 2) and "
                             "(t1.c3 == 3 or t1.c4 == 4) and "
                             "t1.c5 == 5");
-        auto target = ExpressionUtils::expandExpr(filter.get());
+        auto target = ExpressionUtils::expandExpr(pool, filter);
         auto expected = "((((((t1.c1==1) AND (t1.c3==3)) AND (t1.c5==5)) OR "
                         "(((t1.c1==1) AND (t1.c4==4)) AND (t1.c5==5))) OR "
                         "(((t1.c2==2) AND (t1.c3==3)) AND (t1.c5==5))) OR "
@@ -669,7 +650,7 @@ TEST_F(ExpressionUtilsTest, expandExpression) {
     }
     {
         auto filter = parse("t1.c4 == 4 or (t1.c1 == 1 and (t1.c2 == 2 or t1.c3 == 3))");
-        auto target = ExpressionUtils::expandExpr(filter.get());
+        auto target = ExpressionUtils::expandExpr(pool, filter);
         auto expected = "((t1.c4==4) OR "
                         "(((t1.c1==1) AND (t1.c2==2)) OR "
                         "((t1.c1==1) AND (t1.c3==3))))";
@@ -679,7 +660,7 @@ TEST_F(ExpressionUtilsTest, expandExpression) {
         auto filter = parse("t1.c4 == 4 or "
                             "(t1.c1 == 1 and (t1.c2 == 2 or t1.c3 == 3)) or "
                             "t1.c5 == 5");
-        auto target = ExpressionUtils::expandExpr(filter.get());
+        auto target = ExpressionUtils::expandExpr(pool, filter);
         auto expected = "(((t1.c4==4) OR "
                         "(((t1.c1==1) AND (t1.c2==2)) OR ((t1.c1==1) AND (t1.c3==3)))) OR "
                         "(t1.c5==5))";
@@ -687,7 +668,7 @@ TEST_F(ExpressionUtilsTest, expandExpression) {
     }
     {
         auto filter = parse("t1.c1 == 1 and (t1.c2 == 2 or t1.c4) and t1.c5 == 5");
-        auto target = ExpressionUtils::expandExpr(filter.get());
+        auto target = ExpressionUtils::expandExpr(pool, filter);
         auto expected = "((((t1.c1==1) AND (t1.c2==2)) AND (t1.c5==5)) OR "
                         "(((t1.c1==1) AND t1.c4) AND (t1.c5==5)))";
         ASSERT_EQ(expected, target->toString());
@@ -695,7 +676,7 @@ TEST_F(ExpressionUtilsTest, expandExpression) {
     {
         // Invalid expression for index. don't need to expand.
         auto filter = parse("t1.c1 == 1 and (t1.c2 == 2 or t1.c4) == true and t1.c5 == 5");
-        auto target = ExpressionUtils::expandExpr(filter.get());
+        auto target = ExpressionUtils::expandExpr(pool, filter);
         auto expected = "(((t1.c1==1) AND (((t1.c2==2) OR t1.c4)==true)) AND (t1.c5==5))";
         ASSERT_EQ(expected, target->toString());
     }

--- a/src/util/test/ExpressionUtilsTest.cpp
+++ b/src/util/test/ExpressionUtilsTest.cpp
@@ -237,38 +237,38 @@ TEST_F(ExpressionUtilsTest, PullAnds) {
     {
         auto *first = ConstantExpression::make(pool, true);
         auto *second = ConstantExpression::make(pool, false);
-        auto expr = *LogicalExpression::makeAnd(pool, first, second);
-        auto expected = *LogicalExpression::makeAnd(pool, first->clone(), second->clone());
-        ExpressionUtils::pullAnds(&expr);
-        ASSERT_EQ(expected, expr);
+        auto expr = LogicalExpression::makeAnd(pool, first, second);
+        auto expected = LogicalExpression::makeAnd(pool, first->clone(), second->clone());
+        ExpressionUtils::pullAnds(expr);
+        ASSERT_EQ(*expected, *expr);
     }
     // true AND false AND true
     {
         auto *first = ConstantExpression::make(pool, true);
         auto *second = ConstantExpression::make(pool, false);
         auto *third = ConstantExpression::make(pool, true);
-        auto expr = *LogicalExpression::makeAnd(
+        auto expr = LogicalExpression::makeAnd(
             pool, LogicalExpression::makeAnd(pool, first, second), third);
-        auto expected = *LogicalExpression::makeAnd(pool);
-        expected.addOperand(first->clone());
-        expected.addOperand(second->clone());
-        expected.addOperand(third->clone());
-        ExpressionUtils::pullAnds(&expr);
-        ASSERT_EQ(expected, expr);
+        auto expected = LogicalExpression::makeAnd(pool);
+        expected->addOperand(first->clone());
+        expected->addOperand(second->clone());
+        expected->addOperand(third->clone());
+        ExpressionUtils::pullAnds(expr);
+        ASSERT_EQ(*expected, *expr);
     }
     // true AND (false AND true)
     {
         auto *first = ConstantExpression::make(pool, true);
         auto *second = ConstantExpression::make(pool, false);
         auto *third = ConstantExpression::make(pool, true);
-        auto expr = *LogicalExpression::makeAnd(
+        auto expr = LogicalExpression::makeAnd(
             pool, first, LogicalExpression::makeAnd(pool, second, third));
-        auto expected = *LogicalExpression::makeAnd(pool);
-        expected.addOperand(first->clone());
-        expected.addOperand(second->clone());
-        expected.addOperand(third->clone());
-        ExpressionUtils::pullAnds(&expr);
-        ASSERT_EQ(expected, expr);
+        auto expected = LogicalExpression::makeAnd(pool);
+        expected->addOperand(first->clone());
+        expected->addOperand(second->clone());
+        expected->addOperand(third->clone());
+        ExpressionUtils::pullAnds(expr);
+        ASSERT_EQ(*expected, *expr);
     }
     // (true OR false) AND (true OR false)
     {
@@ -276,12 +276,12 @@ TEST_F(ExpressionUtilsTest, PullAnds) {
             pool, ConstantExpression::make(pool, true), ConstantExpression::make(pool, false));
         auto *second = LogicalExpression::makeOr(
             pool, ConstantExpression::make(pool, true), ConstantExpression::make(pool, false));
-        auto expr = *LogicalExpression::makeAnd(pool, first, second);
-        auto expected = *LogicalExpression::makeAnd(pool);
-        expected.addOperand(first->clone());
-        expected.addOperand(second->clone());
-        ExpressionUtils::pullAnds(&expr);
-        ASSERT_EQ(expected, expr);
+        auto expr = LogicalExpression::makeAnd(pool, first, second);
+        auto expected = LogicalExpression::makeAnd(pool);
+        expected->addOperand(first->clone());
+        expected->addOperand(second->clone());
+        ExpressionUtils::pullAnds(expr);
+        ASSERT_EQ(*expected, *expr);
     }
     // true AND ((false AND true) OR false) AND true
     {
@@ -292,14 +292,14 @@ TEST_F(ExpressionUtilsTest, PullAnds) {
                 pool, ConstantExpression::make(pool, false), ConstantExpression::make(pool, true)),
             ConstantExpression::make(pool, false));
         auto *third = ConstantExpression::make(pool, true);
-        auto expr = *LogicalExpression::makeAnd(
+        auto expr = LogicalExpression::makeAnd(
             pool, LogicalExpression::makeAnd(pool, first, second), third);
-        auto expected = *LogicalExpression::makeAnd(pool);
-        expected.addOperand(first->clone());
-        expected.addOperand(second->clone());
-        expected.addOperand(third->clone());
-        ExpressionUtils::pullAnds(&expr);
-        ASSERT_EQ(expected, expr);
+        auto expected = LogicalExpression::makeAnd(pool);
+        expected->addOperand(first->clone());
+        expected->addOperand(second->clone());
+        expected->addOperand(third->clone());
+        ExpressionUtils::pullAnds(expr);
+        ASSERT_EQ(*expected, *expr);
     }
 }
 
@@ -308,10 +308,10 @@ TEST_F(ExpressionUtilsTest, PullOrs) {
     {
         auto *first = ConstantExpression::make(pool, true);
         auto *second = ConstantExpression::make(pool, false);
-        auto expr = *LogicalExpression::makeOr(pool, first, second);
-        auto expected = *LogicalExpression::makeOr(pool, first->clone(), second->clone());
-        ExpressionUtils::pullOrs(&expr);
-        ASSERT_EQ(expected, expr);
+        auto expr = LogicalExpression::makeOr(pool, first, second);
+        auto expected = LogicalExpression::makeOr(pool, first->clone(), second->clone());
+        ExpressionUtils::pullOrs(expr);
+        ASSERT_EQ(*expected, *expr);
     }
     // true OR false OR true
     {
@@ -319,13 +319,13 @@ TEST_F(ExpressionUtilsTest, PullOrs) {
         auto *second = ConstantExpression::make(pool, false);
         auto *third = ConstantExpression::make(pool, true);
         auto expr =
-            *LogicalExpression::makeOr(pool, LogicalExpression::makeOr(pool, first, second), third);
-        auto expected = *LogicalExpression::makeOr(pool);
-        expected.addOperand(first->clone());
-        expected.addOperand(second->clone());
-        expected.addOperand(third->clone());
-        ExpressionUtils::pullOrs(&expr);
-        ASSERT_EQ(expected, expr);
+            LogicalExpression::makeOr(pool, LogicalExpression::makeOr(pool, first, second), third);
+        auto expected = LogicalExpression::makeOr(pool);
+        expected->addOperand(first->clone());
+        expected->addOperand(second->clone());
+        expected->addOperand(third->clone());
+        ExpressionUtils::pullOrs(expr);
+        ASSERT_EQ(*expected, *expr);
     }
     // true OR (false OR true)
     {
@@ -333,13 +333,13 @@ TEST_F(ExpressionUtilsTest, PullOrs) {
         auto *second = ConstantExpression::make(pool, false);
         auto *third = ConstantExpression::make(pool, true);
         auto expr =
-            *LogicalExpression::makeOr(pool, first, LogicalExpression::makeOr(pool, second, third));
-        auto expected = *LogicalExpression::makeOr(pool);
-        expected.addOperand(first->clone());
-        expected.addOperand(second->clone());
-        expected.addOperand(third->clone());
-        ExpressionUtils::pullOrs(&expr);
-        ASSERT_EQ(expected, expr);
+            LogicalExpression::makeOr(pool, first, LogicalExpression::makeOr(pool, second, third));
+        auto expected = LogicalExpression::makeOr(pool);
+        expected->addOperand(first->clone());
+        expected->addOperand(second->clone());
+        expected->addOperand(third->clone());
+        ExpressionUtils::pullOrs(expr);
+        ASSERT_EQ(*expected, *expr);
     }
     // (true AND false) OR (true AND false)
     {
@@ -347,10 +347,10 @@ TEST_F(ExpressionUtilsTest, PullOrs) {
             pool, ConstantExpression::make(pool, true), ConstantExpression::make(pool, false));
         auto *second = LogicalExpression::makeAnd(
             pool, ConstantExpression::make(pool, true), ConstantExpression::make(pool, false));
-        auto expr = *LogicalExpression::makeOr(pool, first, second);
-        auto expected = *LogicalExpression::makeOr(pool, first->clone(), second->clone());
-        ExpressionUtils::pullOrs(&expr);
-        ASSERT_EQ(expected, expr);
+        auto expr = LogicalExpression::makeOr(pool, first, second);
+        auto expected = LogicalExpression::makeOr(pool, first->clone(), second->clone());
+        ExpressionUtils::pullOrs(expr);
+        ASSERT_EQ(*expected, *expr);
     }
     // true OR ((false OR true) AND false) OR true
     {
@@ -362,13 +362,13 @@ TEST_F(ExpressionUtilsTest, PullOrs) {
             ConstantExpression::make(pool, false));
         auto *third = ConstantExpression::make(pool, true);
         auto expr =
-            *LogicalExpression::makeOr(pool, LogicalExpression::makeOr(pool, first, second), third);
-        auto expected = *LogicalExpression::makeOr(pool);
-        expected.addOperand(first->clone());
-        expected.addOperand(second->clone());
-        expected.addOperand(third->clone());
-        ExpressionUtils::pullOrs(&expr);
-        ASSERT_EQ(expected, expr);
+            LogicalExpression::makeOr(pool, LogicalExpression::makeOr(pool, first, second), third);
+        auto expected = LogicalExpression::makeOr(pool);
+        expected->addOperand(first->clone());
+        expected->addOperand(second->clone());
+        expected->addOperand(third->clone());
+        ExpressionUtils::pullOrs(expr);
+        ASSERT_EQ(*expected, *expr);
     }
 }
 
@@ -420,14 +420,14 @@ TEST_F(ExpressionUtilsTest, flattenInnerLogicalExpr) {
         auto *first = ConstantExpression::make(pool, true);
         auto *second = ConstantExpression::make(pool, false);
         auto *third = ConstantExpression::make(pool, true);
-        auto expr = *LogicalExpression::makeAnd(
+        auto expr = LogicalExpression::makeAnd(
             pool, LogicalExpression::makeAnd(pool, first, second), third);
-        auto expected = *LogicalExpression::makeAnd(pool);
-        expected.addOperand(first->clone());
-        expected.addOperand(second->clone());
-        expected.addOperand(third->clone());
-        auto newExpr = ExpressionUtils::flattenInnerLogicalExpr(&expr);
-        ASSERT_EQ(expected, *newExpr);
+        auto expected = LogicalExpression::makeAnd(pool);
+        expected->addOperand(first->clone());
+        expected->addOperand(second->clone());
+        expected->addOperand(third->clone());
+        auto newExpr = ExpressionUtils::flattenInnerLogicalExpr(expr);
+        ASSERT_EQ(*expected, *newExpr);
     }
     // true OR false OR true
     {
@@ -435,13 +435,13 @@ TEST_F(ExpressionUtilsTest, flattenInnerLogicalExpr) {
         auto *second = ConstantExpression::make(pool, false);
         auto *third = ConstantExpression::make(pool, true);
         auto expr =
-            *LogicalExpression::makeOr(pool, LogicalExpression::makeOr(pool, first, second), third);
-        auto expected = *LogicalExpression::makeOr(pool);
-        expected.addOperand(first->clone());
-        expected.addOperand(second->clone());
-        expected.addOperand(third->clone());
-        auto newExpr = ExpressionUtils::flattenInnerLogicalExpr(&expr);
-        ASSERT_EQ(expected, *newExpr);
+            LogicalExpression::makeOr(pool, LogicalExpression::makeOr(pool, first, second), third);
+        auto expected = LogicalExpression::makeOr(pool);
+        expected->addOperand(first->clone());
+        expected->addOperand(second->clone());
+        expected->addOperand(third->clone());
+        auto newExpr = ExpressionUtils::flattenInnerLogicalExpr(expr);
+        ASSERT_EQ(*expected, *newExpr);
     }
     // (true OR false OR true)==(true AND false AND true)
     {
@@ -455,7 +455,7 @@ TEST_F(ExpressionUtilsTest, flattenInnerLogicalExpr) {
         auto *and3 = ConstantExpression::make(pool, true);
         auto *logicAndExpr =
             LogicalExpression::makeAnd(pool, LogicalExpression::makeAnd(pool, and1, and2), and3);
-        auto expr = *RelationalExpression ::makeEQ(pool, logicOrExpr, logicAndExpr);
+        auto expr = RelationalExpression ::makeEQ(pool, logicOrExpr, logicAndExpr);
 
         auto *logicOrFlatten = LogicalExpression::makeOr(pool);
         logicOrFlatten->addOperand(or1->clone());
@@ -465,10 +465,10 @@ TEST_F(ExpressionUtilsTest, flattenInnerLogicalExpr) {
         logicAndFlatten->addOperand(and1->clone());
         logicAndFlatten->addOperand(and2->clone());
         logicAndFlatten->addOperand(and3->clone());
-        auto expected = *RelationalExpression ::makeEQ(pool, logicOrFlatten, logicAndFlatten);
+        auto expected = RelationalExpression ::makeEQ(pool, logicOrFlatten, logicAndFlatten);
 
-        auto newExpr = ExpressionUtils::flattenInnerLogicalExpr(&expr);
-        ASSERT_EQ(expected, *newExpr);
+        auto newExpr = ExpressionUtils::flattenInnerLogicalExpr(expr);
+        ASSERT_EQ(*expected, *newExpr);
     }
     // (true OR false OR true) AND (true AND false AND true)
     {
@@ -482,20 +482,20 @@ TEST_F(ExpressionUtilsTest, flattenInnerLogicalExpr) {
         auto *and3 = ConstantExpression::make(pool, true);
         auto *logicAndExpr =
             LogicalExpression::makeAnd(pool, LogicalExpression::makeAnd(pool, and1, and2), and3);
-        auto expr = *LogicalExpression::makeAnd(pool, logicOrExpr, logicAndExpr);
+        auto expr = LogicalExpression::makeAnd(pool, logicOrExpr, logicAndExpr);
 
         auto *logicOrFlatten = LogicalExpression::makeOr(pool);
         logicOrFlatten->addOperand(or1->clone());
         logicOrFlatten->addOperand(or2->clone());
         logicOrFlatten->addOperand(or3->clone());
-        auto expected = *LogicalExpression::makeAnd(pool);
-        expected.addOperand(logicOrFlatten);
-        expected.addOperand(and1->clone());
-        expected.addOperand(and2->clone());
-        expected.addOperand(and3->clone());
+        auto expected = LogicalExpression::makeAnd(pool);
+        expected->addOperand(logicOrFlatten);
+        expected->addOperand(and1->clone());
+        expected->addOperand(and2->clone());
+        expected->addOperand(and3->clone());
 
-        auto newExpr = ExpressionUtils::flattenInnerLogicalExpr(&expr);
-        ASSERT_EQ(expected, *newExpr);
+        auto newExpr = ExpressionUtils::flattenInnerLogicalExpr(expr);
+        ASSERT_EQ(*expected, *newExpr);
     }
 }
 
@@ -506,11 +506,11 @@ TEST_F(ExpressionUtilsTest, splitFilter) {
         auto *first = ConstantExpression::make(pool, true);
         auto *second = ConstantExpression::make(pool, false);
         auto *third = ConstantExpression::make(pool, true);
-        auto expr = *LogicalExpression::makeAnd(
+        auto expr = LogicalExpression::makeAnd(
             pool, LogicalExpression::makeAnd(pool, first, second), third);
-        auto expected1 = *LogicalExpression::makeAnd(pool);
-        expected1.addOperand(first->clone());
-        expected1.addOperand(third->clone());
+        auto expected1 = LogicalExpression::makeAnd(pool);
+        expected1->addOperand(first->clone());
+        expected1->addOperand(third->clone());
         auto picker = [](const Expression *e) {
             if (e->kind() != Kind::kConstant) return false;
             auto &v = static_cast<const ConstantExpression *>(e)->value();
@@ -519,8 +519,8 @@ TEST_F(ExpressionUtilsTest, splitFilter) {
         };
         Expression *newExpr1 = nullptr;
         Expression *newExpr2 = nullptr;
-        ExpressionUtils::splitFilter(pool, &expr, picker, &newExpr1, &newExpr2);
-        ASSERT_EQ(expected1, *newExpr1);
+        ExpressionUtils::splitFilter(pool, expr, picker, &newExpr1, &newExpr2);
+        ASSERT_EQ(*expected1, *newExpr1);
         ASSERT_EQ(*second, *newExpr2);
     }
     {

--- a/src/util/test/ExpressionUtilsTest.cpp
+++ b/src/util/test/ExpressionUtilsTest.cpp
@@ -532,8 +532,8 @@ TEST_F(ExpressionUtilsTest, splitFilter) {
             if (v.type() != Value::Type::BOOL) return false;
             return v.getBool();
         };
-        Expression *newExpr1;
-        Expression *newExpr2;
+        Expression *newExpr1 = nullptr;
+        Expression *newExpr2 = nullptr;
         ExpressionUtils::splitFilter(pool, expr, picker, &newExpr1, &newExpr2);
         ASSERT_EQ(*expr, *newExpr1);
         ASSERT_EQ(nullptr, newExpr2);

--- a/src/util/test/IdGeneratorTest.cpp
+++ b/src/util/test/IdGeneratorTest.cpp
@@ -12,19 +12,21 @@
 namespace nebula {
 namespace graph {
 TEST(IdGeneratorTest, gen) {
+    // Use the current id as the start id
+    const int64_t curId = EPIdGenerator::instance().id() + 1;
     nebula::concurrent::Barrier bar(3);
     std::vector<int64_t> ids1;
-    auto t1 = std::thread([&ids1, &bar] () {
+    auto t1 = std::thread([&ids1, &bar, &curId]() {
         for (auto i = 0; i < 5; ++i) {
-            ids1.emplace_back(EPIdGenerator::instance().id());
+            ids1.emplace_back(EPIdGenerator::instance().id() - curId);
         }
         bar.wait();
     });
 
     std::vector<int64_t> ids2;
-    auto t2 = std::thread([&ids2, &bar] () {
+    auto t2 = std::thread([&ids2, &bar, &curId]() {
         for (auto i = 0; i < 5; ++i) {
-            ids2.emplace_back(EPIdGenerator::instance().id());
+            ids2.emplace_back(EPIdGenerator::instance().id() - curId);
         }
         bar.wait();
     });

--- a/src/validator/FetchEdgesValidator.cpp
+++ b/src/validator/FetchEdgesValidator.cpp
@@ -66,7 +66,8 @@ Status FetchEdgesValidator::toPlan() {
         }
     } else {
         auto *columns = qctx_->objPool()->add(new YieldColumns());
-        columns->addColumn(new YieldColumn(new EdgeExpression(), "edges_"));
+        auto *pool = qctx_->objPool();
+        columns->addColumn(new YieldColumn(EdgeExpression::make(pool), "edges_"));
         current = Project::make(qctx_, current, columns);
     }
     root_ = current;
@@ -164,10 +165,11 @@ Status FetchEdgesValidator::preparePropertiesWithYield(const YieldClause *yield)
     storage::cpp2::EdgeProp prop;
     prop.set_type(edgeType_);
     // insert the reserved properties expression be compatible with 1.0
+    auto *pool = qctx_->objPool();
     auto *newYieldColumns = new YieldColumns();
-    newYieldColumns->addColumn(new YieldColumn(new EdgeSrcIdExpression(edgeTypeName_)));
-    newYieldColumns->addColumn(new YieldColumn(new EdgeDstIdExpression(edgeTypeName_)));
-    newYieldColumns->addColumn(new YieldColumn(new EdgeRankExpression(edgeTypeName_)));
+    newYieldColumns->addColumn(new YieldColumn(EdgeSrcIdExpression::make(pool, edgeTypeName_)));
+    newYieldColumns->addColumn(new YieldColumn(EdgeDstIdExpression::make(pool, edgeTypeName_)));
+    newYieldColumns->addColumn(new YieldColumn(EdgeRankExpression::make(pool, edgeTypeName_)));
     for (auto col : yield->columns()) {
         newYieldColumns->addColumn(col->clone().release());
     }
@@ -180,7 +182,7 @@ Status FetchEdgesValidator::preparePropertiesWithYield(const YieldClause *yield)
     propsName.reserve(newYield_->columns().size());
     dedup_ = newYield_->isDistinct();
     for (auto col : newYield_->columns()) {
-        col->setExpr(ExpressionUtils::rewriteLabelAttr2EdgeProp(col->expr()));
+        col->setExpr(ExpressionUtils::rewriteLabelAttr2EdgeProp(pool, col->expr()));
         NG_RETURN_IF_ERROR(invalidLabelIdentifiers(col->expr()));
         const auto *invalidExpr = findInvalidYieldExpression(col->expr());
         if (invalidExpr != nullptr) {
@@ -263,17 +265,17 @@ std::string FetchEdgesValidator::buildConstantInput() {
     auto input = vctx_->anonVarGen()->getVar();
     qctx_->ectx()->setResult(input, ResultBuilder().value(Value(std::move(edgeKeys_))).finish());
 
-    src_ = pool->makeAndAdd<VariablePropertyExpression>(input, kSrc);
-    type_ = pool->makeAndAdd<ConstantExpression>(edgeType_);
-    rank_ = pool->makeAndAdd<VariablePropertyExpression>(input, kRank);
-    dst_ = pool->makeAndAdd<VariablePropertyExpression>(input, kDst);
+    src_ = VariablePropertyExpression::make(pool, input, kSrc);
+    type_ = ConstantExpression::make(pool, edgeType_);
+    rank_ = VariablePropertyExpression::make(pool, input, kRank);
+    dst_ = VariablePropertyExpression::make(pool, input, kDst);
     return input;
 }
 
 std::string FetchEdgesValidator::buildRuntimeInput() {
     auto pool = qctx_->objPool();
     src_ = DCHECK_NOTNULL(srcRef_);
-    type_ = pool->makeAndAdd<ConstantExpression>(edgeType_);
+    type_ = ConstantExpression::make(pool, edgeType_);
     rank_ = DCHECK_NOTNULL(rankRef_);
     dst_ = DCHECK_NOTNULL(dstRef_);
     return inputVar_;
@@ -282,9 +284,10 @@ std::string FetchEdgesValidator::buildRuntimeInput() {
 Expression *FetchEdgesValidator::emptyEdgeKeyFilter() {
     // _src != empty && _dst != empty && _rank != empty
     DCHECK_GE(geColNames_.size(), 3);
-    auto *srcNotEmptyExpr = notEmpty(new EdgeSrcIdExpression(edgeTypeName_));
-    auto *dstNotEmptyExpr = notEmpty(new EdgeDstIdExpression(edgeTypeName_));
-    auto *rankNotEmptyExpr = notEmpty(new EdgeRankExpression(edgeTypeName_));
+    auto *pool = qctx_->objPool();
+    auto *srcNotEmptyExpr = notEmpty(EdgeSrcIdExpression::make(pool, edgeTypeName_));
+    auto *dstNotEmptyExpr = notEmpty(EdgeDstIdExpression::make(pool, edgeTypeName_));
+    auto *rankNotEmptyExpr = notEmpty(EdgeRankExpression::make(pool, edgeTypeName_));
     auto *edgeKeyNotEmptyExpr =
         qctx_->objPool()->add(lgAnd(srcNotEmptyExpr, lgAnd(dstNotEmptyExpr, rankNotEmptyExpr)));
     return edgeKeyNotEmptyExpr;

--- a/src/validator/FetchEdgesValidator.cpp
+++ b/src/validator/FetchEdgesValidator.cpp
@@ -288,8 +288,7 @@ Expression *FetchEdgesValidator::emptyEdgeKeyFilter() {
     auto *srcNotEmptyExpr = notEmpty(EdgeSrcIdExpression::make(pool, edgeTypeName_));
     auto *dstNotEmptyExpr = notEmpty(EdgeDstIdExpression::make(pool, edgeTypeName_));
     auto *rankNotEmptyExpr = notEmpty(EdgeRankExpression::make(pool, edgeTypeName_));
-    auto *edgeKeyNotEmptyExpr =
-        qctx_->objPool()->add(lgAnd(srcNotEmptyExpr, lgAnd(dstNotEmptyExpr, rankNotEmptyExpr)));
+    auto *edgeKeyNotEmptyExpr = lgAnd(srcNotEmptyExpr, lgAnd(dstNotEmptyExpr, rankNotEmptyExpr));
     return edgeKeyNotEmptyExpr;
 }
 

--- a/src/validator/FetchEdgesValidator.h
+++ b/src/validator/FetchEdgesValidator.h
@@ -40,13 +40,15 @@ private:
     std::string buildRuntimeInput();
 
     Expression* notEmpty(Expression* expr) {
-        return new RelationalExpression(
-            Expression::Kind::kRelNE, new ConstantExpression(Value::kEmpty), DCHECK_NOTNULL(expr));
+        return RelationalExpression::makeNE(
+            qctx_->objPool(),
+            ConstantExpression::make(qctx_->objPool(), Value::kEmpty),
+            DCHECK_NOTNULL(expr));
     }
 
     Expression* lgAnd(Expression* left, Expression* right) {
-        return new LogicalExpression(
-            Expression::Kind::kLogicalAnd, DCHECK_NOTNULL(left), DCHECK_NOTNULL(right));
+        return LogicalExpression::makeAnd(
+            qctx_->objPool(), DCHECK_NOTNULL(left), DCHECK_NOTNULL(right));
     }
 
     Expression* emptyEdgeKeyFilter();

--- a/src/validator/FindPathValidator.cpp
+++ b/src/validator/FindPathValidator.cpp
@@ -45,7 +45,8 @@ Status FindPathValidator::validateWhere(WhereClause* where) {
         return Status::SemanticError("Not support `%s' in where sentence.",
                                      expr->toString().c_str());
     }
-    where->setFilter(ExpressionUtils::rewriteLabelAttr2EdgeProp(expr));
+    auto* pool = qctx_->objPool();
+    where->setFilter(ExpressionUtils::rewriteLabelAttr2EdgeProp(pool, expr));
     auto filter = where->filter();
 
     auto typeStatus = deduceExprType(filter);

--- a/src/validator/GetSubgraphValidator.cpp
+++ b/src/validator/GetSubgraphValidator.cpp
@@ -138,12 +138,8 @@ Status GetSubgraphValidator::zeroStep(PlanNode* depend, const std::string& input
     auto* pool = qctx_->objPool();
     auto* column = VertexExpression::make(pool);
     auto* func = AggregateExpression::make(pool, "COLLECT", column, false);
-    qctx_->objPool()->add(func);
-    auto* collectVertex =
-        Aggregate::make(qctx_,
-                        getVertex,
-                        {},
-                        {func});
+
+    auto* collectVertex = Aggregate::make(qctx_, getVertex, {}, {func});
     collectVertex->setColNames({"_vertices"});
 
     root_ = collectVertex;
@@ -184,7 +180,6 @@ Status GetSubgraphValidator::toPlan() {
     subgraph->setColNames({nebula::kVid});
 
     auto* loopCondition = buildExpandCondition(gn->outputVar(), steps_.steps() + 1);
-    qctx_->objPool()->add(loopCondition);
     auto* loop = Loop::make(qctx_, loopDep, subgraph, loopCondition);
 
     auto* dc = DataCollect::make(qctx_, DataCollect::DCKind::kSubgraph);

--- a/src/validator/GetSubgraphValidator.cpp
+++ b/src/validator/GetSubgraphValidator.cpp
@@ -135,8 +135,9 @@ Status GetSubgraphValidator::zeroStep(PlanNode* depend, const std::string& input
     getVertex->setInputVar(inputVar);
 
     auto var = vctx_->anonVarGen()->getVar();
-    auto* column = new VertexExpression();
-    auto* func = new AggregateExpression("COLLECT", column, false);
+    auto* pool = qctx_->objPool();
+    auto* column = VertexExpression::make(pool);
+    auto* func = AggregateExpression::make(pool, "COLLECT", column, false);
     qctx_->objPool()->add(func);
     auto* collectVertex =
         Aggregate::make(qctx_,

--- a/src/validator/GoValidator.cpp
+++ b/src/validator/GoValidator.cpp
@@ -194,7 +194,6 @@ Status GoValidator::buildColumns() {
     const auto& inputProps = exprProps.inputProps();
     const auto& varProps = exprProps.varProps();
     const auto& from = goCtx_->from;
-    auto* pool = qctx_->objPool();
 
     if (dstTagProps.empty() && inputProps.empty() && varProps.empty() &&
         from.fromType == FromType::kInstantExpr) {
@@ -219,7 +218,6 @@ Status GoValidator::buildColumns() {
         extractPropExprs(filter);
         auto newFilter = filter->clone();
         goCtx_->filter = rewrite2VarProp(newFilter);
-        pool->add(goCtx_->filter);
     }
 
     auto* newYieldExpr = pool->add(new YieldColumns());

--- a/src/validator/GoValidator.cpp
+++ b/src/validator/GoValidator.cpp
@@ -56,9 +56,9 @@ Status GoValidator::validateWhere(WhereClause* where) {
         return Status::SemanticError("`%s', not support aggregate function in where sentence.",
                                      expr->toString().c_str());
     }
-    where->setFilter(ExpressionUtils::rewriteLabelAttr2EdgeProp(expr));
     auto pool = qctx()->objPool();
-    auto foldRes = ExpressionUtils::foldConstantExpr(where->filter(), pool);
+    where->setFilter(ExpressionUtils::rewriteLabelAttr2EdgeProp(pool, expr));
+    auto foldRes = ExpressionUtils::foldConstantExpr(pool, where->filter());
     NG_RETURN_IF_ERROR(foldRes);
 
     auto filter = foldRes.value();
@@ -123,13 +123,14 @@ Status GoValidator::validateYield(YieldClause* yield) {
     }
     goCtx_->distinct = yield->isDistinct();
     const auto& over = goCtx_->over;
+    auto* pool = qctx_->objPool();
 
     auto cols = yield->columns();
     if (cols.empty() && over.isOverAll) {
         DCHECK(!over.allEdges.empty());
         auto* newCols = qctx_->objPool()->add(new YieldColumns());
         for (const auto& e : over.allEdges) {
-            auto* col = new YieldColumn(new EdgeDstIdExpression(e));
+            auto* col = new YieldColumn(EdgeDstIdExpression::make(pool, e));
             newCols->addColumn(col);
             outputs_.emplace_back(col->name(), vidType_);
             NG_RETURN_IF_ERROR(deduceProps(col->expr(), goCtx_->exprProps));
@@ -140,7 +141,7 @@ Status GoValidator::validateYield(YieldClause* yield) {
     }
 
     for (auto col : cols) {
-        col->setExpr(ExpressionUtils::rewriteLabelAttr2EdgeProp(col->expr()));
+        col->setExpr(ExpressionUtils::rewriteLabelAttr2EdgeProp(pool, col->expr()));
         NG_RETURN_IF_ERROR(invalidLabelIdentifiers(col->expr()));
 
         auto* colExpr = col->expr();
@@ -181,7 +182,7 @@ Expression* GoValidator::rewrite2VarProp(const Expression* expr) {
     auto rewriter = [this](const Expression* e) -> Expression* {
         auto iter = propExprColMap_.find(e->toString());
         DCHECK(iter != propExprColMap_.end());
-        return new VariablePropertyExpression("", iter->second->alias());
+        return VariablePropertyExpression::make(qctx_->objPool(), "", iter->second->alias());
     };
 
     return RewriteVisitor::transform(expr, matcher, rewriter);
@@ -193,6 +194,7 @@ Status GoValidator::buildColumns() {
     const auto& inputProps = exprProps.inputProps();
     const auto& varProps = exprProps.varProps();
     const auto& from = goCtx_->from;
+    auto* pool = qctx_->objPool();
 
     if (dstTagProps.empty() && inputProps.empty() && varProps.empty() &&
         from.fromType == FromType::kInstantExpr) {
@@ -216,7 +218,7 @@ Status GoValidator::buildColumns() {
     if (filter != nullptr) {
         extractPropExprs(filter);
         auto newFilter = filter->clone();
-        goCtx_->filter = rewrite2VarProp(newFilter.get());
+        goCtx_->filter = rewrite2VarProp(newFilter);
         pool->add(goCtx_->filter);
     }
 

--- a/src/validator/GroupByValidator.cpp
+++ b/src/validator/GroupByValidator.cpp
@@ -49,7 +49,7 @@ Status GroupByValidator::validateYield(const YieldClause* yieldClause) {
                                                  colExpr->toString().c_str());
                 }
 
-                groupItems_.emplace_back(pool->add(agg->clone()));
+                groupItems_.emplace_back(agg->clone());
                 needGenProject_ = true;
                 outputColumnNames_.emplace_back(agg->toString());
             }

--- a/src/validator/GroupByValidator.cpp
+++ b/src/validator/GroupByValidator.cpp
@@ -32,14 +32,15 @@ Status GroupByValidator::validateYield(const YieldClause* yieldClause) {
         return Status::SemanticError("Yield cols is Empty");
     }
 
-    projCols_ = qctx_->objPool()->add(new YieldColumns);
+    auto* pool = qctx_->objPool();
+    projCols_ = pool->add(new YieldColumns);
     for (auto* col : columns) {
         auto colOldName = col->name();
         auto* colExpr = col->expr();
         if (col->expr()->kind() != Expression::Kind::kAggregate) {
             auto collectAggCol = colExpr->clone();
             auto aggs =
-                ExpressionUtils::collectAll(collectAggCol.get(), {Expression::Kind::kAggregate});
+                ExpressionUtils::collectAll(collectAggCol, {Expression::Kind::kAggregate});
             for (auto* agg : aggs) {
                 DCHECK_EQ(agg->kind(), Expression::Kind::kAggregate);
                 if (!ExpressionUtils::checkAggExpr(static_cast<const AggregateExpression*>(agg))
@@ -48,12 +49,12 @@ Status GroupByValidator::validateYield(const YieldClause* yieldClause) {
                                                  colExpr->toString().c_str());
                 }
 
-                groupItems_.emplace_back(qctx_->objPool()->add(agg->clone().release()));
+                groupItems_.emplace_back(pool->add(agg->clone()));
                 needGenProject_ = true;
                 outputColumnNames_.emplace_back(agg->toString());
             }
             if (!aggs.empty()) {
-                auto* colRewrited = ExpressionUtils::rewriteAgg2VarProp(colExpr);
+                auto* colRewrited = ExpressionUtils::rewriteAgg2VarProp(pool, colExpr);
                 projCols_->addColumn(new YieldColumn(colRewrited, colOldName));
                 continue;
             }
@@ -74,7 +75,7 @@ Status GroupByValidator::validateYield(const YieldClause* yieldClause) {
         auto type = std::move(status).value();
 
         projCols_->addColumn(
-            new YieldColumn(new VariablePropertyExpression("", colOldName), colOldName));
+            new YieldColumn(VariablePropertyExpression::make(pool, "", colOldName), colOldName));
 
         outputs_.emplace_back(colOldName, type);
         outputColumnNames_.emplace_back(colOldName);

--- a/src/validator/LookupValidator.cpp
+++ b/src/validator/LookupValidator.cpp
@@ -241,8 +241,7 @@ StatusOr<Expression*> LookupValidator::rewriteRelExpr(RelationalExpression* expr
     // so that LabelAttributeExpr is always on the left
     auto right = expr->right();
     if (right->kind() == Expression::Kind::kLabelAttribute) {
-        expr = qctx_->objPool()->add(
-            static_cast<RelationalExpression*>(reverseRelKind(expr)));
+        expr = static_cast<RelationalExpression*>(reverseRelKind(expr));
     }
 
     auto left = expr->left();

--- a/src/validator/LookupValidator.cpp
+++ b/src/validator/LookupValidator.cpp
@@ -93,18 +93,19 @@ Status LookupValidator::prepareYield() {
     if (sentence->yieldClause()->isDistinct()) {
         dedup_ = true;
     }
-    newYieldColumns_ = qctx_->objPool()->makeAndAdd<YieldColumns>();
+    auto* pool = qctx_->objPool();
+    newYieldColumns_ = pool->makeAndAdd<YieldColumns>();
     if (isEdge_) {
         // default columns
         newYieldColumns_->addColumn(
-            new YieldColumn(new InputPropertyExpression(kSrcVID), kSrcVID));
+            new YieldColumn(InputPropertyExpression::make(pool, kSrcVID), kSrcVID));
         newYieldColumns_->addColumn(
-            new YieldColumn(new InputPropertyExpression(kDstVID), kDstVID));
+            new YieldColumn(InputPropertyExpression::make(pool, kDstVID), kDstVID));
         newYieldColumns_->addColumn(
-            new YieldColumn(new InputPropertyExpression(kRanking), kRanking));
+            new YieldColumn(InputPropertyExpression::make(pool, kRanking), kRanking));
     } else {
         newYieldColumns_->addColumn(
-            new YieldColumn(new InputPropertyExpression(kVertexID), kVertexID));
+            new YieldColumn(InputPropertyExpression::make(pool, kVertexID), kVertexID));
     }
     auto columns = sentence->yieldClause()->columns();
     auto schema = isEdge_ ? qctx_->schemaMng()->getEdgeSchema(spaceId_, schemaId_)
@@ -122,10 +123,10 @@ Status LookupValidator::prepareYield() {
             const std::string& colName = value.getStr();
             if (isEdge_) {
                 newYieldColumns_->addColumn(
-                    new YieldColumn(new EdgePropertyExpression(schemaName, colName)));
+                    new YieldColumn(EdgePropertyExpression::make(pool, schemaName, colName)));
             } else {
                 newYieldColumns_->addColumn(
-                    new YieldColumn(new TagPropertyExpression(schemaName, colName)));
+                    new YieldColumn(TagPropertyExpression::make(pool, schemaName, colName)));
             }
             if (!col->alias().empty()) {
                 newYieldColumns_->back()->setAlias(col->alias());
@@ -164,7 +165,8 @@ Status LookupValidator::prepareFilter() {
         tsClients_ = std::move(tsRet).value();
         auto tsIndex = checkTSExpr(filter);
         NG_RETURN_IF_ERROR(tsIndex);
-        auto retFilter = FTIndexUtils::rewriteTSFilter(isEdge_,
+        auto retFilter = FTIndexUtils::rewriteTSFilter(qctx_->objPool(),
+                                                       isEdge_,
                                                        filter,
                                                        tsIndex.value(),
                                                        tsClients_);
@@ -197,7 +199,7 @@ StatusOr<Expression*> LookupValidator::checkFilter(Expression* expr) {
             for (auto i = 0u; i < operands.size(); i++) {
                 auto ret = checkFilter(lExpr->operand(i));
                 NG_RETURN_IF_ERROR(ret);
-                lExpr->setOperand(i, ret.value()->clone().release());
+                lExpr->setOperand(i, ret.value()->clone());
             }
             break;
         }
@@ -240,7 +242,7 @@ StatusOr<Expression*> LookupValidator::rewriteRelExpr(RelationalExpression* expr
     auto right = expr->right();
     if (right->kind() == Expression::Kind::kLabelAttribute) {
         expr = qctx_->objPool()->add(
-            static_cast<RelationalExpression*>(reverseRelKind(expr).release()));
+            static_cast<RelationalExpression*>(reverseRelKind(expr)));
     }
 
     auto left = expr->left();
@@ -251,7 +253,7 @@ StatusOr<Expression*> LookupValidator::rewriteRelExpr(RelationalExpression* expr
 
     // fold constant expression
     auto pool = qctx_->objPool();
-    auto foldRes = ExpressionUtils::foldConstantExpr(expr, pool);
+    auto foldRes = ExpressionUtils::foldConstantExpr(pool, expr);
     NG_RETURN_IF_ERROR(foldRes);
     expr = static_cast<RelationalExpression*>(foldRes.value());
     DCHECK_EQ(expr->left()->kind(), Expression::Kind::kLabelAttribute);
@@ -262,13 +264,13 @@ StatusOr<Expression*> LookupValidator::rewriteRelExpr(RelationalExpression* expr
     if (!c.ok()) {
         return Status::SemanticError("expression error : %s", expr->right()->toString().c_str());
     }
-    expr->setRight(new ConstantExpression(std::move(c).value()));
+    expr->setRight(ConstantExpression::make(pool, std::move(c).value()));
 
     // rewrite PropertyExpression
     if (isEdge_) {
-        expr->setLeft(ExpressionUtils::rewriteLabelAttr2EdgeProp(la));
+        expr->setLeft(ExpressionUtils::rewriteLabelAttr2EdgeProp(pool, la));
     } else {
-        expr->setLeft(ExpressionUtils::rewriteLabelAttr2TagProp(la));
+        expr->setLeft(ExpressionUtils::rewriteLabelAttr2TagProp(pool, la));
     }
     return expr;
 }
@@ -334,7 +336,7 @@ StatusOr<std::string> LookupValidator::checkTSExpr(Expression* expr) {
     return tsName;
 }
 // Transform (A > B) to (B < A)
-std::unique_ptr<Expression> LookupValidator::reverseRelKind(RelationalExpression* expr) {
+Expression* LookupValidator::reverseRelKind(RelationalExpression* expr) {
     auto kind = expr->kind();
     auto reversedKind = kind;
 
@@ -362,9 +364,8 @@ std::unique_ptr<Expression> LookupValidator::reverseRelKind(RelationalExpression
 
     auto left = expr->left();
     auto right = expr->right();
-
-    return std::make_unique<RelationalExpression>(
-        reversedKind, right->clone().release(), left->clone().release());
+    auto* pool = qctx_->objPool();
+    return RelationalExpression::makeKind(pool, reversedKind, right->clone(), left->clone());
 }
 }   // namespace graph
 }   // namespace nebula

--- a/src/validator/LookupValidator.h
+++ b/src/validator/LookupValidator.h
@@ -44,7 +44,7 @@ private:
 
     StatusOr<std::string> checkTSExpr(Expression* expr);
 
-    std::unique_ptr<Expression> reverseRelKind(RelationalExpression* expr);
+    Expression* reverseRelKind(RelationalExpression* expr);
 
 private:
     static constexpr char kSrcVID[] = "SrcVID";

--- a/src/validator/MaintainValidator.cpp
+++ b/src/validator/MaintainValidator.cpp
@@ -49,7 +49,7 @@ Status SchemaValidator::validateColumns(const std::vector<ColumnSpecification *>
                 auto *defaultValueExpr = property->defaultValue();
                 auto pool = qctx()->objPool();
                 // some expression is evaluable but not pure so only fold instead of eval here
-                auto foldRes = ExpressionUtils::foldConstantExpr(defaultValueExpr, pool);
+                auto foldRes = ExpressionUtils::foldConstantExpr(pool, defaultValueExpr);
                 NG_RETURN_IF_ERROR(foldRes);
                 column.set_default_value(foldRes.value()->encode());
             } else if (property->isComment()) {
@@ -79,7 +79,8 @@ Status CreateTagValidator::validateImpl() {
     NG_RETURN_IF_ERROR(validateColumns(sentence->columnSpecs(), schema_));
     NG_RETURN_IF_ERROR(SchemaUtil::validateProps(sentence->getSchemaProps(), schema_));
     // Save the schema in validateContext
-    auto schemaPro = SchemaUtil::generateSchemaProvider(0, schema_);
+    auto pool = qctx_->objPool();
+    auto schemaPro = SchemaUtil::generateSchemaProvider(pool, 0, schema_);
     vctx_->addSchema(name_, schemaPro);
     return Status::OK();
 }
@@ -107,7 +108,8 @@ Status CreateEdgeValidator::validateImpl() {
     NG_RETURN_IF_ERROR(validateColumns(sentence->columnSpecs(), schema_));
     NG_RETURN_IF_ERROR(SchemaUtil::validateProps(sentence->getSchemaProps(), schema_));
     // Save the schema in validateContext
-    auto schemaPro = SchemaUtil::generateSchemaProvider(0, schema_);
+    auto pool = qctx_->objPool();
+    auto schemaPro = SchemaUtil::generateSchemaProvider(pool, 0, schema_);
     vctx_->addSchema(name_, schemaPro);
     return Status::OK();
 }

--- a/src/validator/MatchValidator.cpp
+++ b/src/validator/MatchValidator.cpp
@@ -313,7 +313,7 @@ Status MatchValidator::validateReturn(MatchReturn *ret,
     YieldColumns *columns = nullptr;
     auto *pool = qctx_->objPool();
     if (ret->isAll()) {
-        auto makeColumn = [&](const std::string &name) {
+        auto makeColumn = [&pool](const std::string &name) {
             auto *expr = LabelExpression::make(pool, name);
             return new YieldColumn(expr, name);
         };

--- a/src/validator/MatchValidator.h
+++ b/src/validator/MatchValidator.h
@@ -59,9 +59,6 @@ private:
     StatusOr<Expression*> makeSubFilter(const std::string &alias,
                                         const MapExpression *map,
                                         const std::string &label = "") const;
-    StatusOr<Expression*> makeSubFilterWithoutSave(const std::string &alias,
-                                                   const MapExpression *map,
-                                                   const std::string &label = "") const;
 
     static Expression* andConnect(ObjectPool* pool, Expression *left, Expression *right);
 

--- a/src/validator/MatchValidator.h
+++ b/src/validator/MatchValidator.h
@@ -16,7 +16,7 @@
 namespace nebula {
 
 class MatchStepRange;
-
+class ObjectPool;
 namespace graph {
 class MatchValidator final : public TraversalValidator {
 public:
@@ -63,7 +63,7 @@ private:
                                                    const MapExpression *map,
                                                    const std::string &label = "") const;
 
-    static Expression* andConnect(Expression *left, Expression *right);
+    static Expression* andConnect(ObjectPool* pool, Expression *left, Expression *right);
 
     template <typename T>
     T* saveObject(T *obj) const {

--- a/src/validator/MutateValidator.cpp
+++ b/src/validator/MutateValidator.cpp
@@ -602,10 +602,10 @@ Status UpdateValidator::checkAndResetSymExpr(Expression* inExpr,
 }
 
 // rewrite the expr which has kSymProperty expr to toExpr
-Expression* UpdateValidator::rewriteSymExpr(Expression *expr,
-                                                            const std::string &sym,
-                                                            bool &hasWrongType,
-                                                            bool isEdge) {
+Expression *UpdateValidator::rewriteSymExpr(Expression *expr,
+                                            const std::string &sym,
+                                            bool &hasWrongType,
+                                            bool isEdge) {
     RewriteSymExprVisitor visitor(qctx_->objPool(), sym, isEdge);
     expr->accept(&visitor);
     hasWrongType = visitor.hasWrongType();

--- a/src/validator/MutateValidator.cpp
+++ b/src/validator/MutateValidator.cpp
@@ -307,9 +307,8 @@ std::string DeleteVerticesValidator::buildVIds() {
         ds.rows.emplace_back(std::move(row));
     }
     qctx_->ectx()->setResult(input, ResultBuilder().value(Value(std::move(ds))).finish());
-
-    auto *vIds = new VariablePropertyExpression(input, kVid);
-    qctx_->objPool()->add(vIds);
+    auto *pool = qctx_->objPool();
+    auto *vIds = VariablePropertyExpression::make(pool, input, kVid);
     vidRef_ = vIds;
     return input;
 }
@@ -328,11 +327,12 @@ Status DeleteVerticesValidator::toPlan() {
     // make edgeRefs and edgeProp
     auto index = 0u;
     DCHECK(edgeTypes_.size() == edgeNames_.size());
+    auto *pool = qctx_->objPool();
     for (auto &name : edgeNames_) {
-        auto *edgeKeyRef = new EdgeKeyRef(new EdgeSrcIdExpression(name),
-                                          new EdgeDstIdExpression(name),
-                                          new EdgeRankExpression(name));
-        edgeKeyRef->setType(new EdgeTypeExpression(name));
+        auto *edgeKeyRef = new EdgeKeyRef(EdgeSrcIdExpression::make(pool, name),
+                                          EdgeDstIdExpression::make(pool, name),
+                                          EdgeRankExpression::make(pool, name));
+        edgeKeyRef->setType(EdgeTypeExpression::make(pool, name));
         qctx_->objPool()->add(edgeKeyRef);
         edgeKeyRefs_.emplace_back(edgeKeyRef);
 
@@ -388,9 +388,10 @@ Status DeleteEdgesValidator::validateImpl() {
     auto edgeStatus = qctx_->schemaMng()->toEdgeType(spaceId, *sentence->edge());
     NG_RETURN_IF_ERROR(edgeStatus);
     auto edgeType = edgeStatus.value();
+    auto *pool = qctx_->objPool();
     if (sentence->isRef()) {
         edgeKeyRefs_.emplace_back(sentence->edgeKeyRef());
-        (*edgeKeyRefs_.begin())->setType(new ConstantExpression(edgeType));
+        (*edgeKeyRefs_.begin())->setType(ConstantExpression::make(pool, edgeType));
         NG_RETURN_IF_ERROR(checkInput());
     } else {
         return buildEdgeKeyRef(sentence->edgeKeys()->keys(), edgeType);
@@ -421,11 +422,11 @@ Status DeleteEdgesValidator::buildEdgeKeyRef(const std::vector<EdgeKey*> &edgeKe
         ds.emplace_back(std::move(row));
     }
     qctx_->ectx()->setResult(edgeKeyVar_, ResultBuilder().value(Value(std::move(ds))).finish());
-
-    auto *srcIdExpr = new InputPropertyExpression(kSrc);
-    auto *typeExpr = new InputPropertyExpression(kType);
-    auto *rankExpr = new InputPropertyExpression(kRank);
-    auto *dstIdExpr = new InputPropertyExpression(kDst);
+    auto *pool = qctx_->objPool();
+    auto *srcIdExpr = InputPropertyExpression::make(pool, kSrc);
+    auto *typeExpr = InputPropertyExpression::make(pool, kType);
+    auto *rankExpr = InputPropertyExpression::make(pool, kRank);
+    auto *dstIdExpr = InputPropertyExpression::make(pool, kDst);
     auto* edgeKeyRef = new EdgeKeyRef(srcIdExpr, dstIdExpr, rankExpr);
     edgeKeyRef->setType(typeExpr);
     qctx_->objPool()->add(edgeKeyRef);
@@ -498,15 +499,15 @@ Status UpdateValidator::getCondition() {
     if (clause && clause->filter()) {
         auto filter = clause->filter()->clone();
         bool hasWrongType = false;
-        auto symExpr = rewriteSymExpr(filter.get(), name_, hasWrongType, isEdge_);
+        auto symExpr = rewriteSymExpr(filter, name_, hasWrongType, isEdge_);
         if (hasWrongType) {
             return Status::SemanticError("Has wrong expr in `%s'",
                                          filter->toString().c_str());
         }
         if (symExpr != nullptr) {
-            filter.reset(symExpr.release());
+            filter = symExpr;
         }
-        auto typeStatus = deduceExprType(filter.get());
+        auto typeStatus = deduceExprType(filter);
         NG_RETURN_IF_ERROR(typeStatus);
         auto type = typeStatus.value();
         if (type != Value::Type::BOOL
@@ -529,7 +530,7 @@ Status UpdateValidator::getReturnProps() {
             yieldColNames_.emplace_back(col->name());
             std::string encodeStr;
             auto copyColExpr = col->expr()->clone();
-            NG_LOG_AND_RETURN_IF_ERROR(checkAndResetSymExpr(copyColExpr.get(), name_, encodeStr));
+            NG_LOG_AND_RETURN_IF_ERROR(checkAndResetSymExpr(copyColExpr, name_, encodeStr));
             returnProps_.emplace_back(std::move(encodeStr));
         }
     }
@@ -565,7 +566,7 @@ Status UpdateValidator::getUpdateProps() {
         }
         std::string encodeStr;
         auto copyValueExpr = valueExpr->clone();
-        NG_LOG_AND_RETURN_IF_ERROR(checkAndResetSymExpr(copyValueExpr.get(), symName, encodeStr));
+        NG_LOG_AND_RETURN_IF_ERROR(checkAndResetSymExpr(copyValueExpr, symName, encodeStr));
         updatedProp.set_value(std::move(encodeStr));
         updatedProp.set_name(fieldName);
         updatedProps_.emplace_back(std::move(updatedProp));
@@ -601,11 +602,11 @@ Status UpdateValidator::checkAndResetSymExpr(Expression* inExpr,
 }
 
 // rewrite the expr which has kSymProperty expr to toExpr
-std::unique_ptr<Expression> UpdateValidator::rewriteSymExpr(Expression *expr,
+Expression* UpdateValidator::rewriteSymExpr(Expression *expr,
                                                             const std::string &sym,
                                                             bool &hasWrongType,
                                                             bool isEdge) {
-    RewriteSymExprVisitor visitor(sym, isEdge);
+    RewriteSymExprVisitor visitor(qctx_->objPool(), sym, isEdge);
     expr->accept(&visitor);
     hasWrongType = visitor.hasWrongType();
     return std::move(visitor).expr();

--- a/src/validator/MutateValidator.h
+++ b/src/validator/MutateValidator.h
@@ -138,7 +138,7 @@ private:
                                 const std::string& symName,
                                 std::string &encodeStr);
 
-    std::unique_ptr<Expression> rewriteSymExpr(Expression* expr,
+    Expression* rewriteSymExpr(Expression* expr,
                                                const std::string &sym,
                                                bool &hasWrongType,
                                                bool isEdge = false);

--- a/src/validator/MutateValidator.h
+++ b/src/validator/MutateValidator.h
@@ -136,12 +136,12 @@ protected:
 private:
     Status checkAndResetSymExpr(Expression* inExpr,
                                 const std::string& symName,
-                                std::string &encodeStr);
+                                std::string& encodeStr);
 
     Expression* rewriteSymExpr(Expression* expr,
-                                               const std::string &sym,
-                                               bool &hasWrongType,
-                                               bool isEdge = false);
+                               const std::string& sym,
+                               bool& hasWrongType,
+                               bool isEdge = false);
 
 protected:
     UpdateBaseSentence                                 *sentence_;

--- a/src/validator/OrderByValidator.cpp
+++ b/src/validator/OrderByValidator.cpp
@@ -15,10 +15,11 @@ Status OrderByValidator::validateImpl() {
     auto sentence = static_cast<OrderBySentence*>(sentence_);
     outputs_ = inputCols();
     auto &factors = sentence->factors();
+    auto *pool = qctx_->objPool();
     for (auto &factor : factors) {
         if (factor->expr()->kind() == Expression::Kind::kLabel) {
             auto *label = static_cast<const LabelExpression*>(factor->expr());
-            auto *expr = new InputPropertyExpression(label->name());
+            auto *expr = InputPropertyExpression::make(pool, label->name());
             factor->setExpr(expr);
         }
         if (factor->expr()->kind() != Expression::Kind::kInputProperty) {

--- a/src/validator/TraversalValidator.h
+++ b/src/validator/TraversalValidator.h
@@ -39,9 +39,10 @@ protected:
 
     Expression* buildExpandEndCondition(const std::string &lastStepResult) const;
 
-    Expression* buildExpandCondition(const std::string &lastStepResult, uint32_t steps) {
-        return ExpressionUtils::And(buildNStepLoopCondition(steps),
-                                    buildExpandEndCondition(lastStepResult));
+    Expression* buildExpandCondition(const std::string& lastStepResult, uint32_t steps) {
+        return LogicalExpression::makeAnd(qctx_->objPool(),
+                                          buildNStepLoopCondition(steps),
+                                          buildExpandEndCondition(lastStepResult));
     }
 
 protected:

--- a/src/validator/YieldValidator.cpp
+++ b/src/validator/YieldValidator.cpp
@@ -70,7 +70,7 @@ Status YieldValidator::validateImpl() {
 Status YieldValidator::makeOutputColumn(YieldColumn *column) {
     columns_->addColumn(column);
 
-    auto pool = qctx()->objPool();
+    auto* pool = qctx()->objPool();
     auto colExpr = column->expr();
     DCHECK(colExpr != nullptr);
 

--- a/src/validator/YieldValidator.cpp
+++ b/src/validator/YieldValidator.cpp
@@ -74,7 +74,7 @@ Status YieldValidator::makeOutputColumn(YieldColumn *column) {
     auto colExpr = column->expr();
     DCHECK(colExpr != nullptr);
 
-    auto expr = pool->add(colExpr->clone().release());
+    auto expr = colExpr->clone();
     NG_RETURN_IF_ERROR(deduceProps(expr, exprProps_));
 
     auto status = deduceExprType(expr);
@@ -83,10 +83,10 @@ Status YieldValidator::makeOutputColumn(YieldColumn *column) {
 
     auto name = column->name();
     // Constant expression folding must be after type deduction
-    auto foldedExpr = ExpressionUtils::foldConstantExpr(expr, pool);
+    auto foldedExpr = ExpressionUtils::foldConstantExpr(pool, expr);
     NG_RETURN_IF_ERROR(foldedExpr);
     auto foldedExprCopy = std::move(foldedExpr).value()->clone();
-    column->setExpr(foldedExprCopy.release());
+    column->setExpr(foldedExprCopy);
     outputs_.emplace_back(name, type);
     return Status::OK();
 }
@@ -131,7 +131,8 @@ Status YieldValidator::validateImplicitGroupBy() {
 
 Status YieldValidator::validateYieldAndBuildOutputs(const YieldClause *clause) {
     auto columns = clause->columns();
-    columns_ = qctx_->objPool()->add(new YieldColumns);
+    auto *pool = qctx_->objPool();
+    columns_ = pool->add(new YieldColumns);
     for (auto column : columns) {
         auto expr = DCHECK_NOTNULL(column->expr());
         NG_RETURN_IF_ERROR(invalidLabelIdentifiers(expr));
@@ -142,7 +143,7 @@ Status YieldValidator::validateYieldAndBuildOutputs(const YieldClause *clause) {
             // it's always a root of expression.
             if (ipe->prop() == "*") {
                 for (auto &colDef : inputs_) {
-                    auto newExpr = new InputPropertyExpression(colDef.name);
+                    auto newExpr = InputPropertyExpression::make(pool, colDef.name);
                     NG_RETURN_IF_ERROR(makeOutputColumn(new YieldColumn(newExpr)));
                 }
                 continue;
@@ -157,7 +158,7 @@ Status YieldValidator::validateYieldAndBuildOutputs(const YieldClause *clause) {
                 }
                 auto &varColDefs = vctx_->getVar(var);
                 for (auto &colDef : varColDefs) {
-                    auto newExpr = new VariablePropertyExpression(var, colDef.name);
+                    auto newExpr = VariablePropertyExpression::make(pool, var, colDef.name);
                     NG_RETURN_IF_ERROR(makeOutputColumn(new YieldColumn(newExpr)));
                 }
                 continue;
@@ -178,7 +179,7 @@ Status YieldValidator::validateWhere(const WhereClause *clause) {
     if (filter != nullptr) {
         NG_RETURN_IF_ERROR(deduceProps(filter, exprProps_));
         auto pool = qctx_->objPool();
-        auto foldRes = ExpressionUtils::foldConstantExpr(filter, pool);
+        auto foldRes = ExpressionUtils::foldConstantExpr(pool, filter);
         NG_RETURN_IF_ERROR(foldRes);
         filterCondition_ = foldRes.value();
     }

--- a/src/validator/test/FetchEdgesTest.cpp
+++ b/src/validator/test/FetchEdgesTest.cpp
@@ -166,8 +166,10 @@ TEST_F(FetchEdgesValidatorTest, FetchEdgesProp) {
         yieldColumns->addColumn(new YieldColumn(new EdgeDstIdExpression("like")));
         yieldColumns->addColumn(new YieldColumn(new EdgeRankExpression("like")));
         yieldColumns->addColumn(new YieldColumn(new EdgePropertyExpression("like", "start")));
-        yieldColumns->addColumn(new YieldColumn(new ArithmeticExpression(
-            Expression::Kind::kAdd, new ConstantExpression(1), new ConstantExpression(1))));
+        yieldColumns->addColumn(
+            new YieldColumn(new ArithmeticExpression(Expression::Kind::kAdd,
+                                                     ConstantExpression::make(pool, 1),
+                                                     ConstantExpression::make(pool, 1))));
         yieldColumns->addColumn(new YieldColumn(new EdgePropertyExpression("like", "end")));
         auto *project = Project::make(qctx, filter, yieldColumns.get());
         project->setColNames({std::string("like.") + kSrc,

--- a/src/validator/test/FetchEdgesTest.cpp
+++ b/src/validator/test/FetchEdgesTest.cpp
@@ -21,13 +21,13 @@ protected:
 };
 
 TEST_F(FetchEdgesValidatorTest, FetchEdgesProp) {
-    auto src = std::make_unique<VariablePropertyExpression>("_VAR1_", kSrc);
-    auto type = std::make_unique<VariablePropertyExpression>("_VAR2_", kType);
-    auto rank = std::make_unique<VariablePropertyExpression>("_VAR3_", kRank);
-    auto dst = std::make_unique<VariablePropertyExpression>("_VAR4_", kDst);
+    auto src = VariablePropertyExpression::make(pool_.get(), "_VAR1_", kSrc);
+    auto type = VariablePropertyExpression::make(pool_.get(), "_VAR2_", kType);
+    auto rank = VariablePropertyExpression::make(pool_.get(), "_VAR3_", kRank);
+    auto dst = VariablePropertyExpression::make(pool_.get(), "_VAR4_", kDst);
     {
         auto qctx = getQCtx("FETCH PROP ON like \"1\"->\"2\"");
-
+        auto *pool = qctx->objPool();
         auto *start = StartNode::make(qctx);
 
         auto edgeTypeResult = schemaMng_->toEdgeType(1, "like");
@@ -38,8 +38,7 @@ TEST_F(FetchEdgesValidatorTest, FetchEdgesProp) {
         prop.set_props({kSrc, kDst, kRank, kType, "start", "end", "likeness"});
         auto props = std::make_unique<std::vector<storage::cpp2::EdgeProp>>();
         props->emplace_back(std::move(prop));
-        auto *ge = GetEdges::make(
-            qctx, start, 1, src.get(), type.get(), rank.get(), dst.get(), std::move(props));
+        auto *ge = GetEdges::make(qctx, start, 1, src, type, rank, dst, std::move(props));
         std::vector<std::string> colNames{std::string("like.") + kSrc,
                                           std::string("like.") + kDst,
                                           std::string("like.") + kRank,
@@ -55,7 +54,7 @@ TEST_F(FetchEdgesValidatorTest, FetchEdgesProp) {
 
         // project
         auto yieldColumns = std::make_unique<YieldColumns>();
-        yieldColumns->addColumn(new YieldColumn(new EdgeExpression(), "edges_"));
+        yieldColumns->addColumn(new YieldColumn(EdgeExpression::make(pool), "edges_"));
         auto *project = Project::make(qctx, filter, yieldColumns.get());
         project->setColNames({"edges_"});
         auto result = Eq(qctx->plan()->root(), project);
@@ -64,7 +63,7 @@ TEST_F(FetchEdgesValidatorTest, FetchEdgesProp) {
     // With YIELD
     {
         auto qctx = getQCtx("FETCH PROP ON like \"1\"->\"2\" YIELD like.start, like.end");
-
+        auto *pool = qctx->objPool();
         auto *start = StartNode::make(qctx);
 
         auto edgeTypeResult = schemaMng_->toEdgeType(1, "like");
@@ -77,18 +76,18 @@ TEST_F(FetchEdgesValidatorTest, FetchEdgesProp) {
         props->emplace_back(std::move(prop));
         auto exprs = std::make_unique<std::vector<storage::cpp2::Expr>>();
         storage::cpp2::Expr expr1;
-        expr1.set_expr(EdgePropertyExpression("like", "start").encode());
+        expr1.set_expr(EdgePropertyExpression::make(pool, "like", "start")->encode());
         storage::cpp2::Expr expr2;
-        expr2.set_expr(EdgePropertyExpression("like", "end").encode());
+        expr2.set_expr(EdgePropertyExpression::make(pool, "like", "end")->encode());
         exprs->emplace_back(std::move(expr1));
         exprs->emplace_back(std::move(expr2));
         auto *ge = GetEdges::make(qctx,
                                   start,
                                   1,
-                                  src.get(),
-                                  type.get(),
-                                  rank.get(),
-                                  dst.get(),
+                                  src,
+                                  type,
+                                  rank,
+                                  dst,
                                   std::move(props),
                                   std::move(exprs));
         std::vector<std::string> colNames{std::string("like.") + kSrc,
@@ -104,11 +103,12 @@ TEST_F(FetchEdgesValidatorTest, FetchEdgesProp) {
 
         // Project
         auto yieldColumns = std::make_unique<YieldColumns>();
-        yieldColumns->addColumn(new YieldColumn(new EdgeSrcIdExpression("like")));
-        yieldColumns->addColumn(new YieldColumn(new EdgeDstIdExpression("like")));
-        yieldColumns->addColumn(new YieldColumn(new EdgeRankExpression("like")));
-        yieldColumns->addColumn(new YieldColumn(new EdgePropertyExpression("like", "start")));
-        yieldColumns->addColumn(new YieldColumn(new EdgePropertyExpression("like", "end")));
+        yieldColumns->addColumn(new YieldColumn(EdgeSrcIdExpression::make(pool, "like")));
+        yieldColumns->addColumn(new YieldColumn(EdgeDstIdExpression::make(pool, "like")));
+        yieldColumns->addColumn(new YieldColumn(EdgeRankExpression::make(pool, "like")));
+        yieldColumns->addColumn(
+            new YieldColumn(EdgePropertyExpression::make(pool, "like", "start")));
+        yieldColumns->addColumn(new YieldColumn(EdgePropertyExpression::make(pool, "like", "end")));
         auto *project = Project::make(qctx, filter, yieldColumns.get());
         project->setColNames({std::string("like.") + kSrc,
                               std::string("like.") + kDst,
@@ -121,7 +121,7 @@ TEST_F(FetchEdgesValidatorTest, FetchEdgesProp) {
     // With YIELD const expression
     {
         auto qctx = getQCtx("FETCH PROP ON like \"1\"->\"2\" YIELD like.start, 1 + 1, like.end");
-
+        auto *pool = qctx->objPool();
         auto *start = StartNode::make(qctx);
 
         // GetEdges
@@ -135,18 +135,18 @@ TEST_F(FetchEdgesValidatorTest, FetchEdgesProp) {
         props->emplace_back(std::move(prop));
         auto exprs = std::make_unique<std::vector<storage::cpp2::Expr>>();
         storage::cpp2::Expr expr1;
-        expr1.set_expr(EdgePropertyExpression("like", "start").encode());
+        expr1.set_expr(EdgePropertyExpression::make(pool, "like", "start")->encode());
         storage::cpp2::Expr expr2;
-        expr2.set_expr(EdgePropertyExpression("like", "end").encode());
+        expr2.set_expr(EdgePropertyExpression::make(pool, "like", "end")->encode());
         exprs->emplace_back(std::move(expr1));
         exprs->emplace_back(std::move(expr2));
         auto *ge = GetEdges::make(qctx,
                                   start,
                                   1,
-                                  src.get(),
-                                  type.get(),
-                                  rank.get(),
-                                  dst.get(),
+                                  src,
+                                  type,
+                                  rank,
+                                  dst,
                                   std::move(props),
                                   std::move(exprs));
         std::vector<std::string> colNames{std::string("like.") + kSrc,
@@ -162,15 +162,14 @@ TEST_F(FetchEdgesValidatorTest, FetchEdgesProp) {
 
         // Project
         auto yieldColumns = std::make_unique<YieldColumns>();
-        yieldColumns->addColumn(new YieldColumn(new EdgeSrcIdExpression("like")));
-        yieldColumns->addColumn(new YieldColumn(new EdgeDstIdExpression("like")));
-        yieldColumns->addColumn(new YieldColumn(new EdgeRankExpression("like")));
-        yieldColumns->addColumn(new YieldColumn(new EdgePropertyExpression("like", "start")));
+        yieldColumns->addColumn(new YieldColumn(EdgeSrcIdExpression::make(pool, "like")));
+        yieldColumns->addColumn(new YieldColumn(EdgeDstIdExpression::make(pool, "like")));
+        yieldColumns->addColumn(new YieldColumn(EdgeRankExpression::make(pool, "like")));
         yieldColumns->addColumn(
-            new YieldColumn(new ArithmeticExpression(Expression::Kind::kAdd,
-                                                     ConstantExpression::make(pool, 1),
-                                                     ConstantExpression::make(pool, 1))));
-        yieldColumns->addColumn(new YieldColumn(new EdgePropertyExpression("like", "end")));
+            new YieldColumn(EdgePropertyExpression::make(pool, "like", "start")));
+        yieldColumns->addColumn(new YieldColumn(ArithmeticExpression::makeAdd(
+            pool, ConstantExpression::make(pool, 1), ConstantExpression::make(pool, 1))));
+        yieldColumns->addColumn(new YieldColumn(EdgePropertyExpression::make(pool, "like", "end")));
         auto *project = Project::make(qctx, filter, yieldColumns.get());
         project->setColNames({std::string("like.") + kSrc,
                               std::string("like.") + kDst,
@@ -184,7 +183,7 @@ TEST_F(FetchEdgesValidatorTest, FetchEdgesProp) {
     // With YIELD combine properties
     {
         auto qctx = getQCtx("FETCH PROP ON like \"1\"->\"2\" YIELD like.start > like.end");
-
+        auto *pool = qctx->objPool();
         auto *start = StartNode::make(qctx);
 
         auto edgeTypeResult = schemaMng_->toEdgeType(1, "like");
@@ -198,18 +197,19 @@ TEST_F(FetchEdgesValidatorTest, FetchEdgesProp) {
         props->emplace_back(std::move(prop));
         auto exprs = std::make_unique<std::vector<storage::cpp2::Expr>>();
         storage::cpp2::Expr expr1;
-        expr1.set_expr(RelationalExpression(Expression::Kind::kRelGT,
-                                            new EdgePropertyExpression("like", "start"),
-                                            new EdgePropertyExpression("like", "end"))
-                           .encode());
+        expr1.set_expr(
+            RelationalExpression::makeGT(pool,
+                                         EdgePropertyExpression::make(pool, "like", "start"),
+                                         EdgePropertyExpression::make(pool, "like", "end"))
+                ->encode());
         exprs->emplace_back(std::move(expr1));
         auto *ge = GetEdges::make(qctx,
                                   start,
                                   1,
-                                  src.get(),
-                                  type.get(),
-                                  rank.get(),
-                                  dst.get(),
+                                  src,
+                                  type,
+                                  rank,
+                                  dst,
                                   std::move(props),
                                   std::move(exprs));
         std::vector<std::string> colNames{std::string("like.") + kSrc,
@@ -225,13 +225,13 @@ TEST_F(FetchEdgesValidatorTest, FetchEdgesProp) {
 
         // project, TODO(shylock) it's could push-down to storage if it supported
         auto yieldColumns = std::make_unique<YieldColumns>();
-        yieldColumns->addColumn(new YieldColumn(new EdgeSrcIdExpression("like")));
-        yieldColumns->addColumn(new YieldColumn(new EdgeDstIdExpression("like")));
-        yieldColumns->addColumn(new YieldColumn(new EdgeRankExpression("like")));
-        yieldColumns->addColumn(
-            new YieldColumn(new RelationalExpression(Expression::Kind::kRelGT,
-                                                     new EdgePropertyExpression("like", "start"),
-                                                     new EdgePropertyExpression("like", "end"))));
+        yieldColumns->addColumn(new YieldColumn(EdgeSrcIdExpression::make(pool, "like")));
+        yieldColumns->addColumn(new YieldColumn(EdgeDstIdExpression::make(pool, "like")));
+        yieldColumns->addColumn(new YieldColumn(EdgeRankExpression::make(pool, "like")));
+        yieldColumns->addColumn(new YieldColumn(
+            RelationalExpression::makeGT(pool,
+                                         EdgePropertyExpression::make(pool, "like", "start"),
+                                         EdgePropertyExpression::make(pool, "like", "end"))));
         auto *project = Project::make(qctx, filter, yieldColumns.get());
         project->setColNames({std::string("like.") + kSrc,
                               std::string("like.") + kDst,
@@ -244,7 +244,7 @@ TEST_F(FetchEdgesValidatorTest, FetchEdgesProp) {
     // With YIELD distinct
     {
         auto qctx = getQCtx("FETCH PROP ON like \"1\"->\"2\" YIELD distinct like.start, like.end");
-
+        auto *pool = qctx->objPool();
         auto *start = StartNode::make(qctx);
 
         auto edgeTypeResult = schemaMng_->toEdgeType(1, "like");
@@ -257,18 +257,18 @@ TEST_F(FetchEdgesValidatorTest, FetchEdgesProp) {
         props->emplace_back(std::move(prop));
         auto exprs = std::make_unique<std::vector<storage::cpp2::Expr>>();
         storage::cpp2::Expr expr1;
-        expr1.set_expr(EdgePropertyExpression("like", "start").encode());
+        expr1.set_expr(EdgePropertyExpression::make(pool, "like", "start")->encode());
         storage::cpp2::Expr expr2;
-        expr2.set_expr(EdgePropertyExpression("like", "end").encode());
+        expr2.set_expr(EdgePropertyExpression::make(pool, "like", "end")->encode());
         exprs->emplace_back(std::move(expr1));
         exprs->emplace_back(std::move(expr2));
         auto *ge = GetEdges::make(qctx,
                                   start,
                                   1,
-                                  src.get(),
-                                  type.get(),
-                                  rank.get(),
-                                  dst.get(),
+                                  src,
+                                  type,
+                                  rank,
+                                  dst,
                                   std::move(props),
                                   std::move(exprs));
 
@@ -285,11 +285,12 @@ TEST_F(FetchEdgesValidatorTest, FetchEdgesProp) {
 
         // project
         auto yieldColumns = std::make_unique<YieldColumns>();
-        yieldColumns->addColumn(new YieldColumn(new EdgeSrcIdExpression("like")));
-        yieldColumns->addColumn(new YieldColumn(new EdgeDstIdExpression("like")));
-        yieldColumns->addColumn(new YieldColumn(new EdgeRankExpression("like")));
-        yieldColumns->addColumn(new YieldColumn(new EdgePropertyExpression("like", "start")));
-        yieldColumns->addColumn(new YieldColumn(new EdgePropertyExpression("like", "end")));
+        yieldColumns->addColumn(new YieldColumn(EdgeSrcIdExpression::make(pool, "like")));
+        yieldColumns->addColumn(new YieldColumn(EdgeDstIdExpression::make(pool, "like")));
+        yieldColumns->addColumn(new YieldColumn(EdgeRankExpression::make(pool, "like")));
+        yieldColumns->addColumn(
+            new YieldColumn(EdgePropertyExpression::make(pool, "like", "start")));
+        yieldColumns->addColumn(new YieldColumn(EdgePropertyExpression::make(pool, "like", "end")));
         auto *project = Project::make(qctx, filter, yieldColumns.get());
         project->setColNames({std::string("like.") + kSrc,
                               std::string("like.") + kDst,

--- a/src/validator/test/FetchVerticesTest.cpp
+++ b/src/validator/test/FetchVerticesTest.cpp
@@ -4,9 +4,9 @@
  * attached with Common Clause Condition 1.0, found in the LICENSES directory.
  */
 
+#include "common/base/ObjectPool.h"
 #include "planner/plan/Logic.h"
 #include "planner/plan/Query.h"
-#include "common/base/ObjectPool.h"
 #include "validator/FetchVerticesValidator.h"
 #include "validator/test/ValidatorTestBase.h"
 
@@ -23,10 +23,10 @@ protected:
 };
 
 TEST_F(FetchVerticesValidatorTest, FetchVerticesProp) {
-    auto src = std::make_unique<VariablePropertyExpression>("_VARNAME_", "VertexID");
+    auto src = VariablePropertyExpression::make(pool_.get(), "_VARNAME_", "VertexID");
     {
         auto qctx = getQCtx("FETCH PROP ON person \"1\"");
-
+        auto *pool = qctx->objPool();
         auto *start = StartNode::make(qctx);
 
         auto tagIdResult = schemaMng_->toTagID(1, "person");
@@ -36,12 +36,11 @@ TEST_F(FetchVerticesValidatorTest, FetchVerticesProp) {
         prop.set_tag(tagId);
         auto props = std::make_unique<std::vector<storage::cpp2::VertexProp>>();
         props->emplace_back(std::move(prop));
-        auto *gv = GetVertices::make(
-            qctx, start, 1, src.get(), std::move(props));
+        auto *gv = GetVertices::make(qctx, start, 1, src, std::move(props));
         gv->setColNames({nebula::kVid, "person.name", "person.age"});
         // project
         auto yieldColumns = std::make_unique<YieldColumns>();
-        yieldColumns->addColumn(new YieldColumn(new VertexExpression(), "vertices_"));
+        yieldColumns->addColumn(new YieldColumn(VertexExpression::make(pool), "vertices_"));
         auto *project = Project::make(qctx, gv, yieldColumns.get());
         project->setColNames({"vertices_"});
         auto result = Eq(qctx->plan()->root(), project);
@@ -50,7 +49,7 @@ TEST_F(FetchVerticesValidatorTest, FetchVerticesProp) {
     // multi-tags
     {
         auto qctx = getQCtx("FETCH PROP ON person, book \"1\"");
-
+        auto *pool = qctx->objPool();
         auto *start = StartNode::make(qctx);
 
         // person
@@ -72,12 +71,12 @@ TEST_F(FetchVerticesValidatorTest, FetchVerticesProp) {
             qctx,
             start,
             1,
-            src.get(),
+            src,
             std::move(props));
         gv->setColNames({nebula::kVid, "person.name", "person.age", "book.name"});
         // project
         auto yieldColumns = std::make_unique<YieldColumns>();
-        yieldColumns->addColumn(new YieldColumn(new VertexExpression(), "vertices_"));
+        yieldColumns->addColumn(new YieldColumn(VertexExpression::make(pool), "vertices_"));
         auto *project = Project::make(qctx, gv, yieldColumns.get());
         project->setColNames({"vertices_"});
         auto result = Eq(qctx->plan()->root(), project);
@@ -86,7 +85,7 @@ TEST_F(FetchVerticesValidatorTest, FetchVerticesProp) {
     // With YIELD
     {
         auto qctx = getQCtx("FETCH PROP ON person \"1\" YIELD person.name, person.age");
-
+        auto *pool = qctx->objPool();
         auto *start = StartNode::make(qctx);
 
         auto tagIdResult = schemaMng_->toTagID(1, "person");
@@ -98,9 +97,9 @@ TEST_F(FetchVerticesValidatorTest, FetchVerticesProp) {
         auto props = std::make_unique<std::vector<storage::cpp2::VertexProp>>();
         props->emplace_back(std::move(prop));
         storage::cpp2::Expr expr1;
-        expr1.set_expr(TagPropertyExpression("person", "name").encode());
+        expr1.set_expr(TagPropertyExpression::make(pool, "person", "name")->encode());
         storage::cpp2::Expr expr2;
-        expr2.set_expr(TagPropertyExpression("person", "age").encode());
+        expr2.set_expr(TagPropertyExpression::make(pool, "person", "age")->encode());
         auto exprs = std::make_unique<std::vector<storage::cpp2::Expr>>();
         exprs->emplace_back(std::move(expr1));
         exprs->emplace_back(std::move(expr2));
@@ -108,7 +107,7 @@ TEST_F(FetchVerticesValidatorTest, FetchVerticesProp) {
             GetVertices::make(qctx,
                               start,
                               1,
-                              src.get(),
+                              src,
                               std::move(props),
                               std::move(exprs));
         gv->setColNames({nebula::kVid, "person.name", "person.age"});
@@ -116,9 +115,11 @@ TEST_F(FetchVerticesValidatorTest, FetchVerticesProp) {
         // project
         auto yieldColumns = std::make_unique<YieldColumns>();
         yieldColumns->addColumn(
-            new YieldColumn(new InputPropertyExpression(nebula::kVid), "VertexID"));
-        yieldColumns->addColumn(new YieldColumn(new TagPropertyExpression("person", "name")));
-        yieldColumns->addColumn(new YieldColumn(new TagPropertyExpression("person", "age")));
+            new YieldColumn(InputPropertyExpression::make(pool, nebula::kVid), "VertexID"));
+        yieldColumns->addColumn(
+            new YieldColumn(TagPropertyExpression::make(pool, "person", "name")));
+        yieldColumns->addColumn(
+            new YieldColumn(TagPropertyExpression::make(pool, "person", "age")));
         auto *project = Project::make(qctx, gv, yieldColumns.get());
         project->setColNames({"VertexID", "person.name", "person.age"});
 
@@ -129,7 +130,7 @@ TEST_F(FetchVerticesValidatorTest, FetchVerticesProp) {
     {
         auto qctx =
             getQCtx("FETCH PROP ON person,book \"1\" YIELD person.name, person.age, book.name");
-
+        auto *pool = qctx->objPool();
         auto *start = StartNode::make(qctx);
 
         // person
@@ -150,11 +151,11 @@ TEST_F(FetchVerticesValidatorTest, FetchVerticesProp) {
         props->emplace_back(std::move(personProp));
         props->emplace_back(std::move(bookProp));
         storage::cpp2::Expr expr1;
-        expr1.set_expr(TagPropertyExpression("person", "name").encode());
+        expr1.set_expr(TagPropertyExpression::make(pool, "person", "name")->encode());
         storage::cpp2::Expr expr2;
-        expr2.set_expr(TagPropertyExpression("person", "age").encode());
+        expr2.set_expr(TagPropertyExpression::make(pool, "person", "age")->encode());
         storage::cpp2::Expr expr3;
-        expr3.set_expr(TagPropertyExpression("book", "name").encode());
+        expr3.set_expr(TagPropertyExpression::make(pool, "book", "name")->encode());
         auto exprs = std::make_unique<std::vector<storage::cpp2::Expr>>();
         exprs->emplace_back(std::move(expr1));
         exprs->emplace_back(std::move(expr2));
@@ -163,7 +164,7 @@ TEST_F(FetchVerticesValidatorTest, FetchVerticesProp) {
             qctx,
             start,
             1,
-            src.get(),
+            src,
             std::move(props),
             std::move(exprs));
         gv->setColNames({nebula::kVid, "person.name", "person.age", "book.name"});
@@ -171,10 +172,12 @@ TEST_F(FetchVerticesValidatorTest, FetchVerticesProp) {
         // project
         auto yieldColumns = std::make_unique<YieldColumns>();
         yieldColumns->addColumn(
-            new YieldColumn(new InputPropertyExpression(nebula::kVid), "VertexID"));
-        yieldColumns->addColumn(new YieldColumn(new TagPropertyExpression("person", "name")));
-        yieldColumns->addColumn(new YieldColumn(new TagPropertyExpression("person", "age")));
-        yieldColumns->addColumn(new YieldColumn(new TagPropertyExpression("book", "name")));
+            new YieldColumn(InputPropertyExpression::make(pool, nebula::kVid), "VertexID"));
+        yieldColumns->addColumn(
+            new YieldColumn(TagPropertyExpression::make(pool, "person", "name")));
+        yieldColumns->addColumn(
+            new YieldColumn(TagPropertyExpression::make(pool, "person", "age")));
+        yieldColumns->addColumn(new YieldColumn(TagPropertyExpression::make(pool, "book", "name")));
         auto *project = Project::make(qctx, gv, yieldColumns.get());
         project->setColNames({"VertexID", "person.name", "person.age", "book.name"});
 
@@ -184,7 +187,7 @@ TEST_F(FetchVerticesValidatorTest, FetchVerticesProp) {
     // With YIELD const expression
     {
         auto qctx = getQCtx("FETCH PROP ON person \"1\" YIELD person.name, 1 > 1, person.age");
-
+        auto *pool = qctx->objPool();
         auto *start = StartNode::make(qctx);
 
         // get vertices
@@ -197,9 +200,9 @@ TEST_F(FetchVerticesValidatorTest, FetchVerticesProp) {
         auto props = std::make_unique<std::vector<storage::cpp2::VertexProp>>();
         props->emplace_back(std::move(prop));
         storage::cpp2::Expr expr1;
-        expr1.set_expr(TagPropertyExpression("person", "name").encode());
+        expr1.set_expr(TagPropertyExpression::make(pool, "person", "name")->encode());
         storage::cpp2::Expr expr2;
-        expr2.set_expr(TagPropertyExpression("person", "age").encode());
+        expr2.set_expr(TagPropertyExpression::make(pool, "person", "age")->encode());
         auto exprs = std::make_unique<std::vector<storage::cpp2::Expr>>();
         exprs->emplace_back(std::move(expr1));
         exprs->emplace_back(std::move(expr2));
@@ -207,7 +210,7 @@ TEST_F(FetchVerticesValidatorTest, FetchVerticesProp) {
             GetVertices::make(qctx,
                               start,
                               1,
-                              src.get(),
+                              src,
                               std::move(props),
                               std::move(exprs));
         gv->setColNames({nebula::kVid, "person.name", "person.age"});
@@ -215,13 +218,13 @@ TEST_F(FetchVerticesValidatorTest, FetchVerticesProp) {
         // project
         auto yieldColumns = std::make_unique<YieldColumns>();
         yieldColumns->addColumn(
-            new YieldColumn(new InputPropertyExpression(nebula::kVid), "VertexID"));
-        yieldColumns->addColumn(new YieldColumn(new TagPropertyExpression("person", "name")));
+            new YieldColumn(InputPropertyExpression::make(pool, nebula::kVid), "VertexID"));
         yieldColumns->addColumn(
-            new YieldColumn(new RelationalExpression(Expression::Kind::kRelGT,
-                                                     ConstantExpression::make(pool1),
-                                                     ConstantExpression::make(pool1))));
-        yieldColumns->addColumn(new YieldColumn(new TagPropertyExpression("person", "age")));
+            new YieldColumn(TagPropertyExpression::make(pool, "person", "name")));
+        yieldColumns->addColumn(new YieldColumn(RelationalExpression::makeGT(
+            pool, ConstantExpression::make(pool, 1), ConstantExpression::make(pool, 1))));
+        yieldColumns->addColumn(
+            new YieldColumn(TagPropertyExpression::make(pool, "person", "age")));
         auto *project = Project::make(qctx, gv, yieldColumns.get());
         project->setColNames({"VertexID", "person.name", "(1>1)", "person.age"});
 
@@ -232,7 +235,7 @@ TEST_F(FetchVerticesValidatorTest, FetchVerticesProp) {
     {
         auto qctx = getQCtx(
             "FETCH PROP ON person, book \"1\" YIELD person.name, 1 > 1, book.name, person.age");
-
+        auto *pool = qctx->objPool();
         auto *start = StartNode::make(qctx);
 
         // get vertices
@@ -255,11 +258,11 @@ TEST_F(FetchVerticesValidatorTest, FetchVerticesProp) {
         props->emplace_back(std::move(bookProp));
 
         storage::cpp2::Expr expr1;
-        expr1.set_expr(TagPropertyExpression("person", "name").encode());
+        expr1.set_expr(TagPropertyExpression::make(pool, "person", "name")->encode());
         storage::cpp2::Expr expr2;
-        expr2.set_expr(TagPropertyExpression("book", "name").encode());
+        expr2.set_expr(TagPropertyExpression::make(pool, "book", "name")->encode());
         storage::cpp2::Expr expr3;
-        expr3.set_expr(TagPropertyExpression("person", "age").encode());
+        expr3.set_expr(TagPropertyExpression::make(pool, "person", "age")->encode());
         auto exprs = std::make_unique<std::vector<storage::cpp2::Expr>>();
         exprs->emplace_back(std::move(expr1));
         exprs->emplace_back(std::move(expr2));
@@ -268,7 +271,7 @@ TEST_F(FetchVerticesValidatorTest, FetchVerticesProp) {
             qctx,
             start,
             1,
-            src.get(),
+            src,
             std::move(props),
             std::move(exprs));
         gv->setColNames({nebula::kVid, "person.name", "book.name", "person.age"});
@@ -276,14 +279,14 @@ TEST_F(FetchVerticesValidatorTest, FetchVerticesProp) {
         // project
         auto yieldColumns = std::make_unique<YieldColumns>();
         yieldColumns->addColumn(
-            new YieldColumn(new InputPropertyExpression(nebula::kVid), "VertexID"));
-        yieldColumns->addColumn(new YieldColumn(new TagPropertyExpression("person", "name")));
+            new YieldColumn(InputPropertyExpression::make(pool, nebula::kVid), "VertexID"));
         yieldColumns->addColumn(
-            new YieldColumn(new RelationalExpression(Expression::Kind::kRelGT,
-                                                     ConstantExpression::make(pool, 1),
-                                                     ConstantExpression::make(pool, 1))));
-        yieldColumns->addColumn(new YieldColumn(new TagPropertyExpression("book", "name")));
-        yieldColumns->addColumn(new YieldColumn(new TagPropertyExpression("person", "age")));
+            new YieldColumn(TagPropertyExpression::make(pool, "person", "name")));
+        yieldColumns->addColumn(new YieldColumn(RelationalExpression::makeGT(
+            pool, ConstantExpression::make(pool, 1), ConstantExpression::make(pool, 1))));
+        yieldColumns->addColumn(new YieldColumn(TagPropertyExpression::make(pool, "book", "name")));
+        yieldColumns->addColumn(
+            new YieldColumn(TagPropertyExpression::make(pool, "person", "age")));
         auto *project = Project::make(qctx, gv, yieldColumns.get());
         project->setColNames({"VertexID", "person.name", "(1>1)", "book.name", "person.age"});
 
@@ -293,7 +296,7 @@ TEST_F(FetchVerticesValidatorTest, FetchVerticesProp) {
     // With YIELD combine properties
     {
         auto qctx = getQCtx("FETCH PROP ON person \"1\" YIELD person.name + person.age");
-
+        auto *pool = qctx->objPool();
         auto *start = StartNode::make(qctx);
 
         auto tagIdResult = schemaMng_->toTagID(1, "person");
@@ -305,17 +308,18 @@ TEST_F(FetchVerticesValidatorTest, FetchVerticesProp) {
         auto props = std::make_unique<std::vector<storage::cpp2::VertexProp>>();
         props->emplace_back(std::move(prop));
         storage::cpp2::Expr expr1;
-        expr1.set_expr(ArithmeticExpression(Expression::Kind::kAdd,
-                                            new TagPropertyExpression("person", "name"),
-                                            new TagPropertyExpression("person", "age"))
-                           .encode());
+        expr1.set_expr(
+            ArithmeticExpression::makeAdd(pool,
+                                          TagPropertyExpression::make(pool, "person", "name"),
+                                          TagPropertyExpression::make(pool, "person", "age"))
+                ->encode());
         auto exprs = std::make_unique<std::vector<storage::cpp2::Expr>>();
         exprs->emplace_back(std::move(expr1));
 
         auto *gv = GetVertices::make(qctx,
                                      start,
                                      1,
-                                     src.get(),
+                                     src,
                                      std::move(props),
                                      std::move(exprs));
         gv->setColNames({nebula::kVid, "person.name", "person.age"});
@@ -323,11 +327,11 @@ TEST_F(FetchVerticesValidatorTest, FetchVerticesProp) {
         // project, TODO(shylock) could push down to storage is it supported
         auto yieldColumns = std::make_unique<YieldColumns>();
         yieldColumns->addColumn(
-            new YieldColumn(new InputPropertyExpression(nebula::kVid), "VertexID"));
-        yieldColumns->addColumn(
-            new YieldColumn(new ArithmeticExpression(Expression::Kind::kAdd,
-                                                     new TagPropertyExpression("person", "name"),
-                                                     new TagPropertyExpression("person", "age"))));
+            new YieldColumn(InputPropertyExpression::make(pool, nebula::kVid), "VertexID"));
+        yieldColumns->addColumn(new YieldColumn(
+            ArithmeticExpression::makeAdd(pool,
+                                          TagPropertyExpression::make(pool, "person", "name"),
+                                          TagPropertyExpression::make(pool, "person", "age"))));
         auto *project = Project::make(qctx, gv, yieldColumns.get());
         project->setColNames({"VertexID", "(person.name+person.age)"});
 
@@ -337,7 +341,7 @@ TEST_F(FetchVerticesValidatorTest, FetchVerticesProp) {
     // multi-tags With YIELD combine properties
     {
         auto qctx = getQCtx("FETCH PROP ON book,person \"1\" YIELD person.name + book.name");
-
+        auto *pool = qctx->objPool();
         auto *start = StartNode::make(qctx);
 
         // person
@@ -359,17 +363,18 @@ TEST_F(FetchVerticesValidatorTest, FetchVerticesProp) {
         props->emplace_back(std::move(bookProp));
 
         storage::cpp2::Expr expr1;
-        expr1.set_expr(ArithmeticExpression(Expression::Kind::kAdd,
-                                            new TagPropertyExpression("person", "name"),
-                                            new TagPropertyExpression("book", "name"))
-                           .encode());
+        expr1.set_expr(
+            ArithmeticExpression::makeAdd(pool,
+                                          TagPropertyExpression::make(pool, "person", "name"),
+                                          TagPropertyExpression::make(pool, "book", "name"))
+                ->encode());
         auto exprs = std::make_unique<std::vector<storage::cpp2::Expr>>();
         exprs->emplace_back(std::move(expr1));
         auto *gv = GetVertices::make(
             qctx,
             start,
             1,
-            src.get(),
+            src,
             std::move(props),
             std::move(exprs));
         gv->setColNames({nebula::kVid, "person.name", "book.name"});
@@ -377,11 +382,11 @@ TEST_F(FetchVerticesValidatorTest, FetchVerticesProp) {
         // project, TODO(shylock) could push down to storage is it supported
         auto yieldColumns = std::make_unique<YieldColumns>();
         yieldColumns->addColumn(
-            new YieldColumn(new InputPropertyExpression(nebula::kVid), "VertexID"));
-        yieldColumns->addColumn(
-            new YieldColumn(new ArithmeticExpression(Expression::Kind::kAdd,
-                                                     new TagPropertyExpression("person", "name"),
-                                                     new TagPropertyExpression("book", "name"))));
+            new YieldColumn(InputPropertyExpression::make(pool, nebula::kVid), "VertexID"));
+        yieldColumns->addColumn(new YieldColumn(
+            ArithmeticExpression::makeAdd(pool,
+                                          TagPropertyExpression::make(pool, "person", "name"),
+                                          TagPropertyExpression::make(pool, "book", "name"))));
         auto *project = Project::make(qctx, gv, yieldColumns.get());
         project->setColNames({"VertexID", "(person.name+book.name)"});
 
@@ -391,7 +396,7 @@ TEST_F(FetchVerticesValidatorTest, FetchVerticesProp) {
     // With YIELD distinct
     {
         auto qctx = getQCtx("FETCH PROP ON person \"1\" YIELD distinct person.name, person.age");
-
+        auto *pool = qctx->objPool();
         auto *start = StartNode::make(qctx);
 
         auto tagIdResult = schemaMng_->toTagID(1, "person");
@@ -403,9 +408,9 @@ TEST_F(FetchVerticesValidatorTest, FetchVerticesProp) {
         auto props = std::make_unique<std::vector<storage::cpp2::VertexProp>>();
         props->emplace_back(std::move(prop));
         storage::cpp2::Expr expr1;
-        expr1.set_expr(TagPropertyExpression("person", "name").encode());
+        expr1.set_expr(TagPropertyExpression::make(pool, "person", "name")->encode());
         storage::cpp2::Expr expr2;
-        expr2.set_expr(TagPropertyExpression("person", "age").encode());
+        expr2.set_expr(TagPropertyExpression::make(pool, "person", "age")->encode());
         auto exprs = std::make_unique<std::vector<storage::cpp2::Expr>>();
         exprs->emplace_back(std::move(expr1));
         exprs->emplace_back(std::move(expr2));
@@ -413,7 +418,7 @@ TEST_F(FetchVerticesValidatorTest, FetchVerticesProp) {
             GetVertices::make(qctx,
                               start,
                               1,
-                              src.get(),
+                              src,
                               std::move(props),
                               std::move(exprs));
 
@@ -423,9 +428,11 @@ TEST_F(FetchVerticesValidatorTest, FetchVerticesProp) {
         // project
         auto yieldColumns = std::make_unique<YieldColumns>();
         yieldColumns->addColumn(
-            new YieldColumn(new InputPropertyExpression(nebula::kVid), "VertexID"));
-        yieldColumns->addColumn(new YieldColumn(new TagPropertyExpression("person", "name")));
-        yieldColumns->addColumn(new YieldColumn(new TagPropertyExpression("person", "age")));
+            new YieldColumn(InputPropertyExpression::make(pool, nebula::kVid), "VertexID"));
+        yieldColumns->addColumn(
+            new YieldColumn(TagPropertyExpression::make(pool, "person", "name")));
+        yieldColumns->addColumn(
+            new YieldColumn(TagPropertyExpression::make(pool, "person", "age")));
         auto *project = Project::make(qctx, gv, yieldColumns.get());
         project->setColNames(colNames);
 
@@ -445,14 +452,14 @@ TEST_F(FetchVerticesValidatorTest, FetchVerticesProp) {
     // ON *
     {
         auto qctx = getQCtx("FETCH PROP ON * \"1\"");
-
+        auto *pool = qctx->objPool();
         auto *start = StartNode::make(qctx);
 
-        auto *gv = GetVertices::make(qctx, start, 1, src.get());
+        auto *gv = GetVertices::make(qctx, start, 1, src);
         gv->setColNames({nebula::kVid, "person.name", "person.age"});
         // project
         auto yieldColumns = std::make_unique<YieldColumns>();
-        yieldColumns->addColumn(new YieldColumn(new VertexExpression(), "vertices_"));
+        yieldColumns->addColumn(new YieldColumn(VertexExpression::make(pool), "vertices_"));
         auto *project = Project::make(qctx, gv, yieldColumns.get());
         project->setColNames({"vertices_"});
         auto result = Eq(qctx->plan()->root(), project);
@@ -460,14 +467,14 @@ TEST_F(FetchVerticesValidatorTest, FetchVerticesProp) {
     }
     {
         auto qctx = getQCtx("FETCH PROP ON * \"1\", \"2\"");
-
+        auto *pool = qctx->objPool();
         auto *start = StartNode::make(qctx);
 
-        auto *gv = GetVertices::make(qctx, start, 1, src.get());
+        auto *gv = GetVertices::make(qctx, start, 1, src);
         gv->setColNames({nebula::kVid, "person.name", "person.age"});
         // project
         auto yieldColumns = std::make_unique<YieldColumns>();
-        yieldColumns->addColumn(new YieldColumn(new VertexExpression(), "vertices_"));
+        yieldColumns->addColumn(new YieldColumn(VertexExpression::make(pool), "vertices_"));
         auto *project = Project::make(qctx, gv, yieldColumns.get());
         project->setColNames({"vertices_"});
         auto result = Eq(qctx->plan()->root(), project);
@@ -476,19 +483,20 @@ TEST_F(FetchVerticesValidatorTest, FetchVerticesProp) {
     // ON * with yield
     {
         auto qctx = getQCtx("FETCH PROP ON * \"1\", \"2\" YIELD person.name");
-
+        auto *pool = qctx->objPool();
         auto *start = StartNode::make(qctx);
 
         std::vector<std::string> colNames{"VertexID", "person.name"};
         // Get vertices
-        auto *gv = GetVertices::make(qctx, start, 1, src.get());
+        auto *gv = GetVertices::make(qctx, start, 1, src);
         gv->setColNames(colNames);
 
         // project
         auto yieldColumns = std::make_unique<YieldColumns>();
         yieldColumns->addColumn(
-            new YieldColumn(new InputPropertyExpression(nebula::kVid), "VertexID"));
-        yieldColumns->addColumn(new YieldColumn(new TagPropertyExpression("person", "name")));
+            new YieldColumn(InputPropertyExpression::make(pool, nebula::kVid), "VertexID"));
+        yieldColumns->addColumn(
+            new YieldColumn(TagPropertyExpression::make(pool, "person", "name")));
         auto *project = Project::make(qctx, gv, yieldColumns.get());
         project->setColNames(colNames);
 
@@ -497,20 +505,22 @@ TEST_F(FetchVerticesValidatorTest, FetchVerticesProp) {
     }
     {
         auto qctx = getQCtx("FETCH PROP ON * \"1\", \"2\" YIELD person.name, person.age");
-
+        auto *pool = qctx->objPool();
         auto *start = StartNode::make(qctx);
 
         std::vector<std::string> colNames{"VertexID", "person.name", "person.age"};
         // Get vertices
-        auto *gv = GetVertices::make(qctx, start, 1, src.get());
+        auto *gv = GetVertices::make(qctx, start, 1, src);
         gv->setColNames(colNames);
 
         // project
         auto yieldColumns = std::make_unique<YieldColumns>();
         yieldColumns->addColumn(
-            new YieldColumn(new InputPropertyExpression(nebula::kVid), "VertexID"));
-        yieldColumns->addColumn(new YieldColumn(new TagPropertyExpression("person", "name")));
-        yieldColumns->addColumn(new YieldColumn(new TagPropertyExpression("person", "age")));
+            new YieldColumn(InputPropertyExpression::make(pool, nebula::kVid), "VertexID"));
+        yieldColumns->addColumn(
+            new YieldColumn(TagPropertyExpression::make(pool, "person", "name")));
+        yieldColumns->addColumn(
+            new YieldColumn(TagPropertyExpression::make(pool, "person", "age")));
         auto *project = Project::make(qctx, gv, yieldColumns.get());
         project->setColNames(colNames);
 
@@ -519,23 +529,23 @@ TEST_F(FetchVerticesValidatorTest, FetchVerticesProp) {
     }
     {
         auto qctx = getQCtx("FETCH PROP ON * \"1\", \"2\" YIELD 1+1, person.name, person.age");
-
+        auto *pool = qctx->objPool();
         auto *start = StartNode::make(qctx);
 
         // Get vertices
-        auto *gv = GetVertices::make(qctx, start, 1, src.get());
+        auto *gv = GetVertices::make(qctx, start, 1, src);
         gv->setColNames({nebula::kVid, "person.name", "person.age"});
 
         // project
         auto yieldColumns = std::make_unique<YieldColumns>();
         yieldColumns->addColumn(
-            new YieldColumn(new InputPropertyExpression(nebula::kVid), "VertexID"));
+            new YieldColumn(InputPropertyExpression::make(pool, nebula::kVid), "VertexID"));
+        yieldColumns->addColumn(new YieldColumn(ArithmeticExpression::makeAdd(
+            pool, ConstantExpression::make(pool, 1), ConstantExpression::make(pool, 1))));
         yieldColumns->addColumn(
-            new YieldColumn(new ArithmeticExpression(Expression::Kind::kAdd,
-                                                     ConstantExpression::make(pool1),
-                                                     ConstantExpression::make(pool1))));
-        yieldColumns->addColumn(new YieldColumn(new TagPropertyExpression("person", "name")));
-        yieldColumns->addColumn(new YieldColumn(new TagPropertyExpression("person", "age")));
+            new YieldColumn(TagPropertyExpression::make(pool, "person", "name")));
+        yieldColumns->addColumn(
+            new YieldColumn(TagPropertyExpression::make(pool, "person", "age")));
         auto *project = Project::make(qctx, gv, yieldColumns.get());
         project->setColNames({"VertexID", "(1+1)", "person.name", "person.age"});
 

--- a/src/validator/test/FetchVerticesTest.cpp
+++ b/src/validator/test/FetchVerticesTest.cpp
@@ -41,8 +41,7 @@ TEST_F(FetchVerticesValidatorTest, FetchVerticesProp) {
         gv->setColNames({nebula::kVid, "person.name", "person.age"});
         // project
         auto yieldColumns = std::make_unique<YieldColumns>();
-        yieldColumns->addColumn(
-            new YieldColumn(new VertexExpression(), "vertices_"));
+        yieldColumns->addColumn(new YieldColumn(new VertexExpression(), "vertices_"));
         auto *project = Project::make(qctx, gv, yieldColumns.get());
         project->setColNames({"vertices_"});
         auto result = Eq(qctx->plan()->root(), project);
@@ -78,8 +77,7 @@ TEST_F(FetchVerticesValidatorTest, FetchVerticesProp) {
         gv->setColNames({nebula::kVid, "person.name", "person.age", "book.name"});
         // project
         auto yieldColumns = std::make_unique<YieldColumns>();
-        yieldColumns->addColumn(
-            new YieldColumn(new VertexExpression(), "vertices_"));
+        yieldColumns->addColumn(new YieldColumn(new VertexExpression(), "vertices_"));
         auto *project = Project::make(qctx, gv, yieldColumns.get());
         project->setColNames({"vertices_"});
         auto result = Eq(qctx->plan()->root(), project);
@@ -219,8 +217,10 @@ TEST_F(FetchVerticesValidatorTest, FetchVerticesProp) {
         yieldColumns->addColumn(
             new YieldColumn(new InputPropertyExpression(nebula::kVid), "VertexID"));
         yieldColumns->addColumn(new YieldColumn(new TagPropertyExpression("person", "name")));
-        yieldColumns->addColumn(new YieldColumn(new RelationalExpression(
-            Expression::Kind::kRelGT, new ConstantExpression(1), new ConstantExpression(1))));
+        yieldColumns->addColumn(
+            new YieldColumn(new RelationalExpression(Expression::Kind::kRelGT,
+                                                     ConstantExpression::make(pool1),
+                                                     ConstantExpression::make(pool1))));
         yieldColumns->addColumn(new YieldColumn(new TagPropertyExpression("person", "age")));
         auto *project = Project::make(qctx, gv, yieldColumns.get());
         project->setColNames({"VertexID", "person.name", "(1>1)", "person.age"});
@@ -278,8 +278,10 @@ TEST_F(FetchVerticesValidatorTest, FetchVerticesProp) {
         yieldColumns->addColumn(
             new YieldColumn(new InputPropertyExpression(nebula::kVid), "VertexID"));
         yieldColumns->addColumn(new YieldColumn(new TagPropertyExpression("person", "name")));
-        yieldColumns->addColumn(new YieldColumn(new RelationalExpression(
-            Expression::Kind::kRelGT, new ConstantExpression(1), new ConstantExpression(1))));
+        yieldColumns->addColumn(
+            new YieldColumn(new RelationalExpression(Expression::Kind::kRelGT,
+                                                     ConstantExpression::make(pool, 1),
+                                                     ConstantExpression::make(pool, 1))));
         yieldColumns->addColumn(new YieldColumn(new TagPropertyExpression("book", "name")));
         yieldColumns->addColumn(new YieldColumn(new TagPropertyExpression("person", "age")));
         auto *project = Project::make(qctx, gv, yieldColumns.get());
@@ -450,8 +452,7 @@ TEST_F(FetchVerticesValidatorTest, FetchVerticesProp) {
         gv->setColNames({nebula::kVid, "person.name", "person.age"});
         // project
         auto yieldColumns = std::make_unique<YieldColumns>();
-        yieldColumns->addColumn(
-            new YieldColumn(new VertexExpression(), "vertices_"));
+        yieldColumns->addColumn(new YieldColumn(new VertexExpression(), "vertices_"));
         auto *project = Project::make(qctx, gv, yieldColumns.get());
         project->setColNames({"vertices_"});
         auto result = Eq(qctx->plan()->root(), project);
@@ -466,8 +467,7 @@ TEST_F(FetchVerticesValidatorTest, FetchVerticesProp) {
         gv->setColNames({nebula::kVid, "person.name", "person.age"});
         // project
         auto yieldColumns = std::make_unique<YieldColumns>();
-        yieldColumns->addColumn(
-            new YieldColumn(new VertexExpression(), "vertices_"));
+        yieldColumns->addColumn(new YieldColumn(new VertexExpression(), "vertices_"));
         auto *project = Project::make(qctx, gv, yieldColumns.get());
         project->setColNames({"vertices_"});
         auto result = Eq(qctx->plan()->root(), project);
@@ -530,8 +530,10 @@ TEST_F(FetchVerticesValidatorTest, FetchVerticesProp) {
         auto yieldColumns = std::make_unique<YieldColumns>();
         yieldColumns->addColumn(
             new YieldColumn(new InputPropertyExpression(nebula::kVid), "VertexID"));
-        yieldColumns->addColumn(new YieldColumn(new ArithmeticExpression(
-            Expression::Kind::kAdd, new ConstantExpression(1), new ConstantExpression(1))));
+        yieldColumns->addColumn(
+            new YieldColumn(new ArithmeticExpression(Expression::Kind::kAdd,
+                                                     ConstantExpression::make(pool1),
+                                                     ConstantExpression::make(pool1))));
         yieldColumns->addColumn(new YieldColumn(new TagPropertyExpression("person", "name")));
         yieldColumns->addColumn(new YieldColumn(new TagPropertyExpression("person", "age")));
         auto *project = Project::make(qctx, gv, yieldColumns.get());

--- a/src/validator/test/ValidatorTestBase.h
+++ b/src/validator/test/ValidatorTestBase.h
@@ -47,13 +47,14 @@ protected:
 
     StatusOr<QueryContext*> validate(const std::string& query) {
         VLOG(1) << "query: " << query;
-        auto result = GQLParser().parse(query);
+        auto qctx = buildContext();
+        auto result = GQLParser(qctx).parse(query);
         if (!result.ok()) {
             return std::move(result).status();
         }
-        NG_RETURN_IF_ERROR(AstUtils::reprAstCheck(*result.value()));
+        NG_RETURN_IF_ERROR(AstUtils::reprAstCheck(*result.value(), qctx));
+
         auto sentences = pool_->add(std::move(result).value().release());
-        auto qctx = buildContext();
         NG_RETURN_IF_ERROR(Validator::validate(sentences, qctx));
         return qctx;
     }

--- a/src/visitor/ExtractFilterExprVisitor.cpp
+++ b/src/visitor/ExtractFilterExprVisitor.cpp
@@ -93,13 +93,13 @@ void ExtractFilterExprVisitor::visit(LogicalExpression *expr) {
             canBePushed = canBePushed || canBePushed_;
         }
         if (canBePushed) {
-            auto remainedExpr = std::make_unique<LogicalExpression>(Expression::Kind::kLogicalAnd);
+            auto remainedExpr = LogicalExpression::makeAnd(pool_);
             for (auto i = 0u; i < operands.size(); i++) {
                 if (flags[i]) {
                     continue;
                 }
-                remainedExpr->addOperand(operands[i]->clone().release());
-                expr->setOperand(i, new ConstantExpression(true));
+                remainedExpr->addOperand(operands[i]->clone());
+                expr->setOperand(i, ConstantExpression::make(pool_, true));
             }
             if (remainedExpr->operands().size() > 0) {
                 remainedExpr_ = std::move(remainedExpr);

--- a/src/visitor/ExtractFilterExprVisitor.h
+++ b/src/visitor/ExtractFilterExprVisitor.h
@@ -15,14 +15,14 @@ namespace graph {
 
 class ExtractFilterExprVisitor final : public ExprVisitorImpl {
 public:
-    explicit ExtractFilterExprVisitor(ObjectPool *ObjPool);
+    explicit ExtractFilterExprVisitor(ObjectPool *ObjPool) : pool_(ObjPool) {}
 
     bool ok() const override {
         return canBePushed_;
     }
 
-    Expression* remainedExpr() && {
-        return std::move(remainedExpr_);
+    Expression* remainedExpr() {
+        return remainedExpr_;
     }
 
 private:
@@ -52,7 +52,7 @@ private:
 private:
     ObjectPool *pool_;
     bool canBePushed_{true};
-    Expression* remainedExpr_;
+    Expression* remainedExpr_{nullptr};
 };
 
 }   // namespace graph

--- a/src/visitor/ExtractFilterExprVisitor.h
+++ b/src/visitor/ExtractFilterExprVisitor.h
@@ -15,13 +15,13 @@ namespace graph {
 
 class ExtractFilterExprVisitor final : public ExprVisitorImpl {
 public:
-    ExtractFilterExprVisitor() = default;
+    explicit ExtractFilterExprVisitor(ObjectPool *ObjPool);
 
     bool ok() const override {
         return canBePushed_;
     }
 
-    std::unique_ptr<Expression> remainedExpr() && {
+    Expression* remainedExpr() && {
         return std::move(remainedExpr_);
     }
 
@@ -49,8 +49,10 @@ private:
     void visit(ColumnExpression *) override;
     void visit(SubscriptRangeExpression *) override;
 
+private:
+    ObjectPool *pool_;
     bool canBePushed_{true};
-    std::unique_ptr<Expression> remainedExpr_;
+    Expression* remainedExpr_;
 };
 
 }   // namespace graph

--- a/src/visitor/ExtractPropExprVisitor.cpp
+++ b/src/visitor/ExtractPropExprVisitor.cpp
@@ -102,7 +102,7 @@ void ExtractPropExprVisitor::visitPropertyExpr(PropertyExpression* expr) {
     auto found = propExprColMap_.find(propExpr->toString());
     if (found == propExprColMap_.end()) {
         auto newExpr = propExpr->clone();
-        auto col = new YieldColumn(newExpr.release(), expr->prop());
+        auto col = new YieldColumn(newExpr, expr->prop());
         propExprColMap_.emplace(propExpr->toString(), col);
         inputPropCols_->addColumn(col);
     }
@@ -154,7 +154,7 @@ void ExtractPropExprVisitor::visitVertexEdgePropExpr(PropertyExpression* expr) {
     auto found = propExprColMap_.find(propExpr->toString());
     if (found == propExprColMap_.end()) {
         auto newExpr = propExpr->clone();
-        auto col = new YieldColumn(newExpr.release(), vctx_->anonColGen()->getCol());
+        auto col = new YieldColumn(newExpr, vctx_->anonColGen()->getCol());
         propExprColMap_.emplace(propExpr->toString(), col);
         srcAndEdgePropCols_->addColumn(col);
     }
@@ -192,7 +192,7 @@ void ExtractPropExprVisitor::visit(DestPropertyExpression* expr) {
     auto found = propExprColMap_.find(expr->toString());
     if (found == propExprColMap_.end()) {
         auto newExpr = expr->clone();
-        auto col = new YieldColumn(newExpr.release(), vctx_->anonColGen()->getCol());
+        auto col = new YieldColumn(newExpr, vctx_->anonColGen()->getCol());
         propExprColMap_.emplace(expr->toString(), col);
         dstPropCols_->addColumn(col);
     }

--- a/src/visitor/FoldConstantExprVisitor.h
+++ b/src/visitor/FoldConstantExprVisitor.h
@@ -15,6 +15,8 @@ namespace graph {
 
 class FoldConstantExprVisitor final : public ExprVisitor {
 public:
+    explicit FoldConstantExprVisitor(ObjectPool* pool): pool_(pool) {}
+
     bool canBeFolded() const {
         return canBeFolded_;
     }
@@ -86,6 +88,8 @@ public:
     Expression *fold(Expression *expr);
 
 private:
+    // Obejct pool used to manage expressions generated during visiting
+    ObjectPool *pool_;
     bool canBeFolded_{false};
     Status status_;
 };

--- a/src/visitor/RewriteSymExprVisitor.cpp
+++ b/src/visitor/RewriteSymExprVisitor.cpp
@@ -9,44 +9,46 @@
 namespace nebula {
 namespace graph {
 
-RewriteSymExprVisitor::RewriteSymExprVisitor(const std::string &sym, bool isEdge)
-    : sym_(sym), isEdge_(isEdge) {}
+RewriteSymExprVisitor::RewriteSymExprVisitor(ObjectPool *objPool,
+                                             const std::string &sym,
+                                             bool isEdge)
+    : pool_(objPool), sym_(sym), isEdge_(isEdge) {}
 
 void RewriteSymExprVisitor::visit(ConstantExpression *expr) {
     UNUSED(expr);
-    expr_.reset();
+    expr_ = nullptr;
 }
 
 void RewriteSymExprVisitor::visit(UnaryExpression *expr) {
     expr->operand()->accept(this);
     if (expr_) {
-        expr->setOperand(expr_.release());
+        expr->setOperand(expr_);
     }
 }
 
 void RewriteSymExprVisitor::visit(TypeCastingExpression *expr) {
     expr->operand()->accept(this);
     if (expr_) {
-        expr->setOperand(expr_.release());
+        expr->setOperand(expr_);
     }
 }
 
 void RewriteSymExprVisitor::visit(LabelExpression *expr) {
     if (isEdge_) {
-        expr_ = std::make_unique<EdgePropertyExpression>(sym_, expr->name());
+        expr_ = EdgePropertyExpression::make(pool_, sym_, expr->name());
     } else {
-        expr_ = std::make_unique<SourcePropertyExpression>(sym_, expr->name());
+        expr_ = SourcePropertyExpression::make(pool_, sym_, expr->name());
     }
 }
 
 void RewriteSymExprVisitor::visit(LabelAttributeExpression *expr) {
     if (isEdge_) {
-        expr_ = std::make_unique<EdgePropertyExpression>(expr->left()->name(),
+        expr_ = EdgePropertyExpression::make(pool_, expr->left()->name(),
                                                          expr->right()->value().getStr());
         hasWrongType_ = false;
     } else {
         hasWrongType_ = true;
-        expr_.reset();
+        expr_ = nullptr;
     }
 }
 
@@ -73,7 +75,7 @@ void RewriteSymExprVisitor::visit(LogicalExpression *expr) {
     for (auto i = 0u; i < operands.size(); i++) {
         operands[i]->accept(this);
         if (expr_) {
-            expr->setOperand(i, expr_.release());
+            expr->setOperand(i, expr_);
         }
     }
 }
@@ -94,7 +96,7 @@ void RewriteSymExprVisitor::visit(AggregateExpression *expr) {
     auto* arg = expr->arg();
     arg->accept(this);
     if (expr_) {
-        expr->setArg(std::move(expr_).release());
+        expr->setArg(std::move(expr_));
     }
 }
 
@@ -202,43 +204,43 @@ void RewriteSymExprVisitor::visit(EdgeDstIdExpression *expr) {
 
 void RewriteSymExprVisitor::visit(VertexExpression *expr) {
     UNUSED(expr);
-    expr_.reset();
+    expr_ = nullptr;
 }
 
 void RewriteSymExprVisitor::visit(EdgeExpression *expr) {
     UNUSED(expr);
-    expr_.reset();
+    expr_ = nullptr;
 }
 
 void RewriteSymExprVisitor::visit(ColumnExpression *expr) {
     UNUSED(expr);
-    expr_.reset();
+    expr_ = nullptr;
 }
 
 void RewriteSymExprVisitor::visit(CaseExpression *expr) {
     if (expr->hasCondition()) {
         expr->condition()->accept(this);
         if (expr_) {
-            expr->setCondition(expr_.release());
+            expr->setCondition(expr_);
         }
     }
     if (expr->hasDefault()) {
         expr->defaultResult()->accept(this);
         if (expr_) {
-            expr->setDefault(expr_.release());
+            expr->setDefault(expr_);
         }
     }
     auto &cases = expr->cases();
     for (size_t i = 0; i < cases.size(); ++i) {
-        auto when = cases[i].when.get();
-        auto then = cases[i].then.get();
+        auto when = cases[i].when;
+        auto then = cases[i].then;
         when->accept(this);
         if (expr_) {
-            expr->setWhen(i, expr_.release());
+            expr->setWhen(i, expr_);
         }
         then->accept(this);
         if (expr_) {
-            expr->setThen(i, expr_.release());
+            expr->setThen(i, expr_);
         }
     }
 }
@@ -246,11 +248,11 @@ void RewriteSymExprVisitor::visit(CaseExpression *expr) {
 void RewriteSymExprVisitor::visitBinaryExpr(BinaryExpression *expr) {
     expr->left()->accept(this);
     if (expr_) {
-        expr->setLeft(expr_.release());
+        expr->setLeft(expr_);
     }
     expr->right()->accept(this);
     if (expr_) {
-        expr->setRight(expr_.release());
+        expr->setRight(expr_);
     }
 }
 
@@ -267,18 +269,18 @@ void RewriteSymExprVisitor::visit(PathBuildExpression *expr) {
 void RewriteSymExprVisitor::visit(ListComprehensionExpression *expr) {
     expr->collection()->accept(this);
     if (expr_) {
-        expr->setCollection(expr_.release());
+        expr->setCollection(expr_);
     }
     if (expr->hasFilter()) {
         expr->filter()->accept(this);
         if (expr_) {
-            expr->setFilter(expr_.release());
+            expr->setFilter(expr_);
         }
     }
     if (expr->hasMapping()) {
         expr->mapping()->accept(this);
         if (expr_) {
-            expr->setMapping(expr_.release());
+            expr->setMapping(expr_);
         }
     }
 }
@@ -286,12 +288,12 @@ void RewriteSymExprVisitor::visit(ListComprehensionExpression *expr) {
 void RewriteSymExprVisitor::visit(PredicateExpression *expr) {
     expr->collection()->accept(this);
     if (expr_) {
-        expr->setCollection(expr_.release());
+        expr->setCollection(expr_);
     }
     if (expr->hasFilter()) {
         expr->filter()->accept(this);
         if (expr_) {
-            expr->setFilter(expr_.release());
+            expr->setFilter(expr_);
         }
     }
 }
@@ -299,33 +301,33 @@ void RewriteSymExprVisitor::visit(PredicateExpression *expr) {
 void RewriteSymExprVisitor::visit(ReduceExpression *expr) {
     expr->initial()->accept(this);
     if (expr_) {
-        expr->setInitial(expr_.release());
+        expr->setInitial(expr_);
     }
     expr->collection()->accept(this);
     if (expr_) {
-        expr->setCollection(expr_.release());
+        expr->setCollection(expr_);
     }
     expr->mapping()->accept(this);
     if (expr_) {
-        expr->setMapping(expr_.release());
+        expr->setMapping(expr_);
     }
 }
 
 void RewriteSymExprVisitor::visit(SubscriptRangeExpression *expr) {
     expr->list()->accept(this);
     if (expr_) {
-        expr->setList(expr_.release());
+        expr->setList(expr_);
     }
     if (expr->lo() != nullptr) {
         expr->lo()->accept(this);
         if (expr_) {
-            expr->setLo(expr_.release());
+            expr->setLo(expr_);
         }
     }
     if (expr->hi() != nullptr) {
         expr->hi()->accept(this);
         if (expr_) {
-            expr->setHi(expr_.release());
+            expr->setHi(expr_);
         }
     }
 }

--- a/src/visitor/RewriteSymExprVisitor.cpp
+++ b/src/visitor/RewriteSymExprVisitor.cpp
@@ -43,8 +43,8 @@ void RewriteSymExprVisitor::visit(LabelExpression *expr) {
 
 void RewriteSymExprVisitor::visit(LabelAttributeExpression *expr) {
     if (isEdge_) {
-        expr_ = EdgePropertyExpression::make(pool_, expr->left()->name(),
-                                                         expr->right()->value().getStr());
+        expr_ = EdgePropertyExpression::make(
+            pool_, expr->left()->name(), expr->right()->value().getStr());
         hasWrongType_ = false;
     } else {
         hasWrongType_ = true;

--- a/src/visitor/RewriteSymExprVisitor.h
+++ b/src/visitor/RewriteSymExprVisitor.h
@@ -87,7 +87,7 @@ private:
     const std::string &sym_;
     bool hasWrongType_{false};
     bool isEdge_{false};
-    Expression *expr_;
+    Expression *expr_{nullptr};
 };
 
 }   // namespace graph

--- a/src/visitor/RewriteSymExprVisitor.h
+++ b/src/visitor/RewriteSymExprVisitor.h
@@ -19,14 +19,14 @@ namespace graph {
 
 class RewriteSymExprVisitor final : public ExprVisitor {
 public:
-    RewriteSymExprVisitor(const std::string &sym, bool isEdge);
+    RewriteSymExprVisitor(ObjectPool *objPool, const std::string &sym, bool isEdge);
 
     bool hasWrongType() const {
         return hasWrongType_;
     }
 
-    std::unique_ptr<Expression> expr() && {
-        return std::move(expr_);
+    Expression* expr() {
+        return expr_;
     }
 
     void visit(ConstantExpression *expr) override;
@@ -83,10 +83,11 @@ public:
 private:
     void visitBinaryExpr(BinaryExpression *expr);
 
+    ObjectPool *pool_;
     const std::string &sym_;
     bool hasWrongType_{false};
     bool isEdge_{false};
-    std::unique_ptr<Expression> expr_;
+    Expression *expr_;
 };
 
 }   // namespace graph

--- a/src/visitor/RewriteVisitor.cpp
+++ b/src/visitor/RewriteVisitor.cpp
@@ -39,8 +39,8 @@ void RewriteVisitor::visit(FunctionCallExpression *expr) {
     }
 
     for (auto &arg : expr->args()->args()) {
-        if (matcher_(arg.get())) {
-            arg.reset(rewriter_(arg.get()));
+        if (matcher_(arg)) {
+            arg = rewriter_(arg);
         } else {
             arg->accept(this);
         }
@@ -66,8 +66,8 @@ void RewriteVisitor::visit(LogicalExpression *expr) {
     }
 
     for (auto &operand : expr->operands()) {
-        if (matcher_(operand.get())) {
-            const_cast<std::unique_ptr<Expression> &>(operand).reset(rewriter_(operand.get()));
+        if (matcher_(operand)) {
+            const_cast<Expression* &>(operand) = rewriter_(operand);
         } else {
             operand->accept(this);
         }
@@ -81,8 +81,8 @@ void RewriteVisitor::visit(ListExpression *expr) {
 
     auto &items = expr->items();
     for (auto &item : items) {
-        if (matcher_(item.get())) {
-            const_cast<std::unique_ptr<Expression> &>(item).reset(rewriter_(item.get()));
+        if (matcher_(item)) {
+            const_cast<Expression* &>(item) = rewriter_(item);
         } else {
             item->accept(this);
         }
@@ -96,8 +96,8 @@ void RewriteVisitor::visit(SetExpression *expr) {
 
     auto &items = expr->items();
     for (auto &item : items) {
-        if (matcher_(item.get())) {
-            const_cast<std::unique_ptr<Expression> &>(item).reset(rewriter_(item.get()));
+        if (matcher_(item)) {
+            const_cast<Expression* &>(item) = rewriter_(item);
         } else {
             item->accept(this);
         }
@@ -112,8 +112,8 @@ void RewriteVisitor::visit(MapExpression *expr) {
     auto &items = expr->items();
     for (auto &pair : items) {
         auto &item = pair.second;
-        if (matcher_(item.get())) {
-            const_cast<std::unique_ptr<Expression> &>(item).reset(rewriter_(item.get()));
+        if (matcher_(item)) {
+            const_cast<Expression* &>(item) = rewriter_(item);
         } else {
             item->accept(this);
         }
@@ -141,8 +141,8 @@ void RewriteVisitor::visit(CaseExpression *expr) {
     }
     auto &cases = expr->cases();
     for (size_t i = 0; i < cases.size(); ++i) {
-        auto when = cases[i].when.get();
-        auto then = cases[i].then.get();
+        auto when = cases[i].when;
+        auto then = cases[i].then;
         if (matcher_(when)) {
             expr->setWhen(i, rewriter_(when));
         } else {
@@ -230,8 +230,8 @@ void RewriteVisitor::visit(PathBuildExpression *expr) {
 
     auto &items = expr->items();
     for (auto &item : items) {
-        if (matcher_(item.get())) {
-            const_cast<std::unique_ptr<Expression> &>(item).reset(rewriter_(item.get()));
+        if (matcher_(item)) {
+            const_cast<Expression* &>(item) = rewriter_(item);
         } else {
             item->accept(this);
         }
@@ -327,7 +327,7 @@ Expression *RewriteVisitor::transform(const Expression *expr, Matcher matcher, R
         RewriteVisitor visitor(std::move(matcher), std::move(rewriter));
         auto exprCopy = expr->clone();
         exprCopy->accept(&visitor);
-        return exprCopy.release();
+        return exprCopy;
     }
 }
 
@@ -343,7 +343,7 @@ Expression *RewriteVisitor::transform(
             std::move(matcher), std::move(rewriter), std::move(needVisitedTypes));
         auto exprCopy = expr->clone();
         exprCopy->accept(&visitor);
-        return exprCopy.release();
+        return exprCopy;
     }
 }
 }   // namespace graph

--- a/src/visitor/test/DeduceTypeVisitorTest.cpp
+++ b/src/visitor/test/DeduceTypeVisitorTest.cpp
@@ -5,6 +5,7 @@
  */
 
 #include "visitor/DeduceTypeVisitor.h"
+#include "visitor/test/VisitorTestBase.h"
 
 #include <gtest/gtest.h>
 
@@ -12,7 +13,7 @@ using Type = nebula::Value::Type;
 
 namespace nebula {
 namespace graph {
-class DeduceTypeVisitorTest : public ::testing::Test {
+class DeduceTypeVisitorTest : public ValidatorTestBase {
 protected:
     static ColsDef emptyInput_;
 };
@@ -21,9 +22,10 @@ ColsDef DeduceTypeVisitorTest::emptyInput_;
 
 TEST_F(DeduceTypeVisitorTest, SubscriptExpr) {
     {
-        auto* items = new ExpressionList();
-        items->add(ConstantExpression::make(pool1));
-        auto expr = SubscriptExpression(new ListExpression(items), ConstantExpression::make(pool1));
+        auto* items = ExpressionList::make(pool);
+        items->add(ConstantExpression::make(pool, 1));
+        auto expr = *SubscriptExpression::make(
+            pool, ListExpression::make(pool, items), ConstantExpression::make(pool, 1));
 
         DeduceTypeVisitor visitor(emptyInput_, -1);
         expr.accept(&visitor);
@@ -31,8 +33,9 @@ TEST_F(DeduceTypeVisitorTest, SubscriptExpr) {
         EXPECT_EQ(visitor.type(), Value::Type::__EMPTY__);
     }
     {
-        auto expr = SubscriptExpression(ConstantExpression::make(poolValue::kNullValue),
-                                        ConstantExpression::make(pool1));
+        auto expr = *SubscriptExpression::make(pool,
+                                               ConstantExpression::make(pool, Value::kNullValue),
+                                               ConstantExpression::make(pool, 1));
 
         DeduceTypeVisitor visitor(emptyInput_, -1);
         expr.accept(&visitor);
@@ -40,8 +43,8 @@ TEST_F(DeduceTypeVisitorTest, SubscriptExpr) {
         EXPECT_EQ(visitor.type(), Value::Type::__EMPTY__);
     }
     {
-        auto expr = SubscriptExpression(ConstantExpression::make(poolValue::kEmpty),
-                                        ConstantExpression::make(pool1));
+        auto expr = *SubscriptExpression::make(
+            pool, ConstantExpression::make(pool, Value::kEmpty), ConstantExpression::make(pool, 1));
 
         DeduceTypeVisitor visitor(emptyInput_, -1);
         expr.accept(&visitor);
@@ -49,8 +52,9 @@ TEST_F(DeduceTypeVisitorTest, SubscriptExpr) {
         EXPECT_EQ(visitor.type(), Value::Type::__EMPTY__);
     }
     {
-        auto expr = SubscriptExpression(ConstantExpression::make(poolValue::kNullValue),
-                                        ConstantExpression::make(poolValue::kNullValue));
+        auto expr = *SubscriptExpression::make(pool,
+                                               ConstantExpression::make(pool, Value::kNullValue),
+                                               ConstantExpression::make(pool, Value::kNullValue));
 
         DeduceTypeVisitor visitor(emptyInput_, -1);
         expr.accept(&visitor);
@@ -58,8 +62,9 @@ TEST_F(DeduceTypeVisitorTest, SubscriptExpr) {
         EXPECT_EQ(visitor.type(), Value::Type::__EMPTY__);
     }
     {
-        auto expr = SubscriptExpression(
-            ConstantExpression::make(poolValue(Map({{"k", "v"}, {"k1", "v1"}}))),
+        auto expr = *SubscriptExpression::make(
+            pool,
+            ConstantExpression::make(pool, Value(Map({{"k", "v"}, {"k1", "v1"}}))),
             ConstantExpression::make(pool, "test"));
 
         DeduceTypeVisitor visitor(emptyInput_, -1);
@@ -68,8 +73,9 @@ TEST_F(DeduceTypeVisitorTest, SubscriptExpr) {
         EXPECT_EQ(visitor.type(), Value::Type::__EMPTY__);
     }
     {
-        auto expr = SubscriptExpression(ConstantExpression::make(poolValue::kEmpty),
-                                        ConstantExpression::make(pool, "test"));
+        auto expr = *SubscriptExpression::make(pool,
+                                               ConstantExpression::make(pool, Value::kEmpty),
+                                               ConstantExpression::make(pool, "test"));
 
         DeduceTypeVisitor visitor(emptyInput_, -1);
         expr.accept(&visitor);
@@ -77,8 +83,9 @@ TEST_F(DeduceTypeVisitorTest, SubscriptExpr) {
         EXPECT_EQ(visitor.type(), Value::Type::__EMPTY__);
     }
     {
-        auto expr = SubscriptExpression(ConstantExpression::make(poolValue::kNullValue),
-                                        ConstantExpression::make(pool, "test"));
+        auto expr = *SubscriptExpression::make(pool,
+                                               ConstantExpression::make(pool, Value::kNullValue),
+                                               ConstantExpression::make(pool, "test"));
 
         DeduceTypeVisitor visitor(emptyInput_, -1);
         expr.accept(&visitor);
@@ -88,26 +95,27 @@ TEST_F(DeduceTypeVisitorTest, SubscriptExpr) {
 
     // exceptions
     {
-        auto expr = SubscriptExpression(ConstantExpression::make(pool, "test"),
-                                        ConstantExpression::make(pool, 1));
+        auto expr = *SubscriptExpression::make(
+            pool, ConstantExpression::make(pool, "test"), ConstantExpression::make(pool, 1));
 
         DeduceTypeVisitor visitor(emptyInput_, -1);
         expr.accept(&visitor);
         EXPECT_FALSE(visitor.ok());
     }
     {
-        auto* items = new ExpressionList();
-        items->add(ConstantExpression::make(pool1));
-        auto expr =
-            SubscriptExpression(new ListExpression(items), ConstantExpression::make(pool, "test"));
+        auto* items = ExpressionList::make(pool);
+        items->add(ConstantExpression::make(pool, 1));
+        auto expr = *SubscriptExpression::make(
+            pool, ListExpression::make(pool, items), ConstantExpression::make(pool, "test"));
 
         DeduceTypeVisitor visitor(emptyInput_, -1);
         expr.accept(&visitor);
         EXPECT_FALSE(visitor.ok());
     }
     {
-        auto expr = SubscriptExpression(
-            ConstantExpression::make(poolValue(Map({{"k", "v"}, {"k1", "v1"}}))),
+        auto expr = *SubscriptExpression::make(
+            pool,
+            ConstantExpression::make(pool, Value(Map({{"k", "v"}, {"k1", "v1"}}))),
             ConstantExpression::make(pool, 1));
 
         DeduceTypeVisitor visitor(emptyInput_, -1);
@@ -118,8 +126,9 @@ TEST_F(DeduceTypeVisitorTest, SubscriptExpr) {
 
 TEST_F(DeduceTypeVisitorTest, Attribute) {
     {
-        auto expr = AttributeExpression(
-            ConstantExpression::make(poolValue(Map({{"k", "v"}, {"k1", "v1"}}))),
+        auto expr = *AttributeExpression::make(
+            pool,
+            ConstantExpression::make(pool, Value(Map({{"k", "v"}, {"k1", "v1"}}))),
             ConstantExpression::make(pool, "a"));
 
         DeduceTypeVisitor visitor(emptyInput_, -1);
@@ -128,8 +137,10 @@ TEST_F(DeduceTypeVisitorTest, Attribute) {
         EXPECT_EQ(visitor.type(), Value::Type::__EMPTY__);
     }
     {
-        auto expr = AttributeExpression(ConstantExpression::make(poolValue(Vertex("vid", {}))),
-                                        ConstantExpression::make(pool, "a"));
+        auto expr =
+            *AttributeExpression::make(pool,
+                                       ConstantExpression::make(pool, Value(Vertex("vid", {}))),
+                                       ConstantExpression::make(pool, "a"));
 
         DeduceTypeVisitor visitor(emptyInput_, -1);
         expr.accept(&visitor);
@@ -137,8 +148,9 @@ TEST_F(DeduceTypeVisitorTest, Attribute) {
         EXPECT_EQ(visitor.type(), Value::Type::__EMPTY__);
     }
     {
-        auto expr = AttributeExpression(
-            ConstantExpression::make(poolValue(Edge("v1", "v2", 1, "edge", 0, {}))),
+        auto expr = *AttributeExpression::make(
+            pool,
+            ConstantExpression::make(pool, Value(Edge("v1", "v2", 1, "edge", 0, {}))),
             ConstantExpression::make(pool, "a"));
 
         DeduceTypeVisitor visitor(emptyInput_, -1);
@@ -147,8 +159,9 @@ TEST_F(DeduceTypeVisitorTest, Attribute) {
         EXPECT_EQ(visitor.type(), Value::Type::__EMPTY__);
     }
     {
-        auto expr = AttributeExpression(ConstantExpression::make(poolValue::kNullValue),
-                                        ConstantExpression::make(pool, "a"));
+        auto expr = *AttributeExpression::make(pool,
+                                               ConstantExpression::make(pool, Value::kNullValue),
+                                               ConstantExpression::make(pool, "a"));
 
         DeduceTypeVisitor visitor(emptyInput_, -1);
         expr.accept(&visitor);
@@ -156,8 +169,9 @@ TEST_F(DeduceTypeVisitorTest, Attribute) {
         EXPECT_EQ(visitor.type(), Value::Type::__EMPTY__);
     }
     {
-        auto expr = AttributeExpression(ConstantExpression::make(poolValue::kNullValue),
-                                        ConstantExpression::make(poolValue::kNullValue));
+        auto expr = *AttributeExpression::make(pool,
+                                               ConstantExpression::make(pool, Value::kNullValue),
+                                               ConstantExpression::make(pool, Value::kNullValue));
 
         DeduceTypeVisitor visitor(emptyInput_, -1);
         expr.accept(&visitor);
@@ -167,17 +181,18 @@ TEST_F(DeduceTypeVisitorTest, Attribute) {
 
     // exceptions
     {
-        auto expr = AttributeExpression(ConstantExpression::make(pool, "test"),
-                                        ConstantExpression::make(pool, "a"));
+        auto expr = *AttributeExpression::make(
+            pool, ConstantExpression::make(pool, "test"), ConstantExpression::make(pool, "a"));
 
         DeduceTypeVisitor visitor(emptyInput_, -1);
         expr.accept(&visitor);
         EXPECT_FALSE(visitor.ok());
     }
     {
-        auto expr = AttributeExpression(
-            ConstantExpression::make(poolValue(Map({{"k", "v"}, {"k1", "v1"}}))),
-            ConstantExpression::make(pool1));
+        auto expr = *AttributeExpression::make(
+            pool,
+            ConstantExpression::make(pool, Value(Map({{"k", "v"}, {"k1", "v1"}}))),
+            ConstantExpression::make(pool, 1));
 
         DeduceTypeVisitor visitor(emptyInput_, -1);
         expr.accept(&visitor);

--- a/src/visitor/test/DeduceTypeVisitorTest.cpp
+++ b/src/visitor/test/DeduceTypeVisitorTest.cpp
@@ -24,178 +24,178 @@ TEST_F(DeduceTypeVisitorTest, SubscriptExpr) {
     {
         auto* items = ExpressionList::make(pool);
         items->add(ConstantExpression::make(pool, 1));
-        auto expr = *SubscriptExpression::make(
+        auto expr = SubscriptExpression::make(
             pool, ListExpression::make(pool, items), ConstantExpression::make(pool, 1));
 
         DeduceTypeVisitor visitor(emptyInput_, -1);
-        expr.accept(&visitor);
+        expr->accept(&visitor);
         EXPECT_TRUE(visitor.ok());
         EXPECT_EQ(visitor.type(), Value::Type::__EMPTY__);
     }
     {
-        auto expr = *SubscriptExpression::make(pool,
+        auto expr = SubscriptExpression::make(pool,
                                                ConstantExpression::make(pool, Value::kNullValue),
                                                ConstantExpression::make(pool, 1));
 
         DeduceTypeVisitor visitor(emptyInput_, -1);
-        expr.accept(&visitor);
+        expr->accept(&visitor);
         EXPECT_TRUE(visitor.ok()) << std::move(visitor).status();
         EXPECT_EQ(visitor.type(), Value::Type::__EMPTY__);
     }
     {
-        auto expr = *SubscriptExpression::make(
+        auto expr = SubscriptExpression::make(
             pool, ConstantExpression::make(pool, Value::kEmpty), ConstantExpression::make(pool, 1));
 
         DeduceTypeVisitor visitor(emptyInput_, -1);
-        expr.accept(&visitor);
+        expr->accept(&visitor);
         EXPECT_TRUE(visitor.ok());
         EXPECT_EQ(visitor.type(), Value::Type::__EMPTY__);
     }
     {
-        auto expr = *SubscriptExpression::make(pool,
+        auto expr = SubscriptExpression::make(pool,
                                                ConstantExpression::make(pool, Value::kNullValue),
                                                ConstantExpression::make(pool, Value::kNullValue));
 
         DeduceTypeVisitor visitor(emptyInput_, -1);
-        expr.accept(&visitor);
+        expr->accept(&visitor);
         EXPECT_TRUE(visitor.ok());
         EXPECT_EQ(visitor.type(), Value::Type::__EMPTY__);
     }
     {
-        auto expr = *SubscriptExpression::make(
+        auto expr = SubscriptExpression::make(
             pool,
             ConstantExpression::make(pool, Value(Map({{"k", "v"}, {"k1", "v1"}}))),
             ConstantExpression::make(pool, "test"));
 
         DeduceTypeVisitor visitor(emptyInput_, -1);
-        expr.accept(&visitor);
+        expr->accept(&visitor);
         EXPECT_TRUE(visitor.ok());
         EXPECT_EQ(visitor.type(), Value::Type::__EMPTY__);
     }
     {
-        auto expr = *SubscriptExpression::make(pool,
+        auto expr = SubscriptExpression::make(pool,
                                                ConstantExpression::make(pool, Value::kEmpty),
                                                ConstantExpression::make(pool, "test"));
 
         DeduceTypeVisitor visitor(emptyInput_, -1);
-        expr.accept(&visitor);
+        expr->accept(&visitor);
         EXPECT_TRUE(visitor.ok());
         EXPECT_EQ(visitor.type(), Value::Type::__EMPTY__);
     }
     {
-        auto expr = *SubscriptExpression::make(pool,
+        auto expr = SubscriptExpression::make(pool,
                                                ConstantExpression::make(pool, Value::kNullValue),
                                                ConstantExpression::make(pool, "test"));
 
         DeduceTypeVisitor visitor(emptyInput_, -1);
-        expr.accept(&visitor);
+        expr->accept(&visitor);
         EXPECT_TRUE(visitor.ok()) << std::move(visitor).status();
         EXPECT_EQ(visitor.type(), Value::Type::__EMPTY__);
     }
 
     // exceptions
     {
-        auto expr = *SubscriptExpression::make(
+        auto expr = SubscriptExpression::make(
             pool, ConstantExpression::make(pool, "test"), ConstantExpression::make(pool, 1));
 
         DeduceTypeVisitor visitor(emptyInput_, -1);
-        expr.accept(&visitor);
+        expr->accept(&visitor);
         EXPECT_FALSE(visitor.ok());
     }
     {
         auto* items = ExpressionList::make(pool);
         items->add(ConstantExpression::make(pool, 1));
-        auto expr = *SubscriptExpression::make(
+        auto expr = SubscriptExpression::make(
             pool, ListExpression::make(pool, items), ConstantExpression::make(pool, "test"));
 
         DeduceTypeVisitor visitor(emptyInput_, -1);
-        expr.accept(&visitor);
+        expr->accept(&visitor);
         EXPECT_FALSE(visitor.ok());
     }
     {
-        auto expr = *SubscriptExpression::make(
+        auto expr = SubscriptExpression::make(
             pool,
             ConstantExpression::make(pool, Value(Map({{"k", "v"}, {"k1", "v1"}}))),
             ConstantExpression::make(pool, 1));
 
         DeduceTypeVisitor visitor(emptyInput_, -1);
-        expr.accept(&visitor);
+        expr->accept(&visitor);
         EXPECT_FALSE(visitor.ok());
     }
 }
 
 TEST_F(DeduceTypeVisitorTest, Attribute) {
     {
-        auto expr = *AttributeExpression::make(
+        auto expr = AttributeExpression::make(
             pool,
             ConstantExpression::make(pool, Value(Map({{"k", "v"}, {"k1", "v1"}}))),
             ConstantExpression::make(pool, "a"));
 
         DeduceTypeVisitor visitor(emptyInput_, -1);
-        expr.accept(&visitor);
+        expr->accept(&visitor);
         EXPECT_TRUE(visitor.ok());
         EXPECT_EQ(visitor.type(), Value::Type::__EMPTY__);
     }
     {
         auto expr =
-            *AttributeExpression::make(pool,
+            AttributeExpression::make(pool,
                                        ConstantExpression::make(pool, Value(Vertex("vid", {}))),
                                        ConstantExpression::make(pool, "a"));
 
         DeduceTypeVisitor visitor(emptyInput_, -1);
-        expr.accept(&visitor);
+        expr->accept(&visitor);
         EXPECT_TRUE(visitor.ok());
         EXPECT_EQ(visitor.type(), Value::Type::__EMPTY__);
     }
     {
-        auto expr = *AttributeExpression::make(
+        auto expr = AttributeExpression::make(
             pool,
             ConstantExpression::make(pool, Value(Edge("v1", "v2", 1, "edge", 0, {}))),
             ConstantExpression::make(pool, "a"));
 
         DeduceTypeVisitor visitor(emptyInput_, -1);
-        expr.accept(&visitor);
+        expr->accept(&visitor);
         EXPECT_TRUE(visitor.ok());
         EXPECT_EQ(visitor.type(), Value::Type::__EMPTY__);
     }
     {
-        auto expr = *AttributeExpression::make(pool,
+        auto expr = AttributeExpression::make(pool,
                                                ConstantExpression::make(pool, Value::kNullValue),
                                                ConstantExpression::make(pool, "a"));
 
         DeduceTypeVisitor visitor(emptyInput_, -1);
-        expr.accept(&visitor);
+        expr->accept(&visitor);
         EXPECT_TRUE(visitor.ok());
         EXPECT_EQ(visitor.type(), Value::Type::__EMPTY__);
     }
     {
-        auto expr = *AttributeExpression::make(pool,
+        auto expr = AttributeExpression::make(pool,
                                                ConstantExpression::make(pool, Value::kNullValue),
                                                ConstantExpression::make(pool, Value::kNullValue));
 
         DeduceTypeVisitor visitor(emptyInput_, -1);
-        expr.accept(&visitor);
+        expr->accept(&visitor);
         EXPECT_TRUE(visitor.ok());
         EXPECT_EQ(visitor.type(), Value::Type::__EMPTY__);
     }
 
     // exceptions
     {
-        auto expr = *AttributeExpression::make(
+        auto expr = AttributeExpression::make(
             pool, ConstantExpression::make(pool, "test"), ConstantExpression::make(pool, "a"));
 
         DeduceTypeVisitor visitor(emptyInput_, -1);
-        expr.accept(&visitor);
+        expr->accept(&visitor);
         EXPECT_FALSE(visitor.ok());
     }
     {
-        auto expr = *AttributeExpression::make(
+        auto expr = AttributeExpression::make(
             pool,
             ConstantExpression::make(pool, Value(Map({{"k", "v"}, {"k1", "v1"}}))),
             ConstantExpression::make(pool, 1));
 
         DeduceTypeVisitor visitor(emptyInput_, -1);
-        expr.accept(&visitor);
+        expr->accept(&visitor);
         EXPECT_FALSE(visitor.ok());
     }
 }

--- a/src/visitor/test/DeduceTypeVisitorTest.cpp
+++ b/src/visitor/test/DeduceTypeVisitorTest.cpp
@@ -22,8 +22,8 @@ ColsDef DeduceTypeVisitorTest::emptyInput_;
 TEST_F(DeduceTypeVisitorTest, SubscriptExpr) {
     {
         auto* items = new ExpressionList();
-        items->add(new ConstantExpression(1));
-        auto expr = SubscriptExpression(new ListExpression(items), new ConstantExpression(1));
+        items->add(ConstantExpression::make(pool1));
+        auto expr = SubscriptExpression(new ListExpression(items), ConstantExpression::make(pool1));
 
         DeduceTypeVisitor visitor(emptyInput_, -1);
         expr.accept(&visitor);
@@ -31,8 +31,8 @@ TEST_F(DeduceTypeVisitorTest, SubscriptExpr) {
         EXPECT_EQ(visitor.type(), Value::Type::__EMPTY__);
     }
     {
-        auto expr = SubscriptExpression(new ConstantExpression(Value::kNullValue),
-                                        new ConstantExpression(1));
+        auto expr = SubscriptExpression(ConstantExpression::make(poolValue::kNullValue),
+                                        ConstantExpression::make(pool1));
 
         DeduceTypeVisitor visitor(emptyInput_, -1);
         expr.accept(&visitor);
@@ -40,8 +40,8 @@ TEST_F(DeduceTypeVisitorTest, SubscriptExpr) {
         EXPECT_EQ(visitor.type(), Value::Type::__EMPTY__);
     }
     {
-        auto expr = SubscriptExpression(new ConstantExpression(Value::kEmpty),
-                                        new ConstantExpression(1));
+        auto expr = SubscriptExpression(ConstantExpression::make(poolValue::kEmpty),
+                                        ConstantExpression::make(pool1));
 
         DeduceTypeVisitor visitor(emptyInput_, -1);
         expr.accept(&visitor);
@@ -49,8 +49,8 @@ TEST_F(DeduceTypeVisitorTest, SubscriptExpr) {
         EXPECT_EQ(visitor.type(), Value::Type::__EMPTY__);
     }
     {
-        auto expr = SubscriptExpression(new ConstantExpression(Value::kNullValue),
-                                        new ConstantExpression(Value::kNullValue));
+        auto expr = SubscriptExpression(ConstantExpression::make(poolValue::kNullValue),
+                                        ConstantExpression::make(poolValue::kNullValue));
 
         DeduceTypeVisitor visitor(emptyInput_, -1);
         expr.accept(&visitor);
@@ -58,9 +58,9 @@ TEST_F(DeduceTypeVisitorTest, SubscriptExpr) {
         EXPECT_EQ(visitor.type(), Value::Type::__EMPTY__);
     }
     {
-        auto expr =
-            SubscriptExpression(new ConstantExpression(Value(Map({{"k", "v"}, {"k1", "v1"}}))),
-                                new ConstantExpression("test"));
+        auto expr = SubscriptExpression(
+            ConstantExpression::make(poolValue(Map({{"k", "v"}, {"k1", "v1"}}))),
+            ConstantExpression::make(pool, "test"));
 
         DeduceTypeVisitor visitor(emptyInput_, -1);
         expr.accept(&visitor);
@@ -68,8 +68,8 @@ TEST_F(DeduceTypeVisitorTest, SubscriptExpr) {
         EXPECT_EQ(visitor.type(), Value::Type::__EMPTY__);
     }
     {
-        auto expr = SubscriptExpression(new ConstantExpression(Value::kEmpty),
-                                new ConstantExpression("test"));
+        auto expr = SubscriptExpression(ConstantExpression::make(poolValue::kEmpty),
+                                        ConstantExpression::make(pool, "test"));
 
         DeduceTypeVisitor visitor(emptyInput_, -1);
         expr.accept(&visitor);
@@ -77,8 +77,8 @@ TEST_F(DeduceTypeVisitorTest, SubscriptExpr) {
         EXPECT_EQ(visitor.type(), Value::Type::__EMPTY__);
     }
     {
-        auto expr = SubscriptExpression(new ConstantExpression(Value::kNullValue),
-                                        new ConstantExpression("test"));
+        auto expr = SubscriptExpression(ConstantExpression::make(poolValue::kNullValue),
+                                        ConstantExpression::make(pool, "test"));
 
         DeduceTypeVisitor visitor(emptyInput_, -1);
         expr.accept(&visitor);
@@ -88,8 +88,8 @@ TEST_F(DeduceTypeVisitorTest, SubscriptExpr) {
 
     // exceptions
     {
-        auto expr = SubscriptExpression(new ConstantExpression("test"),
-                                        new ConstantExpression(1));
+        auto expr = SubscriptExpression(ConstantExpression::make(pool, "test"),
+                                        ConstantExpression::make(pool, 1));
 
         DeduceTypeVisitor visitor(emptyInput_, -1);
         expr.accept(&visitor);
@@ -97,17 +97,18 @@ TEST_F(DeduceTypeVisitorTest, SubscriptExpr) {
     }
     {
         auto* items = new ExpressionList();
-        items->add(new ConstantExpression(1));
-        auto expr = SubscriptExpression(new ListExpression(items), new ConstantExpression("test"));
+        items->add(ConstantExpression::make(pool1));
+        auto expr =
+            SubscriptExpression(new ListExpression(items), ConstantExpression::make(pool, "test"));
 
         DeduceTypeVisitor visitor(emptyInput_, -1);
         expr.accept(&visitor);
         EXPECT_FALSE(visitor.ok());
     }
     {
-        auto expr =
-            SubscriptExpression(new ConstantExpression(Value(Map({{"k", "v"}, {"k1", "v1"}}))),
-                                new ConstantExpression(1));
+        auto expr = SubscriptExpression(
+            ConstantExpression::make(poolValue(Map({{"k", "v"}, {"k1", "v1"}}))),
+            ConstantExpression::make(pool, 1));
 
         DeduceTypeVisitor visitor(emptyInput_, -1);
         expr.accept(&visitor);
@@ -117,9 +118,9 @@ TEST_F(DeduceTypeVisitorTest, SubscriptExpr) {
 
 TEST_F(DeduceTypeVisitorTest, Attribute) {
     {
-        auto expr =
-            AttributeExpression(new ConstantExpression(Value(Map({{"k", "v"}, {"k1", "v1"}}))),
-                                new ConstantExpression("a"));
+        auto expr = AttributeExpression(
+            ConstantExpression::make(poolValue(Map({{"k", "v"}, {"k1", "v1"}}))),
+            ConstantExpression::make(pool, "a"));
 
         DeduceTypeVisitor visitor(emptyInput_, -1);
         expr.accept(&visitor);
@@ -127,8 +128,8 @@ TEST_F(DeduceTypeVisitorTest, Attribute) {
         EXPECT_EQ(visitor.type(), Value::Type::__EMPTY__);
     }
     {
-        auto expr = AttributeExpression(new ConstantExpression(Value(Vertex("vid", {}))),
-                                        new ConstantExpression("a"));
+        auto expr = AttributeExpression(ConstantExpression::make(poolValue(Vertex("vid", {}))),
+                                        ConstantExpression::make(pool, "a"));
 
         DeduceTypeVisitor visitor(emptyInput_, -1);
         expr.accept(&visitor);
@@ -136,9 +137,9 @@ TEST_F(DeduceTypeVisitorTest, Attribute) {
         EXPECT_EQ(visitor.type(), Value::Type::__EMPTY__);
     }
     {
-        auto expr =
-            AttributeExpression(new ConstantExpression(Value(Edge("v1", "v2", 1, "edge", 0, {}))),
-                                new ConstantExpression("a"));
+        auto expr = AttributeExpression(
+            ConstantExpression::make(poolValue(Edge("v1", "v2", 1, "edge", 0, {}))),
+            ConstantExpression::make(pool, "a"));
 
         DeduceTypeVisitor visitor(emptyInput_, -1);
         expr.accept(&visitor);
@@ -146,9 +147,8 @@ TEST_F(DeduceTypeVisitorTest, Attribute) {
         EXPECT_EQ(visitor.type(), Value::Type::__EMPTY__);
     }
     {
-        auto expr =
-            AttributeExpression(new ConstantExpression(Value::kNullValue),
-                                new ConstantExpression("a"));
+        auto expr = AttributeExpression(ConstantExpression::make(poolValue::kNullValue),
+                                        ConstantExpression::make(pool, "a"));
 
         DeduceTypeVisitor visitor(emptyInput_, -1);
         expr.accept(&visitor);
@@ -156,9 +156,8 @@ TEST_F(DeduceTypeVisitorTest, Attribute) {
         EXPECT_EQ(visitor.type(), Value::Type::__EMPTY__);
     }
     {
-        auto expr =
-            AttributeExpression(new ConstantExpression(Value::kNullValue),
-                                new ConstantExpression(Value::kNullValue));
+        auto expr = AttributeExpression(ConstantExpression::make(poolValue::kNullValue),
+                                        ConstantExpression::make(poolValue::kNullValue));
 
         DeduceTypeVisitor visitor(emptyInput_, -1);
         expr.accept(&visitor);
@@ -168,22 +167,22 @@ TEST_F(DeduceTypeVisitorTest, Attribute) {
 
     // exceptions
     {
-        auto expr = AttributeExpression(new ConstantExpression("test"),
-                                        new ConstantExpression("a"));
+        auto expr = AttributeExpression(ConstantExpression::make(pool, "test"),
+                                        ConstantExpression::make(pool, "a"));
 
         DeduceTypeVisitor visitor(emptyInput_, -1);
         expr.accept(&visitor);
         EXPECT_FALSE(visitor.ok());
     }
     {
-        auto expr =
-            AttributeExpression(new ConstantExpression(Value(Map({{"k", "v"}, {"k1", "v1"}}))),
-                                new ConstantExpression(1));
+        auto expr = AttributeExpression(
+            ConstantExpression::make(poolValue(Map({{"k", "v"}, {"k1", "v1"}}))),
+            ConstantExpression::make(pool1));
 
         DeduceTypeVisitor visitor(emptyInput_, -1);
         expr.accept(&visitor);
         EXPECT_FALSE(visitor.ok());
     }
 }
-}  // namespace graph
-}  // namespace nebula
+}   // namespace graph
+}   // namespace nebula

--- a/src/visitor/test/FoldConstantExprVisitorTest.cpp
+++ b/src/visitor/test/FoldConstantExprVisitorTest.cpp
@@ -14,72 +14,63 @@
 namespace nebula {
 namespace graph {
 
-class FoldConstantExprVisitorTest : public ValidatorTestBase {
-public:
-    void TearDown() override {
-        pool.clear();
-    }
-
-protected:
-    ObjectPool pool;
-};
+class FoldConstantExprVisitorTest : public ValidatorTestBase {};
 
 TEST_F(FoldConstantExprVisitorTest, TestArithmeticExpr) {
     // (5 - 1) + 2 => 4 + 2
-    auto expr = pool.add(addExpr(minusExpr(constantExpr(5), constantExpr(1)), constantExpr(2)));
-    FoldConstantExprVisitor visitor;
+    auto expr = addExpr(minusExpr(constantExpr(5), constantExpr(1)), constantExpr(2));
+    FoldConstantExprVisitor visitor(pool);
     expr->accept(&visitor);
-    auto expected = pool.add(addExpr(constantExpr(4), constantExpr(2)));
+    auto expected = addExpr(constantExpr(4), constantExpr(2));
     ASSERT_EQ(*expr, *expected) << expr->toString() << " vs. " << expected->toString();
     ASSERT(visitor.canBeFolded());
 
     // 4+2 => 6
-    auto root = pool.add(visitor.fold(expr));
-    auto rootExpected = pool.add(constantExpr(6));
+    auto root = visitor.fold(expr);
+    auto rootExpected = constantExpr(6);
     ASSERT_EQ(*root, *rootExpected) << root->toString() << " vs. " << rootExpected->toString();
 }
 
 TEST_F(FoldConstantExprVisitorTest, TestRelationExpr) {
     // false == !(3 > (1+1)) => false == false
-    auto expr = pool.add(
-        eqExpr(constantExpr(false),
-               notExpr(gtExpr(constantExpr(3), addExpr(constantExpr(1), constantExpr(1))))));
-    auto expected = pool.add(eqExpr(constantExpr(false), constantExpr(false)));
-    FoldConstantExprVisitor visitor;
+    auto expr = eqExpr(constantExpr(false),
+                       notExpr(gtExpr(constantExpr(3), addExpr(constantExpr(1), constantExpr(1)))));
+    auto expected = eqExpr(constantExpr(false), constantExpr(false));
+    FoldConstantExprVisitor visitor(pool);
     expr->accept(&visitor);
     ASSERT_EQ(*expr, *expected) << expr->toString() << " vs. " << expected->toString();
     ASSERT(visitor.canBeFolded());
 
     // false==false => true
-    auto root = pool.add(visitor.fold(expr));
-    auto rootExpected = pool.add(constantExpr(true));
+    auto root = visitor.fold(expr);
+    auto rootExpected = constantExpr(true);
     ASSERT_EQ(*root, *rootExpected) << root->toString() << " vs. " << rootExpected->toString();
 }
 
 TEST_F(FoldConstantExprVisitorTest, TestLogicalExpr) {
     {
         // false AND (false || (3 > (1 + 1))) => false AND true
-        auto expr = pool.add(
+        auto expr =
             andExpr(constantExpr(false),
                     orExpr(constantExpr(false),
-                           gtExpr(constantExpr(3), addExpr(constantExpr(1), constantExpr(1))))));
-        auto expected = pool.add(andExpr(constantExpr(false), constantExpr(true)));
-        FoldConstantExprVisitor visitor;
+                           gtExpr(constantExpr(3), addExpr(constantExpr(1), constantExpr(1)))));
+        auto expected = andExpr(constantExpr(false), constantExpr(true));
+        FoldConstantExprVisitor visitor(pool);
         expr->accept(&visitor);
         ASSERT_EQ(*expr, *expected) << expr->toString() << " vs. " << expected->toString();
         ASSERT(visitor.canBeFolded());
 
         // false AND true => false
-        auto root = pool.add(visitor.fold(expr));
-        auto rootExpected = pool.add(constantExpr(false));
+        auto root = visitor.fold(expr);
+        auto rootExpected = constantExpr(false);
         ASSERT_EQ(*root, *rootExpected) << root->toString() << " vs. " << rootExpected->toString();
     }
     {
         // false == false => true
-        auto expr = pool.add(eqExpr(constantExpr(false), constantExpr(false)));
-        FoldConstantExprVisitor visitor;
-        auto foldedExpr = pool.add(visitor.fold(expr));
-        auto rootExpected = pool.add(constantExpr(true));
+        auto expr = eqExpr(constantExpr(false), constantExpr(false));
+        FoldConstantExprVisitor visitor(pool);
+        auto foldedExpr = visitor.fold(expr);
+        auto rootExpected = constantExpr(true);
         ASSERT_EQ(*foldedExpr, *rootExpected)
             << foldedExpr->toString() << " vs. " << rootExpected->toString();
     }
@@ -87,33 +78,33 @@ TEST_F(FoldConstantExprVisitorTest, TestLogicalExpr) {
 
 TEST_F(FoldConstantExprVisitorTest, TestSubscriptExpr) {
     // 1 + [1, pow(2, 2+1), 2][2-1] => 1 + 8
-    auto expr = pool.add(addExpr(
+    auto expr = addExpr(
         constantExpr(1),
         subExpr(
             listExpr({constantExpr(1),
                       fnExpr("pow", {constantExpr(2), addExpr(constantExpr(2), constantExpr(1))}),
                       constantExpr(2)}),
-            minusExpr(constantExpr(2), constantExpr(1)))));
-    auto expected = pool.add(addExpr(constantExpr(1), constantExpr(8)));
-    FoldConstantExprVisitor visitor;
+            minusExpr(constantExpr(2), constantExpr(1))));
+    auto expected = addExpr(constantExpr(1), constantExpr(8));
+    FoldConstantExprVisitor visitor(pool);
     expr->accept(&visitor);
     ASSERT_EQ(*expr, *expected) << expr->toString() << " vs. " << expected->toString();
     ASSERT(visitor.canBeFolded());
 
     // 1+8 => 9
-    auto root = pool.add(visitor.fold(expr));
-    auto rootExpected = pool.add(constantExpr(9));
+    auto root = visitor.fold(expr);
+    auto rootExpected = constantExpr(9);
     ASSERT_EQ(*root, *rootExpected) << root->toString() << " vs. " << rootExpected->toString();
 }
 
 TEST_F(FoldConstantExprVisitorTest, TestListExpr) {
     // [3+4, pow(2, 2+1), 2] => [7, 8, 2]
-    auto expr = pool.add(
+    auto expr =
         listExpr({addExpr(constantExpr(3), constantExpr(4)),
                   fnExpr("pow", {constantExpr(2), addExpr(constantExpr(2), constantExpr(1))}),
-                  constantExpr(2)}));
-    auto expected = pool.add(listExpr({constantExpr(7), constantExpr(8), constantExpr(2)}));
-    FoldConstantExprVisitor visitor;
+                  constantExpr(2)});
+    auto expected = listExpr({constantExpr(7), constantExpr(8), constantExpr(2)});
+    FoldConstantExprVisitor visitor(pool);
     expr->accept(&visitor);
     ASSERT_EQ(*expr, *expected) << expr->toString() << " vs. " << expected->toString();
     ASSERT(visitor.canBeFolded());
@@ -121,12 +112,12 @@ TEST_F(FoldConstantExprVisitorTest, TestListExpr) {
 
 TEST_F(FoldConstantExprVisitorTest, TestSetExpr) {
     // {sqrt(19-3), pow(2, 3+1), 2} => {4, 16, 2}
-    auto expr = pool.add(
+    auto expr =
         setExpr({fnExpr("sqrt", {minusExpr(constantExpr(19), constantExpr(3))}),
                  fnExpr("pow", {constantExpr(2), addExpr(constantExpr(3), constantExpr(1))}),
-                 constantExpr(2)}));
-    auto expected = pool.add(setExpr({constantExpr(4), constantExpr(16), constantExpr(2)}));
-    FoldConstantExprVisitor visitor;
+                 constantExpr(2)});
+    auto expected = setExpr({constantExpr(4), constantExpr(16), constantExpr(2)});
+    FoldConstantExprVisitor visitor(pool);
     expr->accept(&visitor);
     ASSERT_EQ(*expr, *expected) << expr->toString() << " vs. " << expected->toString();
     ASSERT(visitor.canBeFolded());
@@ -134,13 +125,13 @@ TEST_F(FoldConstantExprVisitorTest, TestSetExpr) {
 
 TEST_F(FoldConstantExprVisitorTest, TestMapExpr) {
     // {"jack":1, "tom":pow(2, 2+1), "jerry":5-1} => {"jack":1, "tom":8, "jerry":4}
-    auto expr = pool.add(mapExpr(
+    auto expr = mapExpr(
         {{"jack", constantExpr(1)},
          {"tom", fnExpr("pow", {constantExpr(2), addExpr(constantExpr(2), constantExpr(1))})},
-         {"jerry", minusExpr(constantExpr(5), constantExpr(1))}}));
-    auto expected = pool.add(
-        mapExpr({{"jack", constantExpr(1)}, {"tom", constantExpr(8)}, {"jerry", constantExpr(4)}}));
-    FoldConstantExprVisitor visitor;
+         {"jerry", minusExpr(constantExpr(5), constantExpr(1))}});
+    auto expected =
+        mapExpr({{"jack", constantExpr(1)}, {"tom", constantExpr(8)}, {"jerry", constantExpr(4)}});
+    FoldConstantExprVisitor visitor(pool);
     expr->accept(&visitor);
     ASSERT_EQ(*expr, *expected) << expr->toString() << " vs. " << expected->toString();
     ASSERT(visitor.canBeFolded());
@@ -148,21 +139,19 @@ TEST_F(FoldConstantExprVisitorTest, TestMapExpr) {
 
 TEST_F(FoldConstantExprVisitorTest, TestCaseExpr) {
     // CASE pow(2, (2+1)) WHEN (2+3) THEN (5-1) ELSE (7+8)
-    auto expr = pool.add(caseExpr(fnExpr("pow", {constantExpr(2),
-                                  addExpr(constantExpr(2), constantExpr(1))}),
-                                  addExpr(constantExpr(7), constantExpr(8)),
-                                  addExpr(constantExpr(2), constantExpr(3)),
-                                  minusExpr(constantExpr(5), constantExpr(1))));
-    auto expected = pool.add(caseExpr(constantExpr(8), constantExpr(15),
-                                      constantExpr(5), constantExpr(4)));
-    FoldConstantExprVisitor visitor;
+    auto expr =
+        caseExpr(fnExpr("pow", {constantExpr(2), addExpr(constantExpr(2), constantExpr(1))}),
+                 addExpr(constantExpr(7), constantExpr(8)),
+                 addExpr(constantExpr(2), constantExpr(3)),
+                 minusExpr(constantExpr(5), constantExpr(1)));
+    auto expected = caseExpr(constantExpr(8), constantExpr(15), constantExpr(5), constantExpr(4));
+    FoldConstantExprVisitor visitor(pool);
     expr->accept(&visitor);
     ASSERT_EQ(*expr, *expected) << expr->toString() << " vs. " << expected->toString();
     ASSERT(visitor.canBeFolded());
-
     // CASE 8 WHEN 5 THEN 4 ELSE 15 => 15
-    auto root = pool.add(visitor.fold(expr));
-    auto rootExpected = pool.add(constantExpr(15));
+    auto root = visitor.fold(expr);
+    auto rootExpected = constantExpr(15);
     ASSERT_EQ(*root, *rootExpected) << root->toString() << " vs. " << rootExpected->toString();
 }
 
@@ -170,9 +159,9 @@ TEST_F(FoldConstantExprVisitorTest, TestFoldFunction) {
     // pure function
     // abs(-1) + 1 => 1 + 1
     {
-        auto expr = pool.add(addExpr(fnExpr("abs", {constantExpr(-1)}), constantExpr(1)));
-        auto expected = pool.add(addExpr(constantExpr(1), constantExpr(1)));
-        FoldConstantExprVisitor visitor;
+        auto expr = addExpr(fnExpr("abs", {constantExpr(-1)}), constantExpr(1));
+        auto expected = addExpr(constantExpr(1), constantExpr(1));
+        FoldConstantExprVisitor visitor(pool);
         expr->accept(&visitor);
         ASSERT_TRUE(visitor.canBeFolded());
         ASSERT_EQ(*expr, *expected) << expr->toString() << " vs. " << expected->toString();
@@ -180,9 +169,9 @@ TEST_F(FoldConstantExprVisitorTest, TestFoldFunction) {
     // not pure function
     // rand32(4) + 1 => rand32(4) + 1
     {
-        auto expr = pool.add(addExpr(fnExpr("rand32", {constantExpr(4)}), constantExpr(1)));
-        auto expected = pool.add(addExpr(fnExpr("rand32", {constantExpr(4)}), constantExpr(1)));
-        FoldConstantExprVisitor visitor;
+        auto expr = addExpr(fnExpr("rand32", {constantExpr(4)}), constantExpr(1));
+        auto expected = addExpr(fnExpr("rand32", {constantExpr(4)}), constantExpr(1));
+        FoldConstantExprVisitor visitor(pool);
         expr->accept(&visitor);
         ASSERT_FALSE(visitor.canBeFolded());
         ASSERT_EQ(*expr, *expected) << expr->toString() << " vs. " << expected->toString();
@@ -193,10 +182,9 @@ TEST_F(FoldConstantExprVisitorTest, TestFoldFailed) {
     // function call
     {
         // pow($v, (1+2)) => pow($v, 3)
-        auto expr =
-            pool.add(fnExpr("pow", {varExpr("v"), addExpr(constantExpr(1), constantExpr(2))}));
-        auto expected = pool.add(fnExpr("pow", {varExpr("v"), constantExpr(3)}));
-        FoldConstantExprVisitor visitor;
+        auto expr = fnExpr("pow", {varExpr("v"), addExpr(constantExpr(1), constantExpr(2))});
+        auto expected = fnExpr("pow", {varExpr("v"), constantExpr(3)});
+        FoldConstantExprVisitor visitor(pool);
         expr->accept(&visitor);
         ASSERT_EQ(*expr, *expected) << expr->toString() << " vs. " << expected->toString();
         ASSERT_FALSE(visitor.canBeFolded());
@@ -204,13 +192,13 @@ TEST_F(FoldConstantExprVisitorTest, TestFoldFailed) {
     // list
     {
         // [$v, pow(1, 2), 1+2][2-1] => [$v, 1, 3][0]
-        auto expr = pool.add(subExpr(listExpr({varExpr("v"),
-                                               fnExpr("pow", {constantExpr(1), constantExpr(2)}),
-                                               addExpr(constantExpr(1), constantExpr(2))}),
-                                     minusExpr(constantExpr(1), constantExpr(1))));
-        auto expected = pool.add(
-            subExpr(listExpr({varExpr("v"), constantExpr(1), constantExpr(3)}), constantExpr(0)));
-        FoldConstantExprVisitor visitor;
+        auto expr = subExpr(listExpr({varExpr("v"),
+                                      fnExpr("pow", {constantExpr(1), constantExpr(2)}),
+                                      addExpr(constantExpr(1), constantExpr(2))}),
+                            minusExpr(constantExpr(1), constantExpr(1)));
+        auto expected =
+            subExpr(listExpr({varExpr("v"), constantExpr(1), constantExpr(3)}), constantExpr(0));
+        FoldConstantExprVisitor visitor(pool);
         expr->accept(&visitor);
         ASSERT_EQ(*expr, *expected) << expr->toString() << " vs. " << expected->toString();
         ASSERT_FALSE(visitor.canBeFolded());
@@ -218,13 +206,13 @@ TEST_F(FoldConstantExprVisitorTest, TestFoldFailed) {
 }
 
 TEST_F(FoldConstantExprVisitorTest, TestPathBuild) {
-    auto expr = pool.makeAndAdd<PathBuildExpression>();
-    expr->add(std::unique_ptr<FunctionCallExpression>(fnExpr("upper", {constantExpr("tom")})));
-    FoldConstantExprVisitor fold;
+    auto expr = PathBuildExpression::make(pool);
+    expr->add(fnExpr("upper", {constantExpr("tom")}));
+    FoldConstantExprVisitor fold(pool);
     expr->accept(&fold);
 
-    auto expected = pool.makeAndAdd<PathBuildExpression>();
-    expected->add(std::unique_ptr<ConstantExpression>(constantExpr("TOM")));
+    auto expected = PathBuildExpression::make(pool);
+    expected->add(ConstantExpression::make(pool, "TOM"));
     ASSERT_EQ(*expr, *expected);
 }
 }   // namespace graph

--- a/src/visitor/test/RewriteUnaryNotExprVisitorTest.cpp
+++ b/src/visitor/test/RewriteUnaryNotExprVisitorTest.cpp
@@ -175,12 +175,12 @@ TEST_F(RewriteUnaryNotExprVisitorTest, TestLogicalExpr) {
                                     leExpr(constantExpr(30), constantExpr(20))));
         auto res = ExpressionUtils::reduceUnaryNotExpr(expr, pool);
 
-        auto expected = *LogicalExpression::makeOr(pool);
-        expected.addOperand(eqExpr(constantExpr(1), constantExpr(1)));
-        expected.addOperand(ltExpr(constantExpr(2), constantExpr(3)));
-        expected.addOperand(gtExpr(constantExpr(30), constantExpr(20)));
+        auto expected = LogicalExpression::makeOr(pool);
+        expected->addOperand(eqExpr(constantExpr(1), constantExpr(1)));
+        expected->addOperand(ltExpr(constantExpr(2), constantExpr(3)));
+        expected->addOperand(gtExpr(constantExpr(30), constantExpr(20)));
 
-        ASSERT_EQ(*res, expected) << res->toString() << " vs. " << expected.toString();
+        ASSERT_EQ(*res, *expected) << res->toString() << " vs. " << expected->toString();
     }
     // !( 1 != 1 || 2 >= 3 || 30 <= 20)  =>  (1 == 1 && 2 < 3 && 30 > 20)
     {
@@ -189,12 +189,12 @@ TEST_F(RewriteUnaryNotExprVisitorTest, TestLogicalExpr) {
                                    leExpr(constantExpr(30), constantExpr(20))));
         auto res = ExpressionUtils::reduceUnaryNotExpr(expr, pool);
 
-        auto expected = *LogicalExpression::makeAnd(pool);
-        expected.addOperand(eqExpr(constantExpr(1), constantExpr(1)));
-        expected.addOperand(ltExpr(constantExpr(2), constantExpr(3)));
-        expected.addOperand(gtExpr(constantExpr(30), constantExpr(20)));
+        auto expected = LogicalExpression::makeAnd(pool);
+        expected->addOperand(eqExpr(constantExpr(1), constantExpr(1)));
+        expected->addOperand(ltExpr(constantExpr(2), constantExpr(3)));
+        expected->addOperand(gtExpr(constantExpr(30), constantExpr(20)));
 
-        ASSERT_EQ(*res, expected) << res->toString() << " vs. " << expected.toString();
+        ASSERT_EQ(*res, *expected) << res->toString() << " vs. " << expected->toString();
     }
     // !( 1 != 1 && 2 >= 3 || 30 <= 20)  =>  ((1 == 1 || 2 < 3) && 30 > 20)
     {

--- a/src/visitor/test/RewriteUnaryNotExprVisitorTest.cpp
+++ b/src/visitor/test/RewriteUnaryNotExprVisitorTest.cpp
@@ -14,45 +14,36 @@
 
 namespace nebula {
 namespace graph {
-class RewriteUnaryNotExprVisitorTest : public ValidatorTestBase {
-public:
-    void TearDown() override {
-        pool.clear();
-    }
-
-protected:
-    ObjectPool pool;
-};
+class RewriteUnaryNotExprVisitorTest : public ValidatorTestBase {};
 
 TEST_F(RewriteUnaryNotExprVisitorTest, TestNestedMultipleUnaryNotExpr) {
     // !!(5 == 10)  =>  (5 == 10)
     {
-        auto expr = pool.add(notExpr(notExpr(eqExpr(constantExpr(5), constantExpr(10)))));
-        auto res = ExpressionUtils::reduceUnaryNotExpr(expr, &pool);
-        auto expected = pool.add(eqExpr(constantExpr(5), constantExpr(10)));
+        auto expr = notExpr(notExpr(eqExpr(constantExpr(5), constantExpr(10))));
+        auto res = ExpressionUtils::reduceUnaryNotExpr(expr, pool);
+        auto expected = eqExpr(constantExpr(5), constantExpr(10));
         ASSERT_EQ(*res, *expected) << res->toString() << " vs. " << expected->toString();
     }
     // !!!!(5 == 10)  =>  (5 == 10)
     {
-        auto expr =
-            pool.add(notExpr(notExpr(notExpr(notExpr(eqExpr(constantExpr(5), constantExpr(10)))))));
-        auto res = ExpressionUtils::reduceUnaryNotExpr(expr, &pool);
-        auto expected = pool.add(eqExpr(constantExpr(5), constantExpr(10)));
+        auto expr = notExpr(notExpr(notExpr(notExpr(eqExpr(constantExpr(5), constantExpr(10))))));
+        auto res = ExpressionUtils::reduceUnaryNotExpr(expr, pool);
+        auto expected = eqExpr(constantExpr(5), constantExpr(10));
         ASSERT_EQ(*res, *expected) << res->toString() << " vs. " << expected->toString();
     }
     // !!!(5 == 10)  =>  (5 != 10)
     {
-        auto expr = pool.add(notExpr(notExpr(notExpr(eqExpr(constantExpr(5), constantExpr(10))))));
-        auto res = ExpressionUtils::reduceUnaryNotExpr(expr, &pool);
-        auto expected = pool.add(neExpr(constantExpr(5), constantExpr(10)));
+        auto expr = notExpr(notExpr(notExpr(eqExpr(constantExpr(5), constantExpr(10)))));
+        auto res = ExpressionUtils::reduceUnaryNotExpr(expr, pool);
+        auto expected = neExpr(constantExpr(5), constantExpr(10));
         ASSERT_EQ(*res, *expected) << res->toString() << " vs. " << expected->toString();
     }
     // !!!!!(5 == 10)  =>  (5 != 10)
     {
-        auto expr = pool.add(
-            notExpr(notExpr(notExpr(notExpr(notExpr(eqExpr(constantExpr(5), constantExpr(10))))))));
-        auto res = ExpressionUtils::reduceUnaryNotExpr(expr, &pool);
-        auto expected = pool.add(neExpr(constantExpr(5), constantExpr(10)));
+        auto expr =
+            notExpr(notExpr(notExpr(notExpr(notExpr(eqExpr(constantExpr(5), constantExpr(10)))))));
+        auto res = ExpressionUtils::reduceUnaryNotExpr(expr, pool);
+        auto expected = neExpr(constantExpr(5), constantExpr(10));
         ASSERT_EQ(*res, *expected) << res->toString() << " vs. " << expected->toString();
     }
 }
@@ -60,21 +51,20 @@ TEST_F(RewriteUnaryNotExprVisitorTest, TestNestedMultipleUnaryNotExpr) {
 TEST_F(RewriteUnaryNotExprVisitorTest, TestMultipleUnaryNotExprLogicalRelExpr) {
     // !!(5 == 10) AND !!(30 > 20)  =>  (5 == 10) AND (30 > 20)
     {
-        auto expr = pool.add(andExpr(notExpr(notExpr(eqExpr(constantExpr(5), constantExpr(10)))),
-                                     notExpr(notExpr(gtExpr(constantExpr(30), constantExpr(20))))));
-        auto res = ExpressionUtils::reduceUnaryNotExpr(expr, &pool);
-        auto expected = pool.add(andExpr(eqExpr(constantExpr(5), constantExpr(10)),
-                                         gtExpr(constantExpr(30), constantExpr(20))));
+        auto expr = andExpr(notExpr(notExpr(eqExpr(constantExpr(5), constantExpr(10)))),
+                            notExpr(notExpr(gtExpr(constantExpr(30), constantExpr(20)))));
+        auto res = ExpressionUtils::reduceUnaryNotExpr(expr, pool);
+        auto expected = andExpr(eqExpr(constantExpr(5), constantExpr(10)),
+                                gtExpr(constantExpr(30), constantExpr(20)));
         ASSERT_EQ(*res, *expected) << res->toString() << " vs. " << expected->toString();
     }
     // !!!(5 <= 10) AND !(30 > 20)  =>  (5 > 10) AND (30 <= 20)
     {
-        auto expr =
-            pool.add(andExpr(notExpr(notExpr(notExpr(leExpr(constantExpr(5), constantExpr(10))))),
-                             notExpr(gtExpr(constantExpr(30), constantExpr(20)))));
-        auto res = ExpressionUtils::reduceUnaryNotExpr(expr, &pool);
-        auto expected = pool.add(andExpr(gtExpr(constantExpr(5), constantExpr(10)),
-                                         leExpr(constantExpr(30), constantExpr(20))));
+        auto expr = andExpr(notExpr(notExpr(notExpr(leExpr(constantExpr(5), constantExpr(10))))),
+                            notExpr(gtExpr(constantExpr(30), constantExpr(20))));
+        auto res = ExpressionUtils::reduceUnaryNotExpr(expr, pool);
+        auto expected = andExpr(gtExpr(constantExpr(5), constantExpr(10)),
+                                leExpr(constantExpr(30), constantExpr(20)));
         ASSERT_EQ(*res, *expected) << res->toString() << " vs. " << expected->toString();
     }
 }
@@ -83,35 +73,34 @@ TEST_F(RewriteUnaryNotExprVisitorTest, TestMultipleUnaryNotContainerExpr) {
     // List
     {
         // [!!(5 == 10), !!!(30 > 20)]  =>  [(5 == 10), (30 <= 20)]
-        auto expr = pool.add(
+        auto expr =
             listExpr({notExpr(notExpr(eqExpr(constantExpr(5), constantExpr(10)))),
-                      notExpr(notExpr(notExpr(gtExpr(constantExpr(30), constantExpr(20)))))}));
-        auto res = ExpressionUtils::reduceUnaryNotExpr(expr, &pool);
-        auto expected = pool.add(listExpr({eqExpr(constantExpr(5), constantExpr(10)),
-                                           leExpr(constantExpr(30), constantExpr(20))}));
+                      notExpr(notExpr(notExpr(gtExpr(constantExpr(30), constantExpr(20)))))});
+        auto res = ExpressionUtils::reduceUnaryNotExpr(expr, pool);
+        auto expected = listExpr({eqExpr(constantExpr(5), constantExpr(10)),
+                                  leExpr(constantExpr(30), constantExpr(20))});
         ASSERT_EQ(*res, *expected) << res->toString() << " vs. " << expected->toString();
     }
     // Set
     {
         // {!!(5 == 10), !!!(30 > 20)}  =>  {(5 == 10), (30 <= 20)}
-        auto expr = pool.add(
+        auto expr =
             setExpr({notExpr(notExpr(eqExpr(constantExpr(5), constantExpr(10)))),
-                     notExpr(notExpr(notExpr(gtExpr(constantExpr(30), constantExpr(20)))))}));
-        auto res = ExpressionUtils::reduceUnaryNotExpr(expr, &pool);
-        auto expected = pool.add(setExpr({eqExpr(constantExpr(5), constantExpr(10)),
-                                          leExpr(constantExpr(30), constantExpr(20))}));
+                     notExpr(notExpr(notExpr(gtExpr(constantExpr(30), constantExpr(20)))))});
+        auto res = ExpressionUtils::reduceUnaryNotExpr(expr, pool);
+        auto expected = setExpr({eqExpr(constantExpr(5), constantExpr(10)),
+                                 leExpr(constantExpr(30), constantExpr(20))});
         ASSERT_EQ(*res, *expected) << res->toString() << " vs. " << expected->toString();
     }
 
     // Map
     {
         // {"k1":!!(5 == 10), "k2":!!!(30 > 20)}} => {"k1":(5 == 10), "k2":(30 <= 20)}
-        auto expr = pool.add(mapExpr(
-            {{"k1", notExpr(notExpr(eqExpr(constantExpr(5), constantExpr(10))))},
-             {"k2", notExpr(notExpr(notExpr(gtExpr(constantExpr(30), constantExpr(20)))))}}));
-        auto res = ExpressionUtils::reduceUnaryNotExpr(expr, &pool);
-        auto expected = pool.add(mapExpr({{"k1", eqExpr(constantExpr(5), constantExpr(10))},
-                                          {"k2", leExpr(constantExpr(30), constantExpr(20))}}));
+        auto expr = mapExpr({{"k1", notExpr(notExpr(eqExpr(constantExpr(5), constantExpr(10))))}, {
+            "k2", notExpr(notExpr(notExpr(gtExpr(constantExpr(30), constantExpr(20)))))}});
+        auto res = ExpressionUtils::reduceUnaryNotExpr(expr, pool);
+        auto expected = mapExpr({{"k1", eqExpr(constantExpr(5), constantExpr(10))},
+                                 {"k2", leExpr(constantExpr(30), constantExpr(20))}});
         ASSERT_EQ(*res, *expected) << res->toString() << " vs. " << expected->toString();
     }
 }
@@ -120,60 +109,60 @@ TEST_F(RewriteUnaryNotExprVisitorTest, TestRelExpr) {
     // (5 == 10)  =>  (5 == 10)
     // no change should be made to the orginal expression
     {
-        auto original = pool.add(eqExpr(constantExpr(5), constantExpr(10)));
-        auto res = ExpressionUtils::reduceUnaryNotExpr(original, &pool);
+        auto original = eqExpr(constantExpr(5), constantExpr(10));
+        auto res = ExpressionUtils::reduceUnaryNotExpr(original, pool);
         ASSERT_EQ(*original, *res) << original->toString() << " vs. " << res->toString();
     }
     // !(5 == 10)  =>  (5 != 10)
     {
-        auto expr = pool.add(notExpr(eqExpr(constantExpr(5), constantExpr(10))));
-        auto res = ExpressionUtils::reduceUnaryNotExpr(expr, &pool);
-        auto expected = pool.add(neExpr(constantExpr(5), constantExpr(10)));
+        auto expr = notExpr(eqExpr(constantExpr(5), constantExpr(10)));
+        auto res = ExpressionUtils::reduceUnaryNotExpr(expr, pool);
+        auto expected = neExpr(constantExpr(5), constantExpr(10));
         ASSERT_EQ(*res, *expected) << res->toString() << " vs. " << expected->toString();
     }
     // !(5 > 10) => (5 <= 10)
     {
-        auto expr = pool.add(notExpr(gtExpr(constantExpr(5), constantExpr(10))));
-        auto res = ExpressionUtils::reduceUnaryNotExpr(expr, &pool);
-        auto expected = pool.add(leExpr(constantExpr(5), constantExpr(10)));
+        auto expr = notExpr(gtExpr(constantExpr(5), constantExpr(10)));
+        auto res = ExpressionUtils::reduceUnaryNotExpr(expr, pool);
+        auto expected = leExpr(constantExpr(5), constantExpr(10));
         ASSERT_EQ(*res, *expected) << res->toString() << " vs. " << expected->toString();
     }
     // !(5 >= 10) => (5 < 10)
     {
-        auto expr = pool.add(notExpr(geExpr(constantExpr(5), constantExpr(10))));
-        auto res = ExpressionUtils::reduceUnaryNotExpr(expr, &pool);
-        auto expected = pool.add(ltExpr(constantExpr(5), constantExpr(10)));
+        auto expr = notExpr(geExpr(constantExpr(5), constantExpr(10)));
+        auto res = ExpressionUtils::reduceUnaryNotExpr(expr, pool);
+        auto expected = ltExpr(constantExpr(5), constantExpr(10));
         ASSERT_EQ(*res, *expected) << res->toString() << " vs. " << expected->toString();
     }
     // !("bcd" IN "abcde")  =>  ("bcd" NOT IN "abcde")
     {
-        auto expr = pool.add(notExpr(inExpr(constantExpr("bcd"), constantExpr("abcde"))));
-        auto res = ExpressionUtils::reduceUnaryNotExpr(expr, &pool);
-        auto expected = pool.add(notInExpr(constantExpr("bcd"), constantExpr("abcde")));
+        auto expr = notExpr(inExpr(constantExpr("bcd"), constantExpr("abcde")));
+        auto res = ExpressionUtils::reduceUnaryNotExpr(expr, pool);
+        auto expected = notInExpr(constantExpr("bcd"), constantExpr("abcde"));
         ASSERT_EQ(*res, *expected) << res->toString() << " vs. " << expected->toString();
     }
 
     // !("bcd" NOT IN "abcde")  =>  ("bcd" IN "abcde")
     {
-        auto expr = pool.add(notExpr(notInExpr(constantExpr("bcd"), constantExpr("abcde"))));
-        auto res = ExpressionUtils::reduceUnaryNotExpr(expr, &pool);
-        auto expected = pool.add(inExpr(constantExpr("bcd"), constantExpr("abcde")));
+        auto expr = notExpr(notInExpr(constantExpr("bcd"), constantExpr("abcde")));
+        auto res = ExpressionUtils::reduceUnaryNotExpr(expr, pool);
+        auto expected = inExpr(constantExpr("bcd"), constantExpr("abcde"));
         ASSERT_EQ(*res, *expected) << res->toString() << " vs. " << expected->toString();
     }
 
     // !("bcd" STARTS WITH "abc")  =>  ("bcd" NOT STARTS WITH "abc")
     {
-        auto expr = pool.add(notExpr(startsWithExpr(constantExpr("bcd"), constantExpr("abcde"))));
-        auto res = ExpressionUtils::reduceUnaryNotExpr(expr, &pool);
-        auto expected = pool.add(notStartsWithExpr(constantExpr("bcd"), constantExpr("abcde")));
+        auto expr = notExpr(startsWithExpr(constantExpr("bcd"), constantExpr("abcde")));
+        auto res = ExpressionUtils::reduceUnaryNotExpr(expr, pool);
+        auto expected = notStartsWithExpr(constantExpr("bcd"), constantExpr("abcde"));
         ASSERT_EQ(*res, *expected) << res->toString() << " vs. " << expected->toString();
     }
 
     // !("bcd" ENDS WITH "abc")  =>  ("bcd" NOT ENDS WITH "abc")
     {
-        auto expr = pool.add(notExpr(endsWithExpr(constantExpr("bcd"), constantExpr("abcde"))));
-        auto res = ExpressionUtils::reduceUnaryNotExpr(expr, &pool);
-        auto expected = pool.add(notEndsWithExpr(constantExpr("bcd"), constantExpr("abcde")));
+        auto expr = notExpr(endsWithExpr(constantExpr("bcd"), constantExpr("abcde")));
+        auto res = ExpressionUtils::reduceUnaryNotExpr(expr, pool);
+        auto expected = notEndsWithExpr(constantExpr("bcd"), constantExpr("abcde"));
         ASSERT_EQ(*res, *expected) << res->toString() << " vs. " << expected->toString();
     }
 }
@@ -181,12 +170,12 @@ TEST_F(RewriteUnaryNotExprVisitorTest, TestRelExpr) {
 TEST_F(RewriteUnaryNotExprVisitorTest, TestLogicalExpr) {
     // !( 1 != 1 && 2 >= 3 && 30 <= 20)  =>  (1 == 1 || 2 < 3 || 30 > 20)
     {
-        auto expr = pool.add(notExpr(andExpr(andExpr(neExpr(constantExpr(1), constantExpr(1)),
-                                                     geExpr(constantExpr(2), constantExpr(3))),
-                                             leExpr(constantExpr(30), constantExpr(20)))));
-        auto res = ExpressionUtils::reduceUnaryNotExpr(expr, &pool);
+        auto expr = notExpr(andExpr(andExpr(neExpr(constantExpr(1), constantExpr(1)),
+                                            geExpr(constantExpr(2), constantExpr(3))),
+                                    leExpr(constantExpr(30), constantExpr(20))));
+        auto res = ExpressionUtils::reduceUnaryNotExpr(expr, pool);
 
-        LogicalExpression expected(Expression::Kind::kLogicalOr);
+        auto expected = *LogicalExpression::makeOr(pool);
         expected.addOperand(eqExpr(constantExpr(1), constantExpr(1)));
         expected.addOperand(ltExpr(constantExpr(2), constantExpr(3)));
         expected.addOperand(gtExpr(constantExpr(30), constantExpr(20)));
@@ -195,12 +184,12 @@ TEST_F(RewriteUnaryNotExprVisitorTest, TestLogicalExpr) {
     }
     // !( 1 != 1 || 2 >= 3 || 30 <= 20)  =>  (1 == 1 && 2 < 3 && 30 > 20)
     {
-        auto expr = pool.add(notExpr(orExpr(orExpr(neExpr(constantExpr(1), constantExpr(1)),
-                                                   geExpr(constantExpr(2), constantExpr(3))),
-                                            leExpr(constantExpr(30), constantExpr(20)))));
-        auto res = ExpressionUtils::reduceUnaryNotExpr(expr, &pool);
+        auto expr = notExpr(orExpr(orExpr(neExpr(constantExpr(1), constantExpr(1)),
+                                          geExpr(constantExpr(2), constantExpr(3))),
+                                   leExpr(constantExpr(30), constantExpr(20))));
+        auto res = ExpressionUtils::reduceUnaryNotExpr(expr, pool);
 
-        LogicalExpression expected(Expression::Kind::kLogicalAnd);
+        auto expected = *LogicalExpression::makeAnd(pool);
         expected.addOperand(eqExpr(constantExpr(1), constantExpr(1)));
         expected.addOperand(ltExpr(constantExpr(2), constantExpr(3)));
         expected.addOperand(gtExpr(constantExpr(30), constantExpr(20)));
@@ -209,14 +198,14 @@ TEST_F(RewriteUnaryNotExprVisitorTest, TestLogicalExpr) {
     }
     // !( 1 != 1 && 2 >= 3 || 30 <= 20)  =>  ((1 == 1 || 2 < 3) && 30 > 20)
     {
-        auto expr = pool.add(notExpr(orExpr(andExpr(neExpr(constantExpr(1), constantExpr(1)),
-                                                    geExpr(constantExpr(2), constantExpr(3))),
-                                            leExpr(constantExpr(30), constantExpr(20)))));
-        auto res = ExpressionUtils::reduceUnaryNotExpr(expr, &pool);
+        auto expr = notExpr(orExpr(andExpr(neExpr(constantExpr(1), constantExpr(1)),
+                                           geExpr(constantExpr(2), constantExpr(3))),
+                                   leExpr(constantExpr(30), constantExpr(20))));
+        auto res = ExpressionUtils::reduceUnaryNotExpr(expr, pool);
 
-        auto expected = pool.add(andExpr(orExpr(eqExpr(constantExpr(1), constantExpr(1)),
-                                                ltExpr(constantExpr(2), constantExpr(3))),
-                                         gtExpr(constantExpr(30), constantExpr(20))));
+        auto expected = andExpr(orExpr(eqExpr(constantExpr(1), constantExpr(1)),
+                                       ltExpr(constantExpr(2), constantExpr(3))),
+                                gtExpr(constantExpr(30), constantExpr(20)));
 
         ASSERT_EQ(*res, *expected) << res->toString() << " vs. " << expected->toString();
     }

--- a/src/visitor/test/VisitorTestBase.h
+++ b/src/visitor/test/VisitorTestBase.h
@@ -19,7 +19,7 @@ namespace graph {
 class ValidatorTestBase : public ::testing::Test {
 protected:
     static ConstantExpression *constantExpr(Value value) {
-        return new ConstantExpression(std::move(value));
+        return ConstantExpression::make(poolstd::move(value));
     }
 
     static ArithmeticExpression *addExpr(Expression *lhs, Expression *rhs) {
@@ -143,7 +143,7 @@ protected:
                                           std::initializer_list<Expression *> args) {
         auto argsList = new ArgumentList;
         for (auto arg : args) {
-            argsList->addArgument(std::unique_ptr<Expression>(arg));
+            argsList->addArgument(Expression*(arg));
         }
         return new FunctionCallExpression(std::move(fn), argsList);
     }
@@ -170,7 +170,7 @@ protected:
 
     static LabelAttributeExpression *laExpr(const std::string &name, Value value) {
         return new LabelAttributeExpression(new LabelExpression(name),
-                                            new ConstantExpression(std::move(value)));
+                                            ConstantExpression::make(poolstd::move(value)));
     }
 };
 

--- a/src/visitor/test/VisitorTestBase.h
+++ b/src/visitor/test/VisitorTestBase.h
@@ -17,161 +17,169 @@ namespace nebula {
 namespace graph {
 
 class ValidatorTestBase : public ::testing::Test {
+    void SetUp() override {
+        pool_ = std::make_unique<ObjectPool>();
+        pool = pool_.get();
+    }
+
 protected:
-    static ConstantExpression *constantExpr(Value value) {
-        return ConstantExpression::make(poolstd::move(value));
+    ConstantExpression *constantExpr(Value value) {
+        return ConstantExpression::make(pool, std::move(value));
     }
 
-    static ArithmeticExpression *addExpr(Expression *lhs, Expression *rhs) {
-        return new ArithmeticExpression(Expression::Kind::kAdd, lhs, rhs);
+    ArithmeticExpression *addExpr(Expression *lhs, Expression *rhs) {
+        return ArithmeticExpression::makeAdd(pool, lhs, rhs);
     }
 
-    static ArithmeticExpression *minusExpr(Expression *lhs, Expression *rhs) {
-        return new ArithmeticExpression(Expression::Kind::kMinus, lhs, rhs);
+    ArithmeticExpression *minusExpr(Expression *lhs, Expression *rhs) {
+        return ArithmeticExpression::makeMinus(pool, lhs, rhs);
     }
 
-    static ArithmeticExpression *multiplyExpr(Expression *lhs, Expression *rhs) {
-        return new ArithmeticExpression(Expression::Kind::kMultiply, lhs, rhs);
+    ArithmeticExpression *multiplyExpr(Expression *lhs, Expression *rhs) {
+        return ArithmeticExpression::makeMultiply(pool, lhs, rhs);
     }
 
-    static ArithmeticExpression *divideExpr(Expression *lhs, Expression *rhs) {
-        return new ArithmeticExpression(Expression::Kind::kDivision, lhs, rhs);
+    ArithmeticExpression *divideExpr(Expression *lhs, Expression *rhs) {
+        return ArithmeticExpression::makeDivision(pool, lhs, rhs);
     }
 
-    static RelationalExpression *eqExpr(Expression *lhs, Expression *rhs) {
-        return new RelationalExpression(Expression::Kind::kRelEQ, lhs, rhs);
+    RelationalExpression *eqExpr(Expression *lhs, Expression *rhs) {
+        return RelationalExpression::makeEQ(pool, lhs, rhs);
     }
 
-    static RelationalExpression *neExpr(Expression *lhs, Expression *rhs) {
-        return new RelationalExpression(Expression::Kind::kRelNE, lhs, rhs);
+    RelationalExpression *neExpr(Expression *lhs, Expression *rhs) {
+        return RelationalExpression::makeNE(pool, lhs, rhs);
     }
 
-    static RelationalExpression *ltExpr(Expression *lhs, Expression *rhs) {
-        return new RelationalExpression(Expression::Kind::kRelLT, lhs, rhs);
+    RelationalExpression *ltExpr(Expression *lhs, Expression *rhs) {
+        return RelationalExpression::makeLT(pool, lhs, rhs);
     }
 
-    static RelationalExpression *leExpr(Expression *lhs, Expression *rhs) {
-        return new RelationalExpression(Expression::Kind::kRelLE, lhs, rhs);
+    RelationalExpression *leExpr(Expression *lhs, Expression *rhs) {
+        return RelationalExpression::makeLE(pool, lhs, rhs);
     }
 
-    static RelationalExpression *gtExpr(Expression *lhs, Expression *rhs) {
-        return new RelationalExpression(Expression::Kind::kRelGT, lhs, rhs);
+    RelationalExpression *gtExpr(Expression *lhs, Expression *rhs) {
+        return RelationalExpression::makeGT(pool, lhs, rhs);
     }
 
-    static RelationalExpression *geExpr(Expression *lhs, Expression *rhs) {
-        return new RelationalExpression(Expression::Kind::kRelGE, lhs, rhs);
+    RelationalExpression *geExpr(Expression *lhs, Expression *rhs) {
+        return RelationalExpression::makeGE(pool, lhs, rhs);
     }
 
-    static RelationalExpression *inExpr(Expression *lhs, Expression *rhs) {
-        return new RelationalExpression(Expression::Kind::kRelIn, lhs, rhs);
+    RelationalExpression *inExpr(Expression *lhs, Expression *rhs) {
+        return RelationalExpression::makeIn(pool, lhs, rhs);
     }
 
-    static RelationalExpression *notInExpr(Expression *lhs, Expression *rhs) {
-        return new RelationalExpression(Expression::Kind::kRelNotIn, lhs, rhs);
+    RelationalExpression *notInExpr(Expression *lhs, Expression *rhs) {
+        return RelationalExpression::makeNotIn(pool, lhs, rhs);
     }
 
-    static RelationalExpression *containsExpr(Expression *lhs, Expression *rhs) {
-        return new RelationalExpression(Expression::Kind::kContains, lhs, rhs);
+    RelationalExpression *containsExpr(Expression *lhs, Expression *rhs) {
+        return RelationalExpression::makeContains(pool, lhs, rhs);
     }
 
-    static RelationalExpression *notContainsExpr(Expression *lhs, Expression *rhs) {
-        return new RelationalExpression(Expression::Kind::kNotContains, lhs, rhs);
+    RelationalExpression *notContainsExpr(Expression *lhs, Expression *rhs) {
+        return RelationalExpression::makeNotContains(pool, lhs, rhs);
     }
 
-    static RelationalExpression *startsWithExpr(Expression *lhs, Expression *rhs) {
-        return new RelationalExpression(Expression::Kind::kStartsWith, lhs, rhs);
+    RelationalExpression *startsWithExpr(Expression *lhs, Expression *rhs) {
+        return RelationalExpression::makeStartsWith(pool, lhs, rhs);
     }
 
-    static RelationalExpression *notStartsWithExpr(Expression *lhs, Expression *rhs) {
-        return new RelationalExpression(Expression::Kind::kNotStartsWith, lhs, rhs);
+    RelationalExpression *notStartsWithExpr(Expression *lhs, Expression *rhs) {
+        return RelationalExpression::makeNotStartsWith(pool, lhs, rhs);
     }
 
-    static RelationalExpression *endsWithExpr(Expression *lhs, Expression *rhs) {
-        return new RelationalExpression(Expression::Kind::kEndsWith, lhs, rhs);
+    RelationalExpression *endsWithExpr(Expression *lhs, Expression *rhs) {
+        return RelationalExpression::makeEndsWith(pool, lhs, rhs);
     }
 
-    static RelationalExpression *notEndsWithExpr(Expression *lhs, Expression *rhs) {
-        return new RelationalExpression(Expression::Kind::kNotEndsWith, lhs, rhs);
+    RelationalExpression *notEndsWithExpr(Expression *lhs, Expression *rhs) {
+        return RelationalExpression::makeNotEndsWith(pool, lhs, rhs);
     }
 
-    static TypeCastingExpression *castExpr(Type type, Expression *expr) {
-        return new TypeCastingExpression(type, expr);
+    TypeCastingExpression *castExpr(Type type, Expression *expr) {
+        return TypeCastingExpression::make(pool, type, expr);
     }
 
-    static UnaryExpression *notExpr(Expression *expr) {
-        return new UnaryExpression(Expression::Kind::kUnaryNot, expr);
+    UnaryExpression *notExpr(Expression *expr) {
+        return UnaryExpression::makeNot(pool, expr);
     }
 
-    static LogicalExpression *andExpr(Expression *lhs, Expression *rhs) {
-        return new LogicalExpression(Expression::Kind::kLogicalAnd, lhs, rhs);
+    LogicalExpression *andExpr(Expression *lhs, Expression *rhs) {
+        return LogicalExpression::makeAnd(pool, lhs, rhs);
     }
 
-    static LogicalExpression *orExpr(Expression *lhs, Expression *rhs) {
-        return new LogicalExpression(Expression::Kind::kLogicalOr, lhs, rhs);
+    LogicalExpression *orExpr(Expression *lhs, Expression *rhs) {
+        return LogicalExpression::makeOr(pool, lhs, rhs);
     }
 
-    static ListExpression *listExpr(std::initializer_list<Expression *> exprs) {
-        auto exprList = new ExpressionList;
+    ListExpression *listExpr(std::initializer_list<Expression *> exprs) {
+        auto exprList = ExpressionList::make(pool);
         for (auto expr : exprs) {
             exprList->add(expr);
         }
-        return new ListExpression(exprList);
+        return ListExpression::make(pool, exprList);
     }
 
-    static SetExpression *setExpr(std::initializer_list<Expression *> exprs) {
-        auto exprList = new ExpressionList;
+    SetExpression *setExpr(std::initializer_list<Expression *> exprs) {
+        auto exprList = ExpressionList::make(pool);
         for (auto expr : exprs) {
             exprList->add(expr);
         }
-        return new SetExpression(exprList);
+        return SetExpression::make(pool, exprList);
     }
 
-    static MapExpression *mapExpr(
-        std::initializer_list<std::pair<std::string, Expression *>> exprs) {
-        auto mapItemList = new MapItemList;
+    MapExpression *mapExpr(std::initializer_list<std::pair<std::string, Expression *>> exprs) {
+        auto mapItemList = MapItemList::make(pool);
         for (auto expr : exprs) {
             mapItemList->add(expr.first, expr.second);
         }
-        return new MapExpression(mapItemList);
+        return MapExpression::make(pool, mapItemList);
     }
 
-    static SubscriptExpression *subExpr(Expression *lhs, Expression *rhs) {
-        return new SubscriptExpression(lhs, rhs);
+    SubscriptExpression *subExpr(Expression *lhs, Expression *rhs) {
+        return SubscriptExpression::make(pool, lhs, rhs);
     }
 
-    static FunctionCallExpression *fnExpr(std::string fn,
-                                          std::initializer_list<Expression *> args) {
-        auto argsList = new ArgumentList;
+    FunctionCallExpression *fnExpr(std::string fn, std::initializer_list<Expression *> args) {
+        auto argsList = ArgumentList::make(pool);
         for (auto arg : args) {
-            argsList->addArgument(Expression*(arg));
+            argsList->addArgument(arg);
         }
-        return new FunctionCallExpression(std::move(fn), argsList);
+        return FunctionCallExpression::make(pool, std::move(fn), argsList);
     }
 
-    static VariableExpression *varExpr(const std::string &name) {
-        return new VariableExpression(name);
+    VariableExpression *varExpr(const std::string &name) {
+        return VariableExpression::make(pool, name);
     }
 
-    static CaseExpression *caseExpr(Expression *cond,
-                                    Expression *defaltResult,
-                                    Expression *when,
-                                    Expression *then) {
-        auto caseList = new CaseList;
+    CaseExpression *caseExpr(Expression *cond,
+                             Expression *defaltResult,
+                             Expression *when,
+                             Expression *then) {
+        auto caseList = CaseList::make(pool);
         caseList->add(when, then);
-        auto expr = new CaseExpression(caseList);
+        auto expr = CaseExpression::make(pool, caseList);
         expr->setCondition(cond);
         expr->setDefault(defaltResult);
         return expr;
     }
 
-    static LabelExpression *labelExpr(const std::string &name) {
-        return new LabelExpression(name);
+    LabelExpression *labelExpr(const std::string &name) {
+        return LabelExpression::make(pool, name);
     }
 
-    static LabelAttributeExpression *laExpr(const std::string &name, Value value) {
-        return new LabelAttributeExpression(new LabelExpression(name),
-                                            ConstantExpression::make(poolstd::move(value)));
+    LabelAttributeExpression *laExpr(const std::string &name, Value value) {
+        return LabelAttributeExpression::make(pool,
+                                              LabelExpression::make(pool, name),
+                                              ConstantExpression::make(pool, std::move(value)));
     }
+
+protected:
+    std::unique_ptr<ObjectPool> pool_;
+    ObjectPool *pool;
 };
 
 }   // namespace graph

--- a/tests/common/nebula_service.py
+++ b/tests/common/nebula_service.py
@@ -73,7 +73,7 @@ class NebulaService(object):
             params.append('--local_config=false')
             params.append('--enable_optimizer=true')
             params.append('--enable_authorize=true')
-            params.append('--system_memory_high_watermark_ratio=0.99')
+            params.append('--system_memory_high_watermark_ratio=0.95')
         if name == 'storaged':
             params.append('--local_config=false')
             params.append('--raft_heartbeat_interval_secs=30')

--- a/tests/common/nebula_service.py
+++ b/tests/common/nebula_service.py
@@ -73,7 +73,7 @@ class NebulaService(object):
             params.append('--local_config=false')
             params.append('--enable_optimizer=true')
             params.append('--enable_authorize=true')
-            params.append('--system_memory_high_watermark_ratio=0.95')
+            params.append('--system_memory_high_watermark_ratio=0.99')
         if name == 'storaged':
             params.append('--local_config=false')
             params.append('--raft_heartbeat_interval_secs=30')


### PR DESCRIPTION
1. Replace all unique_ptr(s) with raw pointers in expression implementation and manage object lifetime using ObjectPool.
2. Disable default expression constructors to preventing mixing raw pointer and unique_ptr.
3. Disable copy constructor and assignment for expression class to force all expression copy to be done by `clone()`


Construct an expression: `auto* expr = ConstantExpression::make(pool, "Tim Duncan")`
Construct an expression with multiple potential kinds: `auto* expr = RelationalExpression::makeGT(pool, expr1, expr2)`

Depends on vesoft-inc/nebula-common#546 and https://github.com/vesoft-inc/nebula-storage/pull/481

Close https://github.com/vesoft-inc/nebula-graph/issues/1054