### PR TITLE
Free unused multiple version result's memory

### DIFF
--- a/src/context/ExecutionContext.cpp
+++ b/src/context/ExecutionContext.cpp
@@ -8,6 +8,7 @@
 
 namespace nebula {
 namespace graph {
+
 constexpr int64_t ExecutionContext::kLatestVersion;
 constexpr int64_t ExecutionContext::kOldestVersion;
 constexpr int64_t ExecutionContext::kPreviousOneVersion;
@@ -18,7 +19,22 @@ void ExecutionContext::setValue(const std::string& name, Value&& val) {
     setResult(name, builder.finish());
 }
 
+void ExecutionContext::appendValue(const std::string& name, Value&& val) {
+    ResultBuilder builder;
+    builder.value(std::move(val)).iter(Iterator::Kind::kDefault);
+    appendResult(name, builder.finish());
+}
+
 void ExecutionContext::setResult(const std::string& name, Result&& result) {
+    auto& hist = valueMap_[name];
+    if (hist.empty()) {
+        hist.emplace_back(std::move(result));
+    } else {
+        hist[0] = std::move(result);
+    }
+}
+
+void ExecutionContext::appendResult(const std::string& name, Result&& result) {
     auto& hist = valueMap_[name];
     hist.emplace_back(std::move(result));
 }

--- a/src/context/ExecutionContext.h
+++ b/src/context/ExecutionContext.h
@@ -60,7 +60,11 @@ public:
 
     void setValue(const std::string& name, Value&& val);
 
+    void appendValue(const std::string& name, Value&& val);
+
     void setResult(const std::string& name, Result&& result);
+
+    void appendResult(const std::string& name, Result&& result);
 
     void dropResult(const std::string& name);
 

--- a/src/context/test/ExecutionContextTest.cpp
+++ b/src/context/test/ExecutionContextTest.cpp
@@ -14,18 +14,18 @@ namespace graph {
 
 TEST(ExecutionContext, ReadWriteTest) {
     ExecutionContext ctx;
-    ctx.setValue("v1", 10);
-    ctx.setValue("v2", "Hello world");
+    ctx.appendValue("v1", 10);
+    ctx.appendValue("v2", "Hello world");
     EXPECT_EQ(Value(10), ctx.getValue("v1"));
     EXPECT_EQ(Value("Hello world"), ctx.getValue("v2"));
 }
 
 TEST(ExecutionContext, HistoryTest) {
     ExecutionContext ctx;
-    ctx.setValue("v1", 10);
-    ctx.setValue("v1", "Hello world");
-    ctx.setValue("v1", 3.14);
-    ctx.setValue("v1", true);
+    ctx.appendValue("v1", 10);
+    ctx.appendValue("v1", "Hello world");
+    ctx.appendValue("v1", 3.14);
+    ctx.appendValue("v1", true);
 
     ASSERT_EQ(4, ctx.numVersions("v1"));
     const auto& hist1 = ctx.getHistory("v1");

--- a/src/context/test/ExpressionContextTest.cpp
+++ b/src/context/test/ExpressionContextTest.cpp
@@ -10,21 +10,23 @@
 
 namespace nebula {
 namespace graph {
+
 TEST(ExpressionContextTest, GetVar) {
     ExecutionContext ectx;
-    ectx.setValue("v1", 10);
-    ectx.setValue("v2", "Hello world");
+    ectx.appendValue("v1", 10);
+    ectx.appendValue("v2", "Hello world");
 
     graph::QueryExpressionContext qECtx(&ectx);
     EXPECT_EQ(Value(10), qECtx(nullptr).getVar("v1"));
     EXPECT_EQ(Value("Hello world"), qECtx(nullptr).getVar("v2"));
 
-    ectx.setValue("v1", "Hello world");
-    ectx.setValue("v1", 3.14);
-    ectx.setValue("v1", true);
+    ectx.appendValue("v1", "Hello world");
+    ectx.appendValue("v1", 3.14);
+    ectx.appendValue("v1", true);
     EXPECT_EQ(Value(true), qECtx(nullptr).getVersionedVar("v1", 0));
     EXPECT_EQ(Value(3.14), qECtx(nullptr).getVersionedVar("v1", -1));
     EXPECT_EQ(Value(10), qECtx(nullptr).getVersionedVar("v1", 1));
 }
+
 }  // namespace graph
 }  // namespace nebula

--- a/src/executor/Executor.cpp
+++ b/src/executor/Executor.cpp
@@ -96,9 +96,9 @@
 #include "service/GraphFlags.h"
 #include "util/ScopedTimer.h"
 
-using folly::stringPrintf;
+DECLARE_bool(enable_lifetime_optimize);
 
-DEFINE_bool(enable_lifetime_optimize, true, "Does enable the lifetime optimize.");
+using folly::stringPrintf;
 
 namespace nebula {
 namespace graph {

--- a/src/executor/algo/SubgraphExecutor.cpp
+++ b/src/executor/algo/SubgraphExecutor.cpp
@@ -71,7 +71,7 @@ void SubgraphExecutor::oneMoreStep() {
     }
     iter->reset();
     builder.iter(std::move(iter));
-    ectx_->setResult(output, builder.finish());
+    ectx_->appendResult(output, builder.finish());
 }
 
 }   // namespace graph

--- a/src/executor/query/AssignExecutor.cpp
+++ b/src/executor/query/AssignExecutor.cpp
@@ -22,9 +22,9 @@ folly::Future<Status> AssignExecutor::execute() {
         auto value = valueExpr->eval(ctx);
         VLOG(1) << "VarName is: " << varName << " value is : " << value;
         if (value.isDataSet()) {
-            ectx_->setResult(varName, ResultBuilder().value(std::move(value)).finish());
+            ectx_->appendResult(varName, ResultBuilder().value(std::move(value)).finish());
         } else {
-            ectx_->setValue(varName, std::move(value));
+            ectx_->appendValue(varName, std::move(value));
         }
     }
     return Status::OK();

--- a/src/executor/test/AggregateTest.cpp
+++ b/src/executor/test/AggregateTest.cpp
@@ -60,7 +60,7 @@ protected:
         ds.rows.emplace_back(std::move(row));
 
         qctx_->symTable()->newVariable(*input_);
-        qctx_->ectx()->setResult(*input_, ResultBuilder().value(Value(ds)).finish());
+        qctx_->ectx()->appendResult(*input_, ResultBuilder().value(Value(ds)).finish());
     }
 
 protected:

--- a/src/executor/test/BFSShortestTest.cpp
+++ b/src/executor/test/BFSShortestTest.cpp
@@ -107,7 +107,7 @@ protected:
                             "_edge:+edge1:prop1:prop2:_dst:_rank",
                             "_expr"};
             qctx_->symTable()->newVariable("empty_get_neighbors");
-            qctx_->ectx()->setResult("empty_get_neighbors",
+            qctx_->ectx()->appendResult("empty_get_neighbors",
                                      ResultBuilder()
                                          .value(Value(std::move(ds)))
                                          .iter(Iterator::Kind::kGetNeighbors)
@@ -135,7 +135,7 @@ TEST_F(BFSShortestTest, BFSShortest) {
         List datasets;
         datasets.values.emplace_back(std::move(firstStepResult_));
         builder.value(std::move(datasets)).iter(Iterator::Kind::kGetNeighbors);
-        qctx_->ectx()->setResult("input", builder.finish());
+        qctx_->ectx()->appendResult("input", builder.finish());
 
         auto future = bfsExe->execute();
         auto status = std::move(future).get();
@@ -168,7 +168,7 @@ TEST_F(BFSShortestTest, BFSShortest) {
         List datasets;
         datasets.values.emplace_back(std::move(secondStepResult_));
         builder.value(std::move(datasets)).iter(Iterator::Kind::kGetNeighbors);
-        qctx_->ectx()->setResult("input", builder.finish());
+        qctx_->ectx()->appendResult("input", builder.finish());
 
         auto future = bfsExe->execute();
         auto status = std::move(future).get();

--- a/src/executor/test/ConjunctPathTest.cpp
+++ b/src/executor/test/ConjunctPathTest.cpp
@@ -60,7 +60,7 @@ protected:
                     ds.rows.emplace_back(std::move(row));
                 }
             }
-            qctx_->ectx()->setResult("conditionalVar", ResultBuilder().value(ds).finish());
+            qctx_->ectx()->appendResult("conditionalVar", ResultBuilder().value(ds).finish());
         }
         {
             DataSet ds;
@@ -131,7 +131,7 @@ protected:
                 row.values.emplace_back(std::move(paths));
                 ds.rows.emplace_back(std::move(row));
             }
-            qctx_->ectx()->setResult("forwardPath1", ResultBuilder().value(ds).finish());
+            qctx_->ectx()->appendResult("forwardPath1", ResultBuilder().value(ds).finish());
         }
         {
             DataSet ds;
@@ -203,7 +203,7 @@ protected:
                 row.values.emplace_back(std::move(paths));
                 ds.rows.emplace_back(std::move(row));
             }
-            qctx_->ectx()->setResult("forwardPath2", ResultBuilder().value(ds).finish());
+            qctx_->ectx()->appendResult("forwardPath2", ResultBuilder().value(ds).finish());
         }
         {
             DataSet ds;
@@ -299,7 +299,7 @@ protected:
                 row.values.emplace_back(std::move(paths));
                 ds.rows.emplace_back(std::move(row));
             }
-            qctx_->ectx()->setResult("forwardPath3", ResultBuilder().value(ds).finish());
+            qctx_->ectx()->appendResult("forwardPath3", ResultBuilder().value(ds).finish());
         }
         // backward endVid {9, 12}
         {
@@ -315,7 +315,7 @@ protected:
                 row.values = {"12", Value::kEmpty, 0, Value::kEmpty};
                 ds.rows.emplace_back(std::move(row));
             }
-            qctx_->ectx()->setResult("backwardPath1", ResultBuilder().value(ds).finish());
+            qctx_->ectx()->appendResult("backwardPath1", ResultBuilder().value(ds).finish());
 
             DataSet ds1;
             auto cost = 1;
@@ -346,8 +346,8 @@ protected:
                 row.values.emplace_back(std::move(paths));
                 ds1.rows.emplace_back(std::move(row));
             }
-            qctx_->ectx()->setResult("backwardPath1", ResultBuilder().value(ds1).finish());
-            qctx_->ectx()->setResult("backwardPath2", ResultBuilder().value(ds1).finish());
+            qctx_->ectx()->appendResult("backwardPath1", ResultBuilder().value(ds1).finish());
+            qctx_->ectx()->appendResult("backwardPath2", ResultBuilder().value(ds1).finish());
         }
         {
             DataSet ds;
@@ -379,8 +379,8 @@ protected:
                 row.values.emplace_back(std::move(paths));
                 ds.rows.emplace_back(std::move(row));
             }
-            qctx_->ectx()->setResult("backwardPath2", ResultBuilder().value(ds).finish());
-            qctx_->ectx()->setResult("backwardPath3", ResultBuilder().value(ds).finish());
+            qctx_->ectx()->appendResult("backwardPath2", ResultBuilder().value(ds).finish());
+            qctx_->ectx()->appendResult("backwardPath3", ResultBuilder().value(ds).finish());
         }
         {
             DataSet ds;
@@ -413,7 +413,7 @@ protected:
                 row.values.emplace_back(std::move(paths));
                 ds.rows.emplace_back(std::move(row));
             }
-            qctx_->ectx()->setResult("backwardPath3", ResultBuilder().value(ds).finish());
+            qctx_->ectx()->appendResult("backwardPath3", ResultBuilder().value(ds).finish());
         }
     }
     void biBfsInit() {
@@ -432,7 +432,7 @@ protected:
                 row.values = {"1", Value::kEmpty};
                 ds1.rows.emplace_back(std::move(row));
             }
-            qctx_->ectx()->setResult("forward1", ResultBuilder().value(ds1).finish());
+            qctx_->ectx()->appendResult("forward1", ResultBuilder().value(ds1).finish());
 
             DataSet ds2;
             ds2.colNames = {kVid, kEdgeStr};
@@ -446,7 +446,7 @@ protected:
                 row.values = {"3", Edge("1", "3", 1, "edge1", 0, {})};
                 ds2.rows.emplace_back(std::move(row));
             }
-            qctx_->ectx()->setResult("forward1", ResultBuilder().value(ds2).finish());
+            qctx_->ectx()->appendResult("forward1", ResultBuilder().value(ds2).finish());
         }
         {
             // 4
@@ -457,11 +457,11 @@ protected:
                 row.values = {"4", Value::kEmpty};
                 ds1.rows.emplace_back(std::move(row));
             }
-            qctx_->ectx()->setResult("backward1", ResultBuilder().value(ds1).finish());
+            qctx_->ectx()->appendResult("backward1", ResultBuilder().value(ds1).finish());
 
             DataSet ds2;
             ds2.colNames = {kVid, kEdgeStr};
-            qctx_->ectx()->setResult("backward1", ResultBuilder().value(ds2).finish());
+            qctx_->ectx()->appendResult("backward1", ResultBuilder().value(ds2).finish());
         }
         {
             // 2
@@ -472,11 +472,11 @@ protected:
                 row.values = {"2", Value::kEmpty};
                 ds1.rows.emplace_back(std::move(row));
             }
-            qctx_->ectx()->setResult("backward2", ResultBuilder().value(ds1).finish());
+            qctx_->ectx()->appendResult("backward2", ResultBuilder().value(ds1).finish());
 
             DataSet ds2;
             ds2.colNames = {kVid, kEdgeStr};
-            qctx_->ectx()->setResult("backward2", ResultBuilder().value(ds2).finish());
+            qctx_->ectx()->appendResult("backward2", ResultBuilder().value(ds2).finish());
         }
         {
             // 4->3
@@ -487,7 +487,7 @@ protected:
                 row.values = {"4", Value::kEmpty};
                 ds1.rows.emplace_back(std::move(row));
             }
-            qctx_->ectx()->setResult("backward3", ResultBuilder().value(ds1).finish());
+            qctx_->ectx()->appendResult("backward3", ResultBuilder().value(ds1).finish());
 
             DataSet ds2;
             ds2.colNames = {kVid, kEdgeStr};
@@ -496,7 +496,7 @@ protected:
                 row.values = {"3", Edge("4", "3", -1, "edge1", 0, {})};
                 ds2.rows.emplace_back(std::move(row));
             }
-            qctx_->ectx()->setResult("backward3", ResultBuilder().value(ds2).finish());
+            qctx_->ectx()->appendResult("backward3", ResultBuilder().value(ds2).finish());
         }
         {
             // 5->4
@@ -507,7 +507,7 @@ protected:
                 row.values = {"5", Value::kEmpty};
                 ds1.rows.emplace_back(std::move(row));
             }
-            qctx_->ectx()->setResult("backward4", ResultBuilder().value(ds1).finish());
+            qctx_->ectx()->appendResult("backward4", ResultBuilder().value(ds1).finish());
 
             DataSet ds2;
             ds2.colNames = {kVid, kEdgeStr};
@@ -516,7 +516,7 @@ protected:
                 row.values = {"4", Edge("5", "4", -1, "edge1", 0, {})};
                 ds2.rows.emplace_back(std::move(row));
             }
-            qctx_->ectx()->setResult("backward4", ResultBuilder().value(ds2).finish());
+            qctx_->ectx()->appendResult("backward4", ResultBuilder().value(ds2).finish());
         }
     }
 
@@ -547,7 +547,7 @@ protected:
                 row.values = {"3", std::move(paths)};
                 ds.rows.emplace_back(std::move(row));
             }
-            qctx_->ectx()->setResult("all_paths_forward1", ResultBuilder().value(ds).finish());
+            qctx_->ectx()->appendResult("all_paths_forward1", ResultBuilder().value(ds).finish());
         }
         {
             // 4->7
@@ -561,7 +561,7 @@ protected:
                 row.values = {"7", std::move(paths)};
                 ds2.rows.emplace_back(std::move(row));
             }
-            qctx_->ectx()->setResult("all_paths_backward1", ResultBuilder().value(ds2).finish());
+            qctx_->ectx()->appendResult("all_paths_backward1", ResultBuilder().value(ds2).finish());
         }
         {
             // 2
@@ -576,7 +576,7 @@ protected:
                 row.values = {"2", std::move(paths)};
                 ds1.rows.emplace_back(std::move(row));
             }
-            qctx_->ectx()->setResult("all_paths_backward2", ResultBuilder().value(ds1).finish());
+            qctx_->ectx()->appendResult("all_paths_backward2", ResultBuilder().value(ds1).finish());
 
             // 2->7
             DataSet ds2;
@@ -589,7 +589,7 @@ protected:
                 row.values = {"7", std::move(paths)};
                 ds2.rows.emplace_back(std::move(row));
             }
-            qctx_->ectx()->setResult("all_paths_backward2", ResultBuilder().value(ds2).finish());
+            qctx_->ectx()->appendResult("all_paths_backward2", ResultBuilder().value(ds2).finish());
         }
         {
             // 4->3
@@ -603,7 +603,7 @@ protected:
                 row.values = {"3", std::move(paths)};
                 ds2.rows.emplace_back(std::move(row));
             }
-            qctx_->ectx()->setResult("all_paths_backward3", ResultBuilder().value(ds2).finish());
+            qctx_->ectx()->appendResult("all_paths_backward3", ResultBuilder().value(ds2).finish());
         }
         {
             // 5->4
@@ -617,7 +617,7 @@ protected:
                 row.values = {"4", std::move(paths)};
                 ds.rows.emplace_back(std::move(row));
             }
-            qctx_->ectx()->setResult("all_paths_backward4", ResultBuilder().value(ds).finish());
+            qctx_->ectx()->appendResult("all_paths_backward4", ResultBuilder().value(ds).finish());
         }
     }
 
@@ -753,7 +753,7 @@ TEST_F(ConjunctPathTest, BiBFSThreeStepsPath) {
                 row.values = {"4", Edge("2", "4", 1, "edge1", 1, {})};
                 ds1.rows.emplace_back(std::move(row));
             }
-            qctx_->ectx()->setResult("forward1", ResultBuilder().value(ds1).finish());
+            qctx_->ectx()->appendResult("forward1", ResultBuilder().value(ds1).finish());
         }
         {
             // 4->6@0
@@ -764,7 +764,7 @@ TEST_F(ConjunctPathTest, BiBFSThreeStepsPath) {
                 row.values = {"6", Edge("4", "6", -1, "edge1", 0, {})};
                 ds1.rows.emplace_back(std::move(row));
             }
-            qctx_->ectx()->setResult("backward4", ResultBuilder().value(ds1).finish());
+            qctx_->ectx()->appendResult("backward4", ResultBuilder().value(ds1).finish());
         }
         auto future = conjunctExe->execute();
         auto status = std::move(future).get();
@@ -835,7 +835,7 @@ TEST_F(ConjunctPathTest, BiBFSFourStepsPath) {
                 row.values = {"6", Edge("2", "6", 1, "edge1", 1, {})};
                 ds1.rows.emplace_back(std::move(row));
             }
-            qctx_->ectx()->setResult("forward1", ResultBuilder().value(ds1).finish());
+            qctx_->ectx()->appendResult("forward1", ResultBuilder().value(ds1).finish());
         }
         {
             // 4->6@0
@@ -846,7 +846,7 @@ TEST_F(ConjunctPathTest, BiBFSFourStepsPath) {
                 row.values = {"6", Edge("4", "6", -1, "edge1", 0, {})};
                 ds1.rows.emplace_back(std::move(row));
             }
-            qctx_->ectx()->setResult("backward4", ResultBuilder().value(ds1).finish());
+            qctx_->ectx()->appendResult("backward4", ResultBuilder().value(ds1).finish());
         }
         auto future = conjunctExe->execute();
         auto status = std::move(future).get();
@@ -997,7 +997,7 @@ TEST_F(ConjunctPathTest, AllPathsThreeStepsPath) {
             }
             row.values = {"4", std::move(paths)};
             ds1.rows.emplace_back(std::move(row));
-            qctx_->ectx()->setResult("all_paths_forward1", ResultBuilder().value(ds1).finish());
+            qctx_->ectx()->appendResult("all_paths_forward1", ResultBuilder().value(ds1).finish());
         }
         auto future = conjunctExe->execute();
         auto status = std::move(future).get();
@@ -1074,7 +1074,7 @@ TEST_F(ConjunctPathTest, AllPathsFourStepsPath) {
             }
             row.values = {"6", std::move(paths)};
             ds1.rows.emplace_back(std::move(row));
-            qctx_->ectx()->setResult("all_paths_forward1", ResultBuilder().value(ds1).finish());
+            qctx_->ectx()->appendResult("all_paths_forward1", ResultBuilder().value(ds1).finish());
         }
         {
             // 5->4->6@0
@@ -1092,7 +1092,7 @@ TEST_F(ConjunctPathTest, AllPathsFourStepsPath) {
             }
             row.values = {"6", std::move(paths)};
             ds1.rows.emplace_back(std::move(row));
-            qctx_->ectx()->setResult("all_paths_backward4", ResultBuilder().value(ds1).finish());
+            qctx_->ectx()->appendResult("all_paths_backward4", ResultBuilder().value(ds1).finish());
         }
         auto future = conjunctExe->execute();
         auto status = std::move(future).get();

--- a/src/executor/test/DataCollectTest.cpp
+++ b/src/executor/test/DataCollectTest.cpp
@@ -91,8 +91,8 @@ protected:
             ResultBuilder builder;
             builder.value(Value(std::move(datasets))).iter(Iterator::Kind::kGetNeighbors);
             qctx_->symTable()->newVariable("input_datasets");
-            qctx_->ectx()->setResult("input_datasets", builder.finish());
-            qctx_->ectx()->setResult("input_datasets",
+            qctx_->ectx()->appendResult("input_datasets", builder.finish());
+            qctx_->ectx()->appendResult("input_datasets",
                                      ResultBuilder()
                                          .value(Value(std::move(ds2)))
                                          .iter(Iterator::Kind::kGetNeighbors)
@@ -108,7 +108,7 @@ protected:
                 ds.rows.emplace_back(std::move(row));
             }
             qctx_->symTable()->newVariable("input_sequential");
-            qctx_->ectx()->setResult("input_sequential",
+            qctx_->ectx()->appendResult("input_sequential",
                                      ResultBuilder().value(Value(std::move(ds))).finish());
         }
         {
@@ -119,12 +119,12 @@ protected:
                             "_edge:+edge1:prop1:prop2:_dst:_rank",
                             "_expr"};
             qctx_->symTable()->newVariable("empty_get_neighbors");
-            qctx_->ectx()->setResult("empty_get_neighbors",
+            qctx_->ectx()->appendResult("empty_get_neighbors",
                                      ResultBuilder()
                                          .value(Value(ds))
                                          .iter(Iterator::Kind::kGetNeighbors)
                                          .finish());
-            qctx_->ectx()->setResult("empty_get_neighbors",
+            qctx_->ectx()->appendResult("empty_get_neighbors",
                                      ResultBuilder()
                                          .value(Value(std::move(ds)))
                                          .iter(Iterator::Kind::kGetNeighbors)
@@ -143,7 +143,7 @@ protected:
                 vertices.rows.emplace_back(std::move(row));
             }
             qctx_->symTable()->newVariable("vertices");
-            qctx_->ectx()->setResult("vertices",
+            qctx_->ectx()->appendResult("vertices",
                                      ResultBuilder()
                                          .value(Value(std::move(vertices)))
                                          .iter(Iterator::Kind::kProp)
@@ -159,7 +159,7 @@ protected:
             edge.values.emplace_back(90);
             edges.rows.emplace_back(std::move(edge));
             qctx_->symTable()->newVariable("edges");
-            qctx_->ectx()->setResult("edges",
+            qctx_->ectx()->appendResult("edges",
                                      ResultBuilder()
                                          .value(Value(std::move(edges)))
                                          .iter(Iterator::Kind::kProp)
@@ -175,7 +175,7 @@ protected:
             row.values.emplace_back(std::move(path));
             paths.rows.emplace_back(std::move(row));
             qctx_->symTable()->newVariable("paths");
-            qctx_->ectx()->setResult("paths",
+            qctx_->ectx()->appendResult("paths",
                                      ResultBuilder().value(Value(std::move(paths))).finish());
         }
     }

--- a/src/executor/test/GetNeighborsTest.cpp
+++ b/src/executor/test/GetNeighborsTest.cpp
@@ -28,7 +28,7 @@ protected:
             ResultBuilder builder;
             builder.value(Value(std::move(ds)));
             qctx_->symTable()->newVariable("input_gn");
-            qctx_->ectx()->setResult("input_gn", builder.finish());
+            qctx_->ectx()->appendResult("input_gn", builder.finish());
         }
 
         meta::cpp2::Session session;

--- a/src/executor/test/JoinTest.cpp
+++ b/src/executor/test/JoinTest.cpp
@@ -34,7 +34,7 @@ protected:
                 ds.rows.emplace_back(std::move(row));
             }
             qctx_->symTable()->newVariable("var1");
-            qctx_->ectx()->setResult(
+            qctx_->ectx()->appendResult(
                 "var1",
                 ResultBuilder().value(Value(std::move(ds))).finish());
         }
@@ -48,7 +48,7 @@ protected:
                 ds.rows.emplace_back(std::move(row));
             }
             qctx_->symTable()->newVariable("var2");
-            qctx_->ectx()->setResult(
+            qctx_->ectx()->appendResult(
                 "var2", ResultBuilder().value(Value(std::move(ds))).finish());
         }
         {
@@ -58,14 +58,14 @@ protected:
             row.values.emplace_back("11");
             ds.rows.emplace_back(std::move(row));
             qctx_->symTable()->newVariable("var3");
-            qctx_->ectx()->setResult(
+            qctx_->ectx()->appendResult(
                 "var3", ResultBuilder().value(Value(std::move(ds))).finish());
         }
         {
             DataSet ds;
             ds.colNames = {kVid, "tag_prop", "edge_prop", kDst};
             qctx_->symTable()->newVariable("empty_var1");
-            qctx_->ectx()->setResult(
+            qctx_->ectx()->appendResult(
                 "empty_var1",
                 ResultBuilder().value(Value(std::move(ds))).finish());
         }
@@ -73,7 +73,7 @@ protected:
             DataSet ds;
             ds.colNames = {"src", "dst"};
             qctx_->symTable()->newVariable("empty_var2");
-            qctx_->ectx()->setResult(
+            qctx_->ectx()->appendResult(
                 "empty_var2",
                 ResultBuilder().value(Value(std::move(ds))).finish());
         }

--- a/src/executor/test/ProduceAllPathsTest.cpp
+++ b/src/executor/test/ProduceAllPathsTest.cpp
@@ -210,7 +210,7 @@ protected:
                             "_edge:+edge1:prop1:prop2:_dst:_rank",
                             "_expr"};
                 qctx_->symTable()->newVariable("empty_get_neighbors");
-                qctx_->ectx()->setResult("empty_get_neighbors",
+                qctx_->ectx()->appendResult("empty_get_neighbors",
                                         ResultBuilder()
                                             .value(Value(std::move(ds)))
                                             .iter(Iterator::Kind::kGetNeighbors)
@@ -241,7 +241,7 @@ TEST_F(ProduceAllPathsTest, AllPath) {
         List datasets;
         datasets.values.emplace_back(std::move(firstStepResult_));
         builder.value(std::move(datasets)).iter(Iterator::Kind::kGetNeighbors);
-        qctx_->ectx()->setResult("input", builder.finish());
+        qctx_->ectx()->appendResult("input", builder.finish());
 
         auto future = allPathsExe->execute();
         auto status = std::move(future).get();
@@ -322,7 +322,7 @@ TEST_F(ProduceAllPathsTest, AllPath) {
         List datasets;
         datasets.values.emplace_back(std::move(secondStepResult_));
         builder.value(std::move(datasets)).iter(Iterator::Kind::kGetNeighbors);
-        qctx_->ectx()->setResult("input", builder.finish());
+        qctx_->ectx()->appendResult("input", builder.finish());
 
         auto future = allPathsExe->execute();
         auto status = std::move(future).get();
@@ -412,7 +412,7 @@ TEST_F(ProduceAllPathsTest, AllPath) {
         List datasets;
         datasets.values.emplace_back(std::move(thridStepResult_));
         builder.value(std::move(datasets)).iter(Iterator::Kind::kGetNeighbors);
-        qctx_->ectx()->setResult("input", builder.finish());
+        qctx_->ectx()->appendResult("input", builder.finish());
 
         auto future = allPathsExe->execute();
         auto status = std::move(future).get();

--- a/src/executor/test/ProduceAllPathsTest.cpp
+++ b/src/executor/test/ProduceAllPathsTest.cpp
@@ -232,6 +232,7 @@ TEST_F(ProduceAllPathsTest, AllPath) {
     auto* allPathsNode = ProduceAllPaths::make(qctx_.get(), nullptr);
     allPathsNode->setInputVar("input");
     allPathsNode->setColNames({kDst, "_paths"});
+    allPathsNode->setInPlaceUpdate(false);
 
     auto allPathsExe = std::make_unique<ProduceAllPathsExecutor>(allPathsNode, qctx_.get());
 
@@ -456,6 +457,7 @@ TEST_F(ProduceAllPathsTest, EmptyInput) {
     auto* allPathsNode = ProduceAllPaths::make(qctx_.get(), nullptr);
     allPathsNode->setInputVar("empty_get_neighbors");
     allPathsNode->setColNames({kDst, "_paths"});
+    allPathsNode->setInPlaceUpdate(false);
 
     auto allPathsExe = std::make_unique<ProduceAllPathsExecutor>(allPathsNode, qctx_.get());
     auto future = allPathsExe->execute();

--- a/src/executor/test/ProduceSemiShortestPathTest.cpp
+++ b/src/executor/test/ProduceSemiShortestPathTest.cpp
@@ -225,6 +225,7 @@ TEST_F(ProduceSemiShortestPathTest, ShortestPath) {
     auto* pssp = ProduceSemiShortestPath::make(qctx_.get(), nullptr);
     pssp->setInputVar("input");
     pssp->setColNames({"_dst", "_src", "cost", "paths"});
+    pssp->setInPlaceUpdate(false);
 
     auto psspExe = std::make_unique<ProduceSemiShortestPathExecutor>(pssp, qctx_.get());
     // Step 1
@@ -493,6 +494,7 @@ TEST_F(ProduceSemiShortestPathTest, EmptyInput) {
     auto* pssp = ProduceSemiShortestPath::make(qctx_.get(), nullptr);
     pssp->setInputVar("empty_get_neighbors");
     pssp->setColNames({"_dst", "_src", "cost", "paths"});
+    pssp->setInPlaceUpdate(false);
 
     auto psspExe = std::make_unique<ProduceSemiShortestPathExecutor>(pssp, qctx_.get());
     auto future = psspExe->execute();

--- a/src/executor/test/ProduceSemiShortestPathTest.cpp
+++ b/src/executor/test/ProduceSemiShortestPathTest.cpp
@@ -203,7 +203,7 @@ protected:
                             "_edge:+edge1:prop1:prop2:_dst:_rank",
                             "_expr"};
                 qctx_->symTable()->newVariable("empty_get_neighbors");
-                qctx_->ectx()->setResult("empty_get_neighbors",
+                qctx_->ectx()->appendResult("empty_get_neighbors",
                                         ResultBuilder()
                                             .value(Value(std::move(ds)))
                                             .iter(Iterator::Kind::kGetNeighbors)
@@ -233,7 +233,7 @@ TEST_F(ProduceSemiShortestPathTest, ShortestPath) {
         List datasets;
         datasets.values.emplace_back(std::move(firstStepResult_));
         builder.value(std::move(datasets)).iter(Iterator::Kind::kGetNeighbors);
-        qctx_->ectx()->setResult("input", builder.finish());
+        qctx_->ectx()->appendResult("input", builder.finish());
 
         auto future = psspExe->execute();
         auto status = std::move(future).get();
@@ -332,7 +332,7 @@ TEST_F(ProduceSemiShortestPathTest, ShortestPath) {
         List datasets;
         datasets.values.emplace_back(std::move(secondStepResult_));
         builder.value(std::move(datasets)).iter(Iterator::Kind::kGetNeighbors);
-        qctx_->ectx()->setResult("input", builder.finish());
+        qctx_->ectx()->appendResult("input", builder.finish());
 
         auto future = psspExe->execute();
         auto status = std::move(future).get();
@@ -444,7 +444,7 @@ TEST_F(ProduceSemiShortestPathTest, ShortestPath) {
         List datasets;
         datasets.values.emplace_back(std::move(thridStepResult_));
         builder.value(std::move(datasets)).iter(Iterator::Kind::kGetNeighbors);
-        qctx_->ectx()->setResult("input", builder.finish());
+        qctx_->ectx()->appendResult("input", builder.finish());
 
         auto future = psspExe->execute();
         auto status = std::move(future).get();

--- a/src/executor/test/ProjectTest.cpp
+++ b/src/executor/test/ProjectTest.cpp
@@ -33,7 +33,7 @@ protected:
             ResultBuilder builder;
             builder.value(Value(std::move(ds)));
             qctx_->symTable()->newVariable("input_project");
-            qctx_->ectx()->setResult("input_project", builder.finish());
+            qctx_->ectx()->appendResult("input_project", builder.finish());
         }
         {
             DataSet ds;
@@ -41,7 +41,7 @@ protected:
             ResultBuilder builder;
             builder.value(Value(std::move(ds)));
             qctx_->symTable()->newVariable("empty");
-            qctx_->ectx()->setResult("empty", builder.finish());
+            qctx_->ectx()->appendResult("empty", builder.finish());
         }
     }
 

--- a/src/executor/test/QueryTestBase.h
+++ b/src/executor/test/QueryTestBase.h
@@ -78,7 +78,7 @@ protected:
                               .iter(Iterator::Kind::kGetNeighbors)
                               .finish();
             qctx_->symTable()->newVariable("input_neighbor");
-            qctx_->ectx()->setResult("input_neighbor", std::move(result));
+            qctx_->ectx()->appendResult("input_neighbor", std::move(result));
         }
         // sequential
         {
@@ -90,7 +90,7 @@ protected:
             dataset.emplace_back(Row({"Ann", "Ann", 18, "School1", 2010, 2014}));
             dataset.emplace_back(Row({"Lily", "Lily", 20, "School2", 2009, 2012}));
             qctx_->symTable()->newVariable("input_sequential");
-            qctx_->ectx()->setResult("input_sequential",
+            qctx_->ectx()->appendResult("input_sequential",
                                      ResultBuilder().value(Value(dataset)).finish());
         }
         // sequential init by two sequentialIters
@@ -101,13 +101,13 @@ protected:
             lds.emplace_back(Row({"Tom", "Tom", 20, "School2", 2008, 2012}));
             lds.emplace_back(Row({"Kate", "Kate", 19, "School2", 2009, 2013}));
             qctx_->symTable()->newVariable("left_neighbor");
-            qctx_->ectx()->setResult("left_sequential",
+            qctx_->ectx()->appendResult("left_sequential",
                                      ResultBuilder().value(Value(lds)).finish());
 
             DataSet rds({"vid", "v_name", "v_age", "v_dst", "e_start_year", "e_end_year"});
             rds.emplace_back(Row({"Ann", "Ann", 18, "School1", 2010, 2014}));
             rds.emplace_back(Row({"Lily", "Lily", 20, "School2", 2009, 2012}));
-            qctx_->ectx()->setResult("right_sequential",
+            qctx_->ectx()->appendResult("right_sequential",
                                      ResultBuilder().value(Value(rds)).finish());
 
             auto lIter = qctx_->ectx()->getResult("left_sequential").iter();
@@ -116,14 +116,14 @@ protected:
             builder.value(lIter->valuePtr())
                 .iter(std::make_unique<SequentialIter>(std::move(lIter), std::move(rIter)));
             qctx_->symTable()->newVariable("union_sequential");
-            qctx_->ectx()->setResult("union_sequential", builder.finish());
+            qctx_->ectx()->appendResult("union_sequential", builder.finish());
         }
         // empty
         {
             DataSet dataset({kVid, "_stats", "_tag:person:name:age",
                              "_edge:+study:_dst:start_year:end_year", "_expr"});
             qctx_->symTable()->newVariable("empty");
-            qctx_->ectx()->setResult("empty",
+            qctx_->ectx()->appendResult("empty",
                                      ResultBuilder().value(Value(dataset)).finish());
         }
     }

--- a/src/executor/test/SetExecutorTest.cpp
+++ b/src/executor/test/SetExecutorTest.cpp
@@ -63,8 +63,8 @@ TEST_F(SetExecutorTest, TestUnionAll) {
         lb.value(Value(lds)).iter(Iterator::Kind::kSequential);
         rb.value(Value(rds)).iter(Iterator::Kind::kSequential);
         // Must save the values after constructing executors
-        qctx_->ectx()->setResult(left->outputVar(), lb.finish());
-        qctx_->ectx()->setResult(right->outputVar(), rb.finish());
+        qctx_->ectx()->appendResult(left->outputVar(), lb.finish());
+        qctx_->ectx()->appendResult(right->outputVar(), rb.finish());
         auto future = unionExecutor->execute();
         EXPECT_TRUE(std::move(future).get().ok());
 
@@ -179,8 +179,8 @@ TEST_F(SetExecutorTest, TestGetNeighobrsIterator) {
     ResultBuilder lrb, rrb;
     auto& lRes = lrb.value(Value(std::move(lds))).iter(Iterator::Kind::kGetNeighbors);
     auto& rRes = rrb.value(Value(std::move(rds)));
-    qctx_->ectx()->setResult(left->outputVar(), lRes.finish());
-    qctx_->ectx()->setResult(right->outputVar(), rRes.finish());
+    qctx_->ectx()->appendResult(left->outputVar(), lRes.finish());
+    qctx_->ectx()->appendResult(right->outputVar(), rRes.finish());
     auto future = unionExecutor->execute();
     auto status = std::move(future).get();
 
@@ -254,8 +254,8 @@ TEST_F(SetExecutorTest, TestIntersect) {
         lb.value(Value(lds)).iter(Iterator::Kind::kSequential);
         rb.value(Value(rds)).iter(Iterator::Kind::kSequential);
         auto executor = Executor::create(intersect, qctx_.get());
-        qctx_->ectx()->setResult(left->outputVar(), lb.finish());
-        qctx_->ectx()->setResult(right->outputVar(), rb.finish());
+        qctx_->ectx()->appendResult(left->outputVar(), lb.finish());
+        qctx_->ectx()->appendResult(right->outputVar(), rb.finish());
 
         auto fut = executor->execute();
         auto status = std::move(fut).get();
@@ -361,8 +361,8 @@ TEST_F(SetExecutorTest, TestMinus) {
         lb.value(Value(lds)).iter(Iterator::Kind::kSequential);
         rb.value(Value(rds)).iter(Iterator::Kind::kSequential);
         auto executor = Executor::create(minus, qctx_.get());
-        qctx_->ectx()->setResult(left->outputVar(), lb.finish());
-        qctx_->ectx()->setResult(right->outputVar(), rb.finish());
+        qctx_->ectx()->appendResult(left->outputVar(), lb.finish());
+        qctx_->ectx()->appendResult(right->outputVar(), rb.finish());
 
         auto fut = executor->execute();
         auto status = std::move(fut).get();

--- a/src/planner/plan/ExecutionPlan.h
+++ b/src/planner/plan/ExecutionPlan.h
@@ -18,6 +18,7 @@ struct PlanNodeDescription;
 namespace graph {
 
 class PlanNode;
+class QueryContext;
 
 class ExecutionPlan final {
 public:
@@ -48,10 +49,14 @@ public:
         explainFormat_ = format;
     }
 
+    void analyze(QueryContext* qctx) const;
+
 private:
     uint64_t makePlanNodeDesc(const PlanNode* node);
     void descBranchInfo(const PlanNode* node, bool isDoBranch, int64_t id);
     void setPlanNodeDeps(const PlanNode* dep, PlanNodeDescription* planNodeDesc) const;
+    void analyzeLifetime(QueryContext* qctx, const PlanNode* node, bool inLoop = false) const;
+    void needMultipleVersionsForInputNodes(QueryContext* qctx, const std::string& var) const;
 
     int32_t optimizeTimeInUs_{0};
     int64_t id_{-1};

--- a/src/planner/plan/PlanNode.cpp
+++ b/src/planner/plan/PlanNode.cpp
@@ -19,7 +19,7 @@
 namespace nebula {
 namespace graph {
 
-PlanNode::PlanNode(QueryContext* qctx, Kind kind) : qctx_(qctx), kind_(kind) {
+PlanNode::PlanNode(QueryContext* qctx, Kind kind) : kind_(kind), qctx_(qctx) {
     DCHECK(qctx != nullptr);
     id_ = qctx_->genId();
     auto varName = folly::stringPrintf("__%s_%ld", toString(kind_), id_);
@@ -347,6 +347,7 @@ std::unique_ptr<PlanNodeDescription> PlanNode::explain() const {
     desc->id = id_;
     desc->name = toString(kind_);
     desc->outputVar = folly::toJson(util::toJson(outputVars_));
+    addDescription("inPlaceUpdate", util::toJson(inPlaceUpdate_), desc.get());
     return desc;
 }
 

--- a/src/planner/plan/PlanNode.h
+++ b/src/planner/plan/PlanNode.h
@@ -263,6 +263,14 @@ public:
         return inputVars_;
     }
 
+    bool isInPlaceUpdate() const {
+        return inPlaceUpdate_;
+    }
+
+    void setInPlaceUpdate(bool update = true) {
+        inPlaceUpdate_ = update;
+    }
+
     void releaseSymbols();
 
     static const char* toString(Kind kind);
@@ -287,8 +295,9 @@ protected:
         outputVars_ = node.outputVars_;
     }
 
-    QueryContext*                            qctx_{nullptr};
+    bool                                     inPlaceUpdate_{true};
     Kind                                     kind_{Kind::kUnknown};
+    QueryContext*                            qctx_{nullptr};
     int64_t                                  id_{-1};
     double                                   cost_{0.0};
     std::vector<const PlanNode*>             dependencies_;

--- a/src/planner/plan/PlanNode.h
+++ b/src/planner/plan/PlanNode.h
@@ -267,7 +267,7 @@ public:
         return inPlaceUpdate_;
     }
 
-    void setInPlaceUpdate(bool update = true) {
+    void setInPlaceUpdate(bool update) {
         inPlaceUpdate_ = update;
     }
 

--- a/src/scheduler/AsyncMsgNotifyBasedScheduler.cpp
+++ b/src/scheduler/AsyncMsgNotifyBasedScheduler.cpp
@@ -9,8 +9,6 @@
 #include "context/QueryContext.h"
 #include "planner/plan/PlanNode.h"
 
-DECLARE_bool(enable_lifetime_optimize);
-
 namespace nebula {
 namespace graph {
 
@@ -18,10 +16,6 @@ AsyncMsgNotifyBasedScheduler::AsyncMsgNotifyBasedScheduler(QueryContext* qctx) :
 
 folly::Future<Status> AsyncMsgNotifyBasedScheduler::schedule() {
     auto root = qctx_->plan()->root();
-    if (FLAGS_enable_lifetime_optimize) {
-        root->outputVarPtr()->setLastUser(-1);  // special for root
-        analyzeLifetime(root);
-    }
     auto executor = Executor::create(root, qctx_);
     return doSchedule(executor);
 }

--- a/src/scheduler/AsyncMsgNotifyBasedScheduler.h
+++ b/src/scheduler/AsyncMsgNotifyBasedScheduler.h
@@ -69,8 +69,6 @@ private:
     void notifyError(std::vector<folly::Promise<Status>>& promises, Status status) const;
 
     folly::Future<Status> execute(Executor *executor) const;
-
-    QueryContext *qctx_{nullptr};
 };
 }  // namespace graph
 }  // namespace nebula

--- a/src/scheduler/Scheduler.cpp
+++ b/src/scheduler/Scheduler.cpp
@@ -6,89 +6,10 @@
 
 #include "scheduler/Scheduler.h"
 
-#include "context/ExecutionContext.h"
-#include "context/QueryContext.h"
-#include "context/Symbols.h"
-#include "executor/ExecutionError.h"
-#include "executor/Executor.h"
-#include "executor/logic/LoopExecutor.h"
-#include "executor/logic/PassThroughExecutor.h"
-#include "executor/logic/SelectExecutor.h"
-#include "planner/plan/Algo.h"
-#include "planner/plan/Logic.h"
-#include "planner/plan/PlanNode.h"
-#include "planner/plan/Query.h"
-
 namespace nebula {
 namespace graph {
 
 Scheduler::Scheduler(QueryContext* qctx) : qctx_(DCHECK_NOTNULL(qctx)) {}
-
-void Scheduler::analyzeLifetime(const PlanNode* root, bool inLoop) const {
-    std::stack<std::tuple<const PlanNode*, bool>> stack;
-    stack.push(std::make_tuple(root, inLoop));
-    while (!stack.empty()) {
-        const auto& current = stack.top();
-        auto currentNode = std::get<0>(current);
-        auto currentInLoop = std::get<1>(current);
-        for (auto& inputVar : currentNode->inputVars()) {
-            if (inputVar != nullptr) {
-                auto isLoopOrBody = currentNode->kind() == PlanNode::Kind::kLoop || currentInLoop;
-                inputVar->setLastUser(isLoopOrBody ? -1 : currentNode->id());
-            }
-        }
-        stack.pop();
-
-        for (auto dep : currentNode->dependencies()) {
-            stack.push(std::make_tuple(dep, currentInLoop));
-        }
-        switch (currentNode->kind()) {
-            case PlanNode::Kind::kSelect: {
-                auto sel = static_cast<const Select*>(currentNode);
-                stack.push(std::make_tuple(sel->then(), currentInLoop));
-                stack.push(std::make_tuple(sel->otherwise(), currentInLoop));
-                break;
-            }
-            case PlanNode::Kind::kLoop: {
-                auto loop = static_cast<const Loop*>(currentNode);
-                loop->outputVarPtr()->setLastUser(-1);
-                stack.push(std::make_tuple(loop->body(), true));
-                break;
-            }
-            case PlanNode::Kind::kInnerJoin:
-            case PlanNode::Kind::kLeftJoin: {
-                auto join = static_cast<const Join*>(currentNode);
-                auto leftVerVar = join->leftVar();
-                if (leftVerVar.second != ExecutionContext::kLatestVersion) {
-                    needMultipleVersionsForInputNodes(leftVerVar.first);
-                }
-                auto rightVerVar = join->rightVar();
-                if (rightVerVar.second != ExecutionContext::kLatestVersion) {
-                    needMultipleVersionsForInputNodes(rightVerVar.first);
-                }
-                break;
-            }
-            case PlanNode::Kind::kConjunctPath:
-            case PlanNode::Kind::kUnionAllVersionVar:
-            case PlanNode::Kind::kDataCollect: {
-                for (auto var : currentNode->inputVars()) {
-                    needMultipleVersionsForInputNodes(var->name);
-                }
-                break;
-            }
-            default:
-                break;
-        }
-    }
-}
-
-void Scheduler::needMultipleVersionsForInputNodes(const std::string& var) const {
-    auto symTbl = qctx_->symTable();
-    auto variable = DCHECK_NOTNULL(symTbl->getVar(var));
-    for (auto w : variable->writtenBy) {
-        w->setInPlaceUpdate(false);
-    }
-}
 
 }   // namespace graph
 }   // namespace nebula

--- a/src/scheduler/Scheduler.h
+++ b/src/scheduler/Scheduler.h
@@ -25,11 +25,7 @@ public:
 
     virtual folly::Future<Status> schedule() = 0;
 
-    void analyzeLifetime(const PlanNode *node, bool inLoop = false) const;
-
 protected:
-    void needMultipleVersionsForInputNodes(const std::string &var) const;
-
     QueryContext *qctx_{nullptr};
 };
 

--- a/src/scheduler/Scheduler.h
+++ b/src/scheduler/Scheduler.h
@@ -7,22 +7,32 @@
 #ifndef SCHEDULER_SCHEDULER_H_
 #define SCHEDULER_SCHEDULER_H_
 
-#include "common/base/Base.h"
+#include <folly/futures/Future.h>
+
 #include "common/base/Status.h"
-#include "executor/Executor.h"
-#include "planner/plan/PlanNode.h"
+#include "common/cpp/helpers.h"
 
 namespace nebula {
 namespace graph {
+
+class PlanNode;
+class QueryContext;
+
 class Scheduler : private cpp::NonCopyable, private cpp::NonMovable {
 public:
-    Scheduler() = default;
+    explicit Scheduler(QueryContext *qctx);
     virtual ~Scheduler() = default;
 
     virtual folly::Future<Status> schedule() = 0;
 
-    static void analyzeLifetime(const PlanNode *node, bool inLoop = false);
+    void analyzeLifetime(const PlanNode *node, bool inLoop = false) const;
+
+protected:
+    void needMultipleVersionsForInputNodes(const std::string &var) const;
+
+    QueryContext *qctx_{nullptr};
 };
-}  // namespace graph
-}  // namespace nebula
-#endif  // SCHEDULER_SCHEDULER_H_
+
+}   // namespace graph
+}   // namespace nebula
+#endif   // SCHEDULER_SCHEDULER_H_

--- a/src/service/GraphFlags.cpp
+++ b/src/service/GraphFlags.cpp
@@ -61,3 +61,5 @@ DEFINE_double(system_memory_high_watermark_ratio, 0.8, "high watermark ratio of 
 
 DEFINE_bool(disable_octal_escape_char, false, "Octal escape character will be disabled"
                                          " in next version to ensure compatibility with cypher.");
+
+DEFINE_bool(enable_lifetime_optimize, true, "Does enable the lifetime optimize.");

--- a/src/service/GraphFlags.h
+++ b/src/service/GraphFlags.h
@@ -39,6 +39,8 @@ DECLARE_string(cloud_http_url);
 DECLARE_uint32(max_allowed_statements);
 DECLARE_double(system_memory_high_watermark_ratio);
 
+DECLARE_bool(enable_lifetime_optimize);
+
 // optimizer
 DECLARE_bool(enable_optimizer);
 

--- a/src/service/QueryInstance.cpp
+++ b/src/service/QueryInstance.cpp
@@ -193,6 +193,7 @@ Status QueryInstance::findBestPlan() {
     NG_RETURN_IF_ERROR(rootStatus);
     auto root = std::move(rootStatus).value();
     plan->setRoot(const_cast<PlanNode *>(root));
+    plan->analyze(qctx_.get());
     return Status::OK();
 }
 

--- a/src/util/QueryUtil.cpp
+++ b/src/util/QueryUtil.cpp
@@ -25,7 +25,7 @@ void QueryUtil::buildConstantInput(QueryContext *qctx, Starts& starts, std::stri
         row.values.emplace_back(vid);
         ds.rows.emplace_back(std::move(row));
     }
-    qctx->ectx()->setResult(vidsVar, ResultBuilder().value(Value(std::move(ds))).finish());
+    qctx->ectx()->appendResult(vidsVar, ResultBuilder().value(Value(std::move(ds))).finish());
     auto* pool = qctx->objPool();
     // If possible, use column numbers in preference to column names,
     starts.src = ColumnExpression::make(pool, 0);

--- a/src/validator/FetchEdgesValidator.cpp
+++ b/src/validator/FetchEdgesValidator.cpp
@@ -263,7 +263,7 @@ const Expression *FetchEdgesValidator::findInvalidYieldExpression(const Expressi
 std::string FetchEdgesValidator::buildConstantInput() {
     auto pool = qctx_->objPool();
     auto input = vctx_->anonVarGen()->getVar();
-    qctx_->ectx()->setResult(input, ResultBuilder().value(Value(std::move(edgeKeys_))).finish());
+    qctx_->ectx()->appendResult(input, ResultBuilder().value(Value(std::move(edgeKeys_))).finish());
 
     src_ = VariablePropertyExpression::make(pool, input, kSrc);
     type_ = ConstantExpression::make(pool, edgeType_);

--- a/src/validator/FetchVerticesValidator.cpp
+++ b/src/validator/FetchVerticesValidator.cpp
@@ -237,7 +237,7 @@ Status FetchVerticesValidator::preparePropertiesWithoutYield() {
 // TODO(shylock) optimize dedup input when distinct given
 std::string FetchVerticesValidator::buildConstantInput() {
     auto input = vctx_->anonVarGen()->getVar();
-    qctx_->ectx()->setResult(input, ResultBuilder().value(Value(std::move(srcVids_))).finish());
+    qctx_->ectx()->appendResult(input, ResultBuilder().value(Value(std::move(srcVids_))).finish());
 
     auto *pool = qctx_->objPool();
     src_ = VariablePropertyExpression::make(pool, input, kVid);

--- a/src/validator/MutateValidator.cpp
+++ b/src/validator/MutateValidator.cpp
@@ -306,7 +306,7 @@ std::string DeleteVerticesValidator::buildVIds() {
         row.values.emplace_back(vid);
         ds.rows.emplace_back(std::move(row));
     }
-    qctx_->ectx()->setResult(input, ResultBuilder().value(Value(std::move(ds))).finish());
+    qctx_->ectx()->appendResult(input, ResultBuilder().value(Value(std::move(ds))).finish());
     auto *pool = qctx_->objPool();
     auto *vIds = VariablePropertyExpression::make(pool, input, kVid);
     vidRef_ = vIds;
@@ -437,7 +437,7 @@ Status DeleteEdgesValidator::buildEdgeKeyRef(const std::vector<EdgeKey*> &edgeKe
         row.emplace_back(std::move(dstId));
         ds.emplace_back(std::move(row));
     }
-    qctx_->ectx()->setResult(edgeKeyVar_, ResultBuilder().value(Value(std::move(ds))).finish());
+    qctx_->ectx()->appendResult(edgeKeyVar_, ResultBuilder().value(Value(std::move(ds))).finish());
     auto *pool = qctx_->objPool();
     auto *srcIdExpr = InputPropertyExpression::make(pool, kSrc);
     auto *typeExpr = InputPropertyExpression::make(pool, kType);

--- a/src/validator/TraversalValidator.cpp
+++ b/src/validator/TraversalValidator.cpp
@@ -148,7 +148,7 @@ void TraversalValidator::buildConstantInput(Starts& starts, std::string& startVi
         row.values.emplace_back(vid);
         ds.rows.emplace_back(std::move(row));
     }
-    qctx_->ectx()->setResult(startVidsVar, ResultBuilder().value(Value(std::move(ds))).finish());
+    qctx_->ectx()->appendResult(startVidsVar, ResultBuilder().value(Value(std::move(ds))).finish());
 
     auto pool = qctx_->objPool();
     starts.src = VariablePropertyExpression::make(pool, startVidsVar, kVid);

--- a/src/validator/YieldValidator.cpp
+++ b/src/validator/YieldValidator.cpp
@@ -101,7 +101,7 @@ void YieldValidator::genConstantExprValues() {
         row.values.emplace_back(Expression::eval(column->expr(), ctx(nullptr)));
     }
     ds.emplace_back(std::move(row));
-    qctx_->ectx()->setResult(constantExprVar_,
+    qctx_->ectx()->appendResult(constantExprVar_,
                              ResultBuilder().value(Value(std::move(ds))).finish());
 }
 


### PR DESCRIPTION
for most plan nodes, it's not necessary to store multiple version's results. So this PR lets these plan nodes update the outputs in place to save the memory usage.