### PR TITLE
fix create space on group

### DIFF
--- a/src/parser/AdminSentences.h
+++ b/src/parser/AdminSentences.h
@@ -310,6 +310,9 @@ public:
     const std::string* spaceName() const {
         return spaceName_.get();
     }
+    const std::string* groupName() const {
+        return groupName_.get();
+    }
 
     void setOpts(SpaceOptList* spaceOpts) {
         spaceOpts_.reset(spaceOpts);

--- a/src/validator/AdminValidator.cpp
+++ b/src/validator/AdminValidator.cpp
@@ -24,6 +24,8 @@ Status CreateSpaceValidator::validateImpl() {
     ifNotExist_ = sentence->isIfNotExist();
     auto status = Status::OK();
     spaceDesc_.set_space_name(std::move(*(sentence->spaceName())));
+    if (sentence->groupName())
+        spaceDesc_.set_group_name(std::move(*(sentence->groupName())));
     StatusOr<std::string> retStatusOr;
     std::string result;
     auto* charsetInfo = qctx_->getCharsetInfo();
@@ -99,6 +101,7 @@ Status CreateSpaceValidator::validateImpl() {
             }
         }
     }
+<<<<<<< HEAD
     // check comment
     if (sentence->comment() != nullptr) {
         spaceDesc_.set_comment(*sentence->comment());
@@ -108,6 +111,8 @@ Status CreateSpaceValidator::validateImpl() {
         return Status::SemanticError("Group default conflict");
     }
 
+=======
+>>>>>>> fix create space on group
     // if charset and collate are not specified, set default value
     if (!(*spaceDesc_.charset_name_ref()).empty() && !(*spaceDesc_.collate_name_ref()).empty()) {
         NG_RETURN_IF_ERROR(charsetInfo->charsetAndCollateMatch(*spaceDesc_.charset_name_ref(),


### PR DESCRIPTION
create space group_test2(partition_num=9,replica_factor=1) ON group1 .
This PR can make sure that the  'group_test2' space is on the storage nodes of group1 rather than all the storage nodes.