### PR TITLE
Replace the lastUser by user count.…

### DIFF
--- a/src/context/Symbols.h
+++ b/src/context/Symbols.h
@@ -47,16 +47,8 @@ struct Variable {
     std::unordered_set<PlanNode*> readBy;
     std::unordered_set<PlanNode*> writtenBy;
 
-    // None means will used in later
-    // non-positive means static lifetime
-    // positive means last user id
-    folly::Optional<int64_t>      lastUser;
-
-    void setLastUser(int64_t id) {
-        if (!lastUser.hasValue()) {
-            lastUser = id;
-        }
-    }
+    // the count of use the variable
+    std::atomic<uint64_t>         userCount;
 };
 
 class SymbolTable final {

--- a/src/executor/Executor.cpp
+++ b/src/executor/Executor.cpp
@@ -582,9 +582,9 @@ folly::Future<Status> Executor::error(Status status) const {
 void Executor::drop() {
     for (const auto &inputVar : node()->inputVars()) {
         if (inputVar != nullptr) {
-            // Make sure use the variable happened-before de-increment count
+            // Make sure use the variable happened-before decrement count
             if (inputVar->userCount.fetch_sub(1, std::memory_order_release) == 1) {
-                // Make sure drop happened-after count de-increment
+                // Make sure drop happened-after count decrement
                 CHECK_EQ(inputVar->userCount.load(std::memory_order_acquire), 0);
                 ectx_->dropResult(inputVar->name);
                 VLOG(1) << "Drop variable " << node()->outputVar();

--- a/src/scheduler/AsyncMsgNotifyBasedScheduler.cpp
+++ b/src/scheduler/AsyncMsgNotifyBasedScheduler.cpp
@@ -16,7 +16,9 @@ AsyncMsgNotifyBasedScheduler::AsyncMsgNotifyBasedScheduler(QueryContext* qctx) :
 
 folly::Future<Status> AsyncMsgNotifyBasedScheduler::schedule() {
     if (FLAGS_enable_lifetime_optimize) {
-        qctx_->plan()->root()->outputVarPtr()->setLastUser(-1);  // special for root
+        // special for root
+        qctx_->plan()->root()->outputVarPtr()->userCount.store(std::numeric_limits<uint64_t>::max(),
+                                                               std::memory_order_relaxed);
         analyzeLifetime(qctx_->plan()->root());
     }
     auto executor = Executor::create(qctx_->plan()->root(), qctx_);


### PR DESCRIPTION
The last user maybe could run simultaneously(multiple dependencies use the same variable or select branch use the same variable), so can't determine which is real last user in timeline. Although now we can't write such query in fact, but it's a potential risk, so replace it by user count.