### PR TITLE
fix util functions

### DIFF
--- a/src/executor/test/FilterTest.cpp
+++ b/src/executor/test/FilterTest.cpp
@@ -25,15 +25,14 @@ public:
 #define FILTER_RESUTL_CHECK(inputName, outputName, sentence, expected)                             \
     do {                                                                                           \
         qctx_->symTable()->newVariable(outputName);                                                \
-        auto* pool = qctx_->objPool();                                                             \
         auto yieldSentence = getYieldSentence(sentence, qctx_.get());                              \
         auto columns = yieldSentence->columns();                                                   \
         for (auto& col : columns) {                                                                \
-            col->setExpr(ExpressionUtils::rewriteLabelAttr2EdgeProp(pool, col->expr()));           \
+            col->setExpr(ExpressionUtils::rewriteLabelAttr2EdgeProp(col->expr()));                 \
         }                                                                                          \
         auto* whereSentence = yieldSentence->where();                                              \
         whereSentence->setFilter(                                                                  \
-            ExpressionUtils::rewriteLabelAttr2EdgeProp(pool, whereSentence->filter()));            \
+            ExpressionUtils::rewriteLabelAttr2EdgeProp(whereSentence->filter()));                  \
         auto* filterNode = Filter::make(qctx_.get(), nullptr, yieldSentence->where()->filter());   \
         filterNode->setInputVar(inputName);                                                        \
         filterNode->setOutputVar(outputName);                                                      \

--- a/src/optimizer/rule/PushFilterDownProjectRule.cpp
+++ b/src/optimizer/rule/PushFilterDownProjectRule.cpp
@@ -43,7 +43,6 @@ StatusOr<OptRule::TransformResult> PushFilterDownProjectRule::transform(
     DCHECK_EQ(projNode->kind(), PlanNode::Kind::kProject);
     const auto* oldProjNode = static_cast<const graph::Project*>(projNode);
     const auto* condition = oldFilterNode->condition();
-    auto objPool = octx->qctx()->objPool();
 
     auto projColNames = oldProjNode->colNames();
     auto projColumns = oldProjNode->columns()->columns();
@@ -86,7 +85,7 @@ StatusOr<OptRule::TransformResult> PushFilterDownProjectRule::transform(
     };
     Expression* filterPicked = nullptr;
     Expression* filterUnpicked = nullptr;
-    graph::ExpressionUtils::splitFilter(objPool, condition, picker, &filterPicked, &filterUnpicked);
+    graph::ExpressionUtils::splitFilter(condition, picker, &filterPicked, &filterUnpicked);
 
     if (!filterPicked) {
         return TransformResult::noTransform();

--- a/src/planner/match/LabelIndexSeek.cpp
+++ b/src/planner/match/LabelIndexSeek.cpp
@@ -117,8 +117,7 @@ StatusOr<SubPlan> LabelIndexSeek::transformNode(NodeContext* nodeCtx) {
                     }
                 }
                 if (canBeEmbeded2IndexScan) {
-                    auto* srcFilter =
-                        ExpressionUtils::rewriteLabelAttr2TagProp(pool, flattenFilter);
+                    auto* srcFilter = ExpressionUtils::rewriteLabelAttr2TagProp(flattenFilter);
                     storage::cpp2::IndexQueryContext ctx;
                     ctx.set_filter(Expression::encode(*srcFilter));
                     scan->setIndexQueryContext({ctx});

--- a/src/util/ExpressionUtils.h
+++ b/src/util/ExpressionUtils.h
@@ -56,36 +56,33 @@ public:
 
     static bool isEvaluableExpr(const Expression* expr);
 
-    static Expression* rewriteLabelAttr2TagProp(ObjectPool* pool, const Expression* expr);
+    static Expression* rewriteLabelAttr2TagProp(const Expression* expr);
 
-    static Expression* rewriteLabelAttr2EdgeProp(ObjectPool* pool, const Expression* expr);
+    static Expression* rewriteLabelAttr2EdgeProp(const Expression* expr);
 
-    static Expression* rewriteAgg2VarProp(ObjectPool* pool, const Expression* expr);
+    static Expression* rewriteAgg2VarProp(const Expression* expr);
 
-    static Expression* rewriteInnerVar(ObjectPool* pool,
-                                       const Expression* expr,
-                                       std::string newVar);
+    static Expression* rewriteInnerVar(const Expression* expr, std::string newVar);
 
     // Rewrite relational expression, gather evaluable expressions to one side
-    static Expression* rewriteRelExpr(const Expression* expr, ObjectPool* pool);
-    static Expression* rewriteRelExprHelper(ObjectPool* pool,
-                                            const Expression* expr,
+    static Expression* rewriteRelExpr(const Expression* expr);
+    static Expression* rewriteRelExprHelper(const Expression* expr,
                                             Expression*& relRightOperandExpr);
 
     // Clone and fold constant expression
-    static StatusOr<Expression*> foldConstantExpr(ObjectPool* objPool, const Expression* expr);
+    static StatusOr<Expression*> foldConstantExpr(const Expression* expr);
 
     // Clone and reduce unaryNot expression
-    static Expression* reduceUnaryNotExpr(const Expression* expr, ObjectPool* pool);
+    static Expression* reduceUnaryNotExpr(const Expression* expr);
 
     // Transform filter using multiple expression rewrite strategies
-    static StatusOr<Expression*> filterTransform(const Expression* expr, ObjectPool* objPool);
+    static StatusOr<Expression*> filterTransform(const Expression* expr);
 
     // Negate the given logical expr: (A && B) -> (!A || !B)
-    static LogicalExpression* reverseLogicalExpr(ObjectPool* pool, LogicalExpression* expr);
+    static LogicalExpression* reverseLogicalExpr(LogicalExpression* expr);
 
     // Negate the given relational expr: (A > B) -> (A <= B)
-    static RelationalExpression* reverseRelExpr(ObjectPool* pool, RelationalExpression* expr);
+    static RelationalExpression* reverseRelExpr(RelationalExpression* expr);
 
     // Return the negation of the given relational kind
     static Expression::Kind getNegatedRelExprKind(const Expression::Kind kind);
@@ -119,8 +116,7 @@ public:
 
     static Expression* flattenInnerLogicalExpr(const Expression* expr);
 
-    static void splitFilter(ObjectPool* pool,
-                            const Expression* expr,
+    static void splitFilter(const Expression* expr,
                             std::function<bool(const Expression*)> picker,
                             Expression** filterPicked,
                             Expression** filterUnpicked);

--- a/src/util/test/ExpressionUtilsTest.cpp
+++ b/src/util/test/ExpressionUtilsTest.cpp
@@ -519,7 +519,7 @@ TEST_F(ExpressionUtilsTest, splitFilter) {
         };
         Expression *newExpr1 = nullptr;
         Expression *newExpr2 = nullptr;
-        ExpressionUtils::splitFilter(pool, expr, picker, &newExpr1, &newExpr2);
+        ExpressionUtils::splitFilter(expr, picker, &newExpr1, &newExpr2);
         ASSERT_EQ(*expected1, *newExpr1);
         ASSERT_EQ(*second, *newExpr2);
     }
@@ -534,7 +534,7 @@ TEST_F(ExpressionUtilsTest, splitFilter) {
         };
         Expression *newExpr1 = nullptr;
         Expression *newExpr2 = nullptr;
-        ExpressionUtils::splitFilter(pool, expr, picker, &newExpr1, &newExpr2);
+        ExpressionUtils::splitFilter(expr, picker, &newExpr1, &newExpr2);
         ASSERT_EQ(*expr, *newExpr1);
         ASSERT_EQ(nullptr, newExpr2);
     }

--- a/src/validator/FetchEdgesValidator.cpp
+++ b/src/validator/FetchEdgesValidator.cpp
@@ -182,7 +182,7 @@ Status FetchEdgesValidator::preparePropertiesWithYield(const YieldClause *yield)
     propsName.reserve(newYield_->columns().size());
     dedup_ = newYield_->isDistinct();
     for (auto col : newYield_->columns()) {
-        col->setExpr(ExpressionUtils::rewriteLabelAttr2EdgeProp(pool, col->expr()));
+        col->setExpr(ExpressionUtils::rewriteLabelAttr2EdgeProp(col->expr()));
         NG_RETURN_IF_ERROR(invalidLabelIdentifiers(col->expr()));
         const auto *invalidExpr = findInvalidYieldExpression(col->expr());
         if (invalidExpr != nullptr) {

--- a/src/validator/FetchVerticesValidator.cpp
+++ b/src/validator/FetchVerticesValidator.cpp
@@ -153,7 +153,7 @@ Status FetchVerticesValidator::preparePropertiesWithYield(const YieldClause *yie
 
     auto* pool = qctx_->objPool();
     for (auto col : yield->columns()) {
-        col->setExpr(ExpressionUtils::rewriteLabelAttr2TagProp(pool, col->expr()));
+        col->setExpr(ExpressionUtils::rewriteLabelAttr2TagProp(col->expr()));
         NG_RETURN_IF_ERROR(invalidLabelIdentifiers(col->expr()));
         col->expr()->accept(&deducePropsVisitor);
         if (!deducePropsVisitor.ok()) {

--- a/src/validator/FindPathValidator.cpp
+++ b/src/validator/FindPathValidator.cpp
@@ -45,8 +45,7 @@ Status FindPathValidator::validateWhere(WhereClause* where) {
         return Status::SemanticError("Not support `%s' in where sentence.",
                                      expr->toString().c_str());
     }
-    auto* pool = qctx_->objPool();
-    where->setFilter(ExpressionUtils::rewriteLabelAttr2EdgeProp(pool, expr));
+    where->setFilter(ExpressionUtils::rewriteLabelAttr2EdgeProp(expr));
     auto filter = where->filter();
 
     auto typeStatus = deduceExprType(filter);

--- a/src/validator/GoValidator.cpp
+++ b/src/validator/GoValidator.cpp
@@ -56,9 +56,8 @@ Status GoValidator::validateWhere(WhereClause* where) {
         return Status::SemanticError("`%s', not support aggregate function in where sentence.",
                                      expr->toString().c_str());
     }
-    auto pool = qctx()->objPool();
-    where->setFilter(ExpressionUtils::rewriteLabelAttr2EdgeProp(pool, expr));
-    auto foldRes = ExpressionUtils::foldConstantExpr(pool, where->filter());
+    where->setFilter(ExpressionUtils::rewriteLabelAttr2EdgeProp(expr));
+    auto foldRes = ExpressionUtils::foldConstantExpr(where->filter());
     NG_RETURN_IF_ERROR(foldRes);
 
     auto filter = foldRes.value();
@@ -141,7 +140,7 @@ Status GoValidator::validateYield(YieldClause* yield) {
     }
 
     for (auto col : cols) {
-        col->setExpr(ExpressionUtils::rewriteLabelAttr2EdgeProp(pool, col->expr()));
+        col->setExpr(ExpressionUtils::rewriteLabelAttr2EdgeProp(col->expr()));
         NG_RETURN_IF_ERROR(invalidLabelIdentifiers(col->expr()));
 
         auto* colExpr = col->expr();

--- a/src/validator/GroupByValidator.cpp
+++ b/src/validator/GroupByValidator.cpp
@@ -50,7 +50,7 @@ Status GroupByValidator::validateYield(const YieldClause* yieldClause) {
                 needGenProject_ = true;
             }
             if (!aggs.empty()) {
-                auto* colRewrited = ExpressionUtils::rewriteAgg2VarProp(pool, colExpr);
+                auto* colRewrited = ExpressionUtils::rewriteAgg2VarProp(colExpr);
                 projCols_->addColumn(new YieldColumn(colRewrited, colOldName));
                 continue;
             }

--- a/src/validator/LookupValidator.cpp
+++ b/src/validator/LookupValidator.cpp
@@ -199,7 +199,7 @@ StatusOr<Expression*> LookupValidator::rewriteRelExpr(RelationalExpression* expr
 
     // fold constant expression
     auto pool = qctx_->objPool();
-    auto foldRes = ExpressionUtils::foldConstantExpr(pool, expr);
+    auto foldRes = ExpressionUtils::foldConstantExpr(expr);
     NG_RETURN_IF_ERROR(foldRes);
     expr = static_cast<RelationalExpression*>(foldRes.value());
     DCHECK_EQ(expr->left()->kind(), Expression::Kind::kLabelAttribute);
@@ -212,9 +212,9 @@ StatusOr<Expression*> LookupValidator::rewriteRelExpr(RelationalExpression* expr
 
     // rewrite PropertyExpression
     if (lookupCtx_->isEdge) {
-        expr->setLeft(ExpressionUtils::rewriteLabelAttr2EdgeProp(pool, la));
+        expr->setLeft(ExpressionUtils::rewriteLabelAttr2EdgeProp(la));
     } else {
-        expr->setLeft(ExpressionUtils::rewriteLabelAttr2TagProp(pool, la));
+        expr->setLeft(ExpressionUtils::rewriteLabelAttr2TagProp(la));
     }
     return expr;
 }

--- a/src/validator/MaintainValidator.cpp
+++ b/src/validator/MaintainValidator.cpp
@@ -47,9 +47,8 @@ Status SchemaValidator::validateColumns(const std::vector<ColumnSpecification *>
                                                  property->defaultValue()->toString().c_str());
                 }
                 auto *defaultValueExpr = property->defaultValue();
-                auto pool = qctx()->objPool();
                 // some expression is evaluable but not pure so only fold instead of eval here
-                auto foldRes = ExpressionUtils::foldConstantExpr(pool, defaultValueExpr);
+                auto foldRes = ExpressionUtils::foldConstantExpr(defaultValueExpr);
                 NG_RETURN_IF_ERROR(foldRes);
                 column.set_default_value(foldRes.value()->encode());
             } else if (property->isComment()) {

--- a/src/validator/MatchValidator.cpp
+++ b/src/validator/MatchValidator.cpp
@@ -278,8 +278,7 @@ Status MatchValidator::buildEdgeInfo(const MatchPath *path,
 
 Status MatchValidator::validateFilter(const Expression *filter,
                                       WhereClauseContext &whereClauseCtx) const {
-    auto pool = whereClauseCtx.qctx->objPool();
-    auto transformRes =  ExpressionUtils::filterTransform(filter, pool);
+    auto transformRes =  ExpressionUtils::filterTransform(filter);
     NG_RETURN_IF_ERROR(transformRes);
     whereClauseCtx.filter = transformRes.value();
 
@@ -692,7 +691,7 @@ Status MatchValidator::validateGroup(YieldClauseContext &yieldCtx) const {
                 yieldCtx.aggOutputColumnNames_.emplace_back(agg->toString());
             }
             if (!aggs.empty()) {
-                auto *rewritedExpr = ExpressionUtils::rewriteAgg2VarProp(pool, colExpr);
+                auto *rewritedExpr = ExpressionUtils::rewriteAgg2VarProp(colExpr);
                 yieldCtx.projCols_->addColumn(new YieldColumn(rewritedExpr, colOldName));
                 yieldCtx.projOutputColumnNames_.emplace_back(colOldName);
                 continue;

--- a/src/validator/YieldValidator.cpp
+++ b/src/validator/YieldValidator.cpp
@@ -70,7 +70,6 @@ Status YieldValidator::validateImpl() {
 Status YieldValidator::makeOutputColumn(YieldColumn *column) {
     columns_->addColumn(column);
 
-    auto* pool = qctx()->objPool();
     auto colExpr = column->expr();
     DCHECK(colExpr != nullptr);
 
@@ -83,7 +82,7 @@ Status YieldValidator::makeOutputColumn(YieldColumn *column) {
 
     auto name = column->name();
     // Constant expression folding must be after type deduction
-    auto foldedExpr = ExpressionUtils::foldConstantExpr(pool, expr);
+    auto foldedExpr = ExpressionUtils::foldConstantExpr(expr);
     NG_RETURN_IF_ERROR(foldedExpr);
     auto foldedExprCopy = std::move(foldedExpr).value()->clone();
     column->setExpr(foldedExprCopy);
@@ -178,8 +177,7 @@ Status YieldValidator::validateWhere(const WhereClause *clause) {
     }
     if (filter != nullptr) {
         NG_RETURN_IF_ERROR(deduceProps(filter, exprProps_));
-        auto pool = qctx_->objPool();
-        auto foldRes = ExpressionUtils::foldConstantExpr(pool, filter);
+        auto foldRes = ExpressionUtils::foldConstantExpr(filter);
         NG_RETURN_IF_ERROR(foldRes);
         filterCondition_ = foldRes.value();
     }

--- a/src/visitor/test/FilterTransformTest.cpp
+++ b/src/visitor/test/FilterTransformTest.cpp
@@ -20,7 +20,7 @@ TEST_F(FilterTransformTest, TestComplexExprRewrite) {
     // !!!(v.age - 1 < 40)  =>  (v.age >= 41)
     auto expr = notExpr(notExpr(
         notExpr(ltExpr(minusExpr(laExpr("v", "age"), constantExpr(1)), constantExpr(40)))));
-    auto res = ExpressionUtils::filterTransform(expr, pool);
+    auto res = ExpressionUtils::filterTransform(expr);
     auto expected = geExpr(laExpr("v", "age"), constantExpr(41));
     ASSERT_EQ(*res.value(), *expected)
         << res.value()->toString() << " vs. " << expected->toString();
@@ -31,7 +31,7 @@ TEST_F(FilterTransformTest, TestCalculationOverflow) {
     {
         auto expr = ltExpr(minusExpr(laExpr("v", "age"), constantExpr(1)),
                                     constantExpr(9223372036854775807));
-        auto res = ExpressionUtils::filterTransform(expr, pool);
+        auto res = ExpressionUtils::filterTransform(expr);
         auto expected =
             Status::Error("result of (9223372036854775807+1) cannot be represented as an integer");
         ASSERT(!res.status().ok());
@@ -42,7 +42,7 @@ TEST_F(FilterTransformTest, TestCalculationOverflow) {
     {
         auto expr =
             ltExpr(addExpr(laExpr("v", "age"), constantExpr(1)), constantExpr(INT64_MIN));
-        auto res = ExpressionUtils::filterTransform(expr, pool);
+        auto res = ExpressionUtils::filterTransform(expr);
         auto expected =
             Status::Error("result of (-9223372036854775808-1) cannot be represented as an integer");
         ASSERT(!res.status().ok());
@@ -53,7 +53,7 @@ TEST_F(FilterTransformTest, TestCalculationOverflow) {
     {
         auto expr = ltExpr(minusExpr(laExpr("v", "age"), constantExpr(1)),
                                     addExpr(constantExpr(9223372036854775807), constantExpr(1)));
-        auto res = ExpressionUtils::filterTransform(expr, pool);
+        auto res = ExpressionUtils::filterTransform(expr);
         auto expected =
             Status::Error("result of (9223372036854775807+1) cannot be represented as an integer");
         ASSERT(!res.status().ok());
@@ -64,7 +64,7 @@ TEST_F(FilterTransformTest, TestCalculationOverflow) {
     {
         auto expr = ltExpr(addExpr(laExpr("v", "age"), constantExpr(1)),
                                     minusExpr(constantExpr(INT64_MIN), constantExpr(1)));
-        auto res = ExpressionUtils::filterTransform(expr, pool);
+        auto res = ExpressionUtils::filterTransform(expr);
         auto expected =
             Status::Error("result of (-9223372036854775808-1) cannot be represented as an integer");
         ASSERT(!res.status().ok());
@@ -75,7 +75,7 @@ TEST_F(FilterTransformTest, TestCalculationOverflow) {
     {
         auto expr = notExpr(notExpr(notExpr(ltExpr(
             minusExpr(laExpr("v", "age"), constantExpr(1)), constantExpr(9223372036854775807)))));
-        auto res = ExpressionUtils::filterTransform(expr, pool);
+        auto res = ExpressionUtils::filterTransform(expr);
         auto expected =
             Status::Error("result of (9223372036854775807+1) cannot be represented as an integer");
         ASSERT(!res.status().ok());
@@ -86,7 +86,7 @@ TEST_F(FilterTransformTest, TestCalculationOverflow) {
     {
         auto expr = notExpr(notExpr(notExpr(
             ltExpr(addExpr(laExpr("v", "age"), constantExpr(1)), constantExpr(INT64_MIN)))));
-        auto res = ExpressionUtils::filterTransform(expr, pool);
+        auto res = ExpressionUtils::filterTransform(expr);
         auto expected =
             Status::Error("result of (-9223372036854775808-1) cannot be represented as an integer");
         ASSERT(!res.status().ok());

--- a/src/visitor/test/RewriteRelExprVisitorTest.cpp
+++ b/src/visitor/test/RewriteRelExprVisitorTest.cpp
@@ -19,21 +19,21 @@ TEST_F(RewriteRelExprVisitorTest, TestArithmeticalExpr) {
     // (label + 1 < 40)  =>  (label < 40 - 1)
     {
         auto expr = ltExpr(addExpr(laExpr("v", "age"), constantExpr(1)), constantExpr(40));
-        auto res = ExpressionUtils::rewriteRelExpr(expr, pool);
+        auto res = ExpressionUtils::rewriteRelExpr(expr);
         auto expected = ltExpr(laExpr("v", "age"), minusExpr(constantExpr(40), constantExpr(1)));
         ASSERT_EQ(*res, *expected) << res->toString() << " vs. " << expected->toString();
     }
     // (1 + label < 40)  =>  (label < 40 - 1)
     {
         auto expr = ltExpr(addExpr(constantExpr(1), laExpr("v", "age")), constantExpr(40));
-        auto res = ExpressionUtils::rewriteRelExpr(expr, pool);
+        auto res = ExpressionUtils::rewriteRelExpr(expr);
         auto expected = ltExpr(laExpr("v", "age"), minusExpr(constantExpr(40), constantExpr(1)));
         ASSERT_EQ(*res, *expected) << res->toString() << " vs. " << expected->toString();
     }
     // (-1 + label < 40)  =>  (label < 40 - (-1))
     {
         auto expr = ltExpr(addExpr(constantExpr(-1), laExpr("v", "age")), constantExpr(40));
-        auto res = ExpressionUtils::rewriteRelExpr(expr, pool);
+        auto res = ExpressionUtils::rewriteRelExpr(expr);
         auto expected = ltExpr(laExpr("v", "age"), minusExpr(constantExpr(40), constantExpr(-1)));
         ASSERT_EQ(*res, *expected) << res->toString() << " vs. " << expected->toString();
     }
@@ -41,21 +41,21 @@ TEST_F(RewriteRelExprVisitorTest, TestArithmeticalExpr) {
     // TODO: replace list with set in object pool and avoid copy
     {
         auto expr = ltExpr(addExpr(laExpr("v", "age"), laExpr("v2", "age2")), constantExpr(40));
-        auto res = ExpressionUtils::rewriteRelExpr(expr, pool);
+        auto res = ExpressionUtils::rewriteRelExpr(expr);
         auto expected = expr;
         ASSERT_EQ(*res, *expected) << res->toString() << " vs. " << expected->toString();
     }
     // (label * 2 < 40)  =>  (2*label < 40) Unchanged
     {
         auto expr = ltExpr(multiplyExpr(laExpr("v", "age"), constantExpr(2)), constantExpr(40));
-        auto res = ExpressionUtils::rewriteRelExpr(expr, pool);
+        auto res = ExpressionUtils::rewriteRelExpr(expr);
         auto expected = expr;
         ASSERT_EQ(*res, *expected) << res->toString() << " vs. " << expected->toString();
     }
     // (label / 3 < 40)  =>  (label / 3 < 40) Unchanged
     {
         auto expr = ltExpr(divideExpr(laExpr("v", "age"), constantExpr(3)), constantExpr(40));
-        auto res = ExpressionUtils::rewriteRelExpr(expr, pool);
+        auto res = ExpressionUtils::rewriteRelExpr(expr);
         auto expected = expr;
         ASSERT_EQ(*res, *expected) << res->toString() << " vs. " << expected->toString();
     }
@@ -66,7 +66,7 @@ TEST_F(RewriteRelExprVisitorTest, TestNestedArithmeticalExpr) {
     {
         auto expr = ltExpr(addExpr(addExpr(laExpr("v", "age"), constantExpr(1)), constantExpr(2)),
                            constantExpr(40));
-        auto res = ExpressionUtils::rewriteRelExpr(expr, pool);
+        auto res = ExpressionUtils::rewriteRelExpr(expr);
         auto expected =
             ltExpr(laExpr("v", "age"),
                    minusExpr(minusExpr(constantExpr(40), constantExpr(2)), constantExpr(1)));
@@ -76,7 +76,7 @@ TEST_F(RewriteRelExprVisitorTest, TestNestedArithmeticalExpr) {
     {
         auto expr = ltExpr(minusExpr(addExpr(laExpr("v", "age"), constantExpr(1)), constantExpr(2)),
                            constantExpr(40));
-        auto res = ExpressionUtils::rewriteRelExpr(expr, pool);
+        auto res = ExpressionUtils::rewriteRelExpr(expr);
         auto expected =
             ltExpr(laExpr("v", "age"),
                    minusExpr(addExpr(constantExpr(40), constantExpr(2)), constantExpr(1)));
@@ -88,7 +88,7 @@ TEST_F(RewriteRelExprVisitorTest, TestNestedArithmeticalExpr) {
             ltExpr(addExpr(minusExpr(addExpr(laExpr("v", "age"), constantExpr(1)), constantExpr(2)),
                            constantExpr(3)),
                    constantExpr(40));
-        auto res = ExpressionUtils::rewriteRelExpr(expr, pool);
+        auto res = ExpressionUtils::rewriteRelExpr(expr);
         auto expected =
             ltExpr(laExpr("v", "age"),
                    minusExpr(addExpr(minusExpr(constantExpr(40), constantExpr(3)), constantExpr(2)),
@@ -100,7 +100,7 @@ TEST_F(RewriteRelExprVisitorTest, TestNestedArithmeticalExpr) {
         auto expr =
             ltExpr(addExpr(multiplyExpr(constantExpr(2), laExpr("v", "age")), constantExpr(1)),
                    constantExpr(40));
-        auto res = ExpressionUtils::rewriteRelExpr(expr, pool);
+        auto res = ExpressionUtils::rewriteRelExpr(expr);
         auto expected = ltExpr(multiplyExpr(constantExpr(2), laExpr("v", "age")),
                                minusExpr(constantExpr(40), constantExpr(1)));
         ASSERT_EQ(*res, *expected) << res->toString() << " vs. " << expected->toString();
@@ -110,7 +110,7 @@ TEST_F(RewriteRelExprVisitorTest, TestNestedArithmeticalExpr) {
         auto expr =
             ltExpr(minusExpr(divideExpr(laExpr("v", "age"), constantExpr(3)), constantExpr(1)),
                    constantExpr(40));
-        auto res = ExpressionUtils::rewriteRelExpr(expr, pool);
+        auto res = ExpressionUtils::rewriteRelExpr(expr);
         auto expected = ltExpr(divideExpr(laExpr("v", "age"), constantExpr(3)),
                                addExpr(constantExpr(40), constantExpr(1)));
         ASSERT_EQ(*res, *expected) << res->toString() << " vs. " << expected->toString();
@@ -121,14 +121,14 @@ TEST_F(RewriteRelExprVisitorTest, TestReduceBoolNullExpr) {
     // (v.age > 40 == true)  => (v.age > 40)
     {
         auto expr = eqExpr(gtExpr(laExpr("v", "age"), constantExpr(40)), constantExpr(true));
-        auto res = ExpressionUtils::rewriteRelExpr(expr, pool);
+        auto res = ExpressionUtils::rewriteRelExpr(expr);
         auto expected = gtExpr(laExpr("v", "age"), constantExpr(40));
         ASSERT_EQ(*res, *expected) << res->toString() << " vs. " << expected->toString();
     }
     // (v.age > 40 == false)  => !(v.age > 40)
     {
         auto expr = eqExpr(gtExpr(laExpr("v", "age"), constantExpr(40)), constantExpr(false));
-        auto res = ExpressionUtils::rewriteRelExpr(expr, pool);
+        auto res = ExpressionUtils::rewriteRelExpr(expr);
         auto expected = notExpr(gtExpr(laExpr("v", "age"), constantExpr(40)));
         ASSERT_EQ(*res, *expected) << res->toString() << " vs. " << expected->toString();
     }
@@ -136,14 +136,14 @@ TEST_F(RewriteRelExprVisitorTest, TestReduceBoolNullExpr) {
     {
         auto expr = eqExpr(gtExpr(laExpr("v", "age"), constantExpr(40)),
                            constantExpr(Value(NullType::__NULL__)));
-        auto res = ExpressionUtils::rewriteRelExpr(expr, pool);
+        auto res = ExpressionUtils::rewriteRelExpr(expr);
         auto expected = constantExpr(Value(NullType::__NULL__));
         ASSERT_EQ(*res, *expected) << res->toString() << " vs. " << expected->toString();
     }
     // (v.age <= null)  =>  (null)
     {
         auto expr = leExpr(laExpr("v", "age"), constantExpr(Value(NullType::__NULL__)));
-        auto res = ExpressionUtils::rewriteRelExpr(expr, pool);
+        auto res = ExpressionUtils::rewriteRelExpr(expr);
         auto expected = constantExpr(Value(NullType::__NULL__));
         ASSERT_EQ(*res, *expected) << res->toString() << " vs. " << expected->toString();
     }
@@ -151,7 +151,7 @@ TEST_F(RewriteRelExprVisitorTest, TestReduceBoolNullExpr) {
     {
         auto expr = gtExpr(addExpr(laExpr("v", "age"), constantExpr(10)),
                            constantExpr(Value(NullType::__NULL__)));
-        auto res = ExpressionUtils::rewriteRelExpr(expr, pool);
+        auto res = ExpressionUtils::rewriteRelExpr(expr);
         auto expected = constantExpr(Value(NullType::__NULL__));
         ASSERT_EQ(*res, *expected) << res->toString() << " vs. " << expected->toString();
     }
@@ -167,7 +167,7 @@ TEST_F(RewriteRelExprVisitorTest, TestLogicalExpr) {
             ltExpr(addExpr(minusExpr(addExpr(laExpr("v", "age"), constantExpr(1)), constantExpr(2)),
                            constantExpr(3)),
                    constantExpr(40)));
-        auto res = ExpressionUtils::rewriteRelExpr(expr, pool);
+        auto res = ExpressionUtils::rewriteRelExpr(expr);
         auto expected = andExpr(
             ltExpr(laExpr("v", "age"),
                    minusExpr(minusExpr(constantExpr(40), constantExpr(2)), constantExpr(1))),
@@ -189,7 +189,7 @@ TEST_F(RewriteRelExprVisitorTest, TestContainer) {
                     constantExpr(40)),
              ltExpr(minusExpr(addExpr(laExpr("v", "age"), constantExpr(1)), constantExpr(2)),
                     constantExpr(40))});
-        auto res = ExpressionUtils::rewriteRelExpr(expr, pool);
+        auto res = ExpressionUtils::rewriteRelExpr(expr);
         auto expected = listExpr(
             {ltExpr(laExpr("v", "age"),
                     minusExpr(minusExpr(constantExpr(40), constantExpr(2)), constantExpr(1))),
@@ -207,7 +207,7 @@ TEST_F(RewriteRelExprVisitorTest, TestContainer) {
                     constantExpr(40)),
              ltExpr(minusExpr(addExpr(laExpr("v", "age"), constantExpr(1)), constantExpr(2)),
                     constantExpr(40))});
-        auto res = ExpressionUtils::rewriteRelExpr(expr, pool);
+        auto res = ExpressionUtils::rewriteRelExpr(expr);
         auto expected = setExpr(
             {ltExpr(laExpr("v", "age"),
                     minusExpr(minusExpr(constantExpr(40), constantExpr(2)), constantExpr(1))),
@@ -227,7 +227,7 @@ TEST_F(RewriteRelExprVisitorTest, TestContainer) {
              {"k2",
               ltExpr(minusExpr(addExpr(laExpr("v", "age"), constantExpr(1)), constantExpr(2)),
                      constantExpr(40))}});
-        auto res = ExpressionUtils::rewriteRelExpr(expr, pool);
+        auto res = ExpressionUtils::rewriteRelExpr(expr);
         auto expected = mapExpr(
             {{"k1",
               ltExpr(laExpr("v", "age"),

--- a/src/visitor/test/RewriteUnaryNotExprVisitorTest.cpp
+++ b/src/visitor/test/RewriteUnaryNotExprVisitorTest.cpp
@@ -20,21 +20,21 @@ TEST_F(RewriteUnaryNotExprVisitorTest, TestNestedMultipleUnaryNotExpr) {
     // !!(5 == 10)  =>  (5 == 10)
     {
         auto expr = notExpr(notExpr(eqExpr(constantExpr(5), constantExpr(10))));
-        auto res = ExpressionUtils::reduceUnaryNotExpr(expr, pool);
+        auto res = ExpressionUtils::reduceUnaryNotExpr(expr);
         auto expected = eqExpr(constantExpr(5), constantExpr(10));
         ASSERT_EQ(*res, *expected) << res->toString() << " vs. " << expected->toString();
     }
     // !!!!(5 == 10)  =>  (5 == 10)
     {
         auto expr = notExpr(notExpr(notExpr(notExpr(eqExpr(constantExpr(5), constantExpr(10))))));
-        auto res = ExpressionUtils::reduceUnaryNotExpr(expr, pool);
+        auto res = ExpressionUtils::reduceUnaryNotExpr(expr);
         auto expected = eqExpr(constantExpr(5), constantExpr(10));
         ASSERT_EQ(*res, *expected) << res->toString() << " vs. " << expected->toString();
     }
     // !!!(5 == 10)  =>  (5 != 10)
     {
         auto expr = notExpr(notExpr(notExpr(eqExpr(constantExpr(5), constantExpr(10)))));
-        auto res = ExpressionUtils::reduceUnaryNotExpr(expr, pool);
+        auto res = ExpressionUtils::reduceUnaryNotExpr(expr);
         auto expected = neExpr(constantExpr(5), constantExpr(10));
         ASSERT_EQ(*res, *expected) << res->toString() << " vs. " << expected->toString();
     }
@@ -42,7 +42,7 @@ TEST_F(RewriteUnaryNotExprVisitorTest, TestNestedMultipleUnaryNotExpr) {
     {
         auto expr =
             notExpr(notExpr(notExpr(notExpr(notExpr(eqExpr(constantExpr(5), constantExpr(10)))))));
-        auto res = ExpressionUtils::reduceUnaryNotExpr(expr, pool);
+        auto res = ExpressionUtils::reduceUnaryNotExpr(expr);
         auto expected = neExpr(constantExpr(5), constantExpr(10));
         ASSERT_EQ(*res, *expected) << res->toString() << " vs. " << expected->toString();
     }
@@ -53,7 +53,7 @@ TEST_F(RewriteUnaryNotExprVisitorTest, TestMultipleUnaryNotExprLogicalRelExpr) {
     {
         auto expr = andExpr(notExpr(notExpr(eqExpr(constantExpr(5), constantExpr(10)))),
                             notExpr(notExpr(gtExpr(constantExpr(30), constantExpr(20)))));
-        auto res = ExpressionUtils::reduceUnaryNotExpr(expr, pool);
+        auto res = ExpressionUtils::reduceUnaryNotExpr(expr);
         auto expected = andExpr(eqExpr(constantExpr(5), constantExpr(10)),
                                 gtExpr(constantExpr(30), constantExpr(20)));
         ASSERT_EQ(*res, *expected) << res->toString() << " vs. " << expected->toString();
@@ -62,7 +62,7 @@ TEST_F(RewriteUnaryNotExprVisitorTest, TestMultipleUnaryNotExprLogicalRelExpr) {
     {
         auto expr = andExpr(notExpr(notExpr(notExpr(leExpr(constantExpr(5), constantExpr(10))))),
                             notExpr(gtExpr(constantExpr(30), constantExpr(20))));
-        auto res = ExpressionUtils::reduceUnaryNotExpr(expr, pool);
+        auto res = ExpressionUtils::reduceUnaryNotExpr(expr);
         auto expected = andExpr(gtExpr(constantExpr(5), constantExpr(10)),
                                 leExpr(constantExpr(30), constantExpr(20)));
         ASSERT_EQ(*res, *expected) << res->toString() << " vs. " << expected->toString();
@@ -76,7 +76,7 @@ TEST_F(RewriteUnaryNotExprVisitorTest, TestMultipleUnaryNotContainerExpr) {
         auto expr =
             listExpr({notExpr(notExpr(eqExpr(constantExpr(5), constantExpr(10)))),
                       notExpr(notExpr(notExpr(gtExpr(constantExpr(30), constantExpr(20)))))});
-        auto res = ExpressionUtils::reduceUnaryNotExpr(expr, pool);
+        auto res = ExpressionUtils::reduceUnaryNotExpr(expr);
         auto expected = listExpr({eqExpr(constantExpr(5), constantExpr(10)),
                                   leExpr(constantExpr(30), constantExpr(20))});
         ASSERT_EQ(*res, *expected) << res->toString() << " vs. " << expected->toString();
@@ -87,7 +87,7 @@ TEST_F(RewriteUnaryNotExprVisitorTest, TestMultipleUnaryNotContainerExpr) {
         auto expr =
             setExpr({notExpr(notExpr(eqExpr(constantExpr(5), constantExpr(10)))),
                      notExpr(notExpr(notExpr(gtExpr(constantExpr(30), constantExpr(20)))))});
-        auto res = ExpressionUtils::reduceUnaryNotExpr(expr, pool);
+        auto res = ExpressionUtils::reduceUnaryNotExpr(expr);
         auto expected = setExpr({eqExpr(constantExpr(5), constantExpr(10)),
                                  leExpr(constantExpr(30), constantExpr(20))});
         ASSERT_EQ(*res, *expected) << res->toString() << " vs. " << expected->toString();
@@ -98,7 +98,7 @@ TEST_F(RewriteUnaryNotExprVisitorTest, TestMultipleUnaryNotContainerExpr) {
         // {"k1":!!(5 == 10), "k2":!!!(30 > 20)}} => {"k1":(5 == 10), "k2":(30 <= 20)}
         auto expr = mapExpr({{"k1", notExpr(notExpr(eqExpr(constantExpr(5), constantExpr(10))))}, {
             "k2", notExpr(notExpr(notExpr(gtExpr(constantExpr(30), constantExpr(20)))))}});
-        auto res = ExpressionUtils::reduceUnaryNotExpr(expr, pool);
+        auto res = ExpressionUtils::reduceUnaryNotExpr(expr);
         auto expected = mapExpr({{"k1", eqExpr(constantExpr(5), constantExpr(10))},
                                  {"k2", leExpr(constantExpr(30), constantExpr(20))}});
         ASSERT_EQ(*res, *expected) << res->toString() << " vs. " << expected->toString();
@@ -110,34 +110,34 @@ TEST_F(RewriteUnaryNotExprVisitorTest, TestRelExpr) {
     // no change should be made to the orginal expression
     {
         auto original = eqExpr(constantExpr(5), constantExpr(10));
-        auto res = ExpressionUtils::reduceUnaryNotExpr(original, pool);
+        auto res = ExpressionUtils::reduceUnaryNotExpr(original);
         ASSERT_EQ(*original, *res) << original->toString() << " vs. " << res->toString();
     }
     // !(5 == 10)  =>  (5 != 10)
     {
         auto expr = notExpr(eqExpr(constantExpr(5), constantExpr(10)));
-        auto res = ExpressionUtils::reduceUnaryNotExpr(expr, pool);
+        auto res = ExpressionUtils::reduceUnaryNotExpr(expr);
         auto expected = neExpr(constantExpr(5), constantExpr(10));
         ASSERT_EQ(*res, *expected) << res->toString() << " vs. " << expected->toString();
     }
     // !(5 > 10) => (5 <= 10)
     {
         auto expr = notExpr(gtExpr(constantExpr(5), constantExpr(10)));
-        auto res = ExpressionUtils::reduceUnaryNotExpr(expr, pool);
+        auto res = ExpressionUtils::reduceUnaryNotExpr(expr);
         auto expected = leExpr(constantExpr(5), constantExpr(10));
         ASSERT_EQ(*res, *expected) << res->toString() << " vs. " << expected->toString();
     }
     // !(5 >= 10) => (5 < 10)
     {
         auto expr = notExpr(geExpr(constantExpr(5), constantExpr(10)));
-        auto res = ExpressionUtils::reduceUnaryNotExpr(expr, pool);
+        auto res = ExpressionUtils::reduceUnaryNotExpr(expr);
         auto expected = ltExpr(constantExpr(5), constantExpr(10));
         ASSERT_EQ(*res, *expected) << res->toString() << " vs. " << expected->toString();
     }
     // !("bcd" IN "abcde")  =>  ("bcd" NOT IN "abcde")
     {
         auto expr = notExpr(inExpr(constantExpr("bcd"), constantExpr("abcde")));
-        auto res = ExpressionUtils::reduceUnaryNotExpr(expr, pool);
+        auto res = ExpressionUtils::reduceUnaryNotExpr(expr);
         auto expected = notInExpr(constantExpr("bcd"), constantExpr("abcde"));
         ASSERT_EQ(*res, *expected) << res->toString() << " vs. " << expected->toString();
     }
@@ -145,7 +145,7 @@ TEST_F(RewriteUnaryNotExprVisitorTest, TestRelExpr) {
     // !("bcd" NOT IN "abcde")  =>  ("bcd" IN "abcde")
     {
         auto expr = notExpr(notInExpr(constantExpr("bcd"), constantExpr("abcde")));
-        auto res = ExpressionUtils::reduceUnaryNotExpr(expr, pool);
+        auto res = ExpressionUtils::reduceUnaryNotExpr(expr);
         auto expected = inExpr(constantExpr("bcd"), constantExpr("abcde"));
         ASSERT_EQ(*res, *expected) << res->toString() << " vs. " << expected->toString();
     }
@@ -153,7 +153,7 @@ TEST_F(RewriteUnaryNotExprVisitorTest, TestRelExpr) {
     // !("bcd" STARTS WITH "abc")  =>  ("bcd" NOT STARTS WITH "abc")
     {
         auto expr = notExpr(startsWithExpr(constantExpr("bcd"), constantExpr("abcde")));
-        auto res = ExpressionUtils::reduceUnaryNotExpr(expr, pool);
+        auto res = ExpressionUtils::reduceUnaryNotExpr(expr);
         auto expected = notStartsWithExpr(constantExpr("bcd"), constantExpr("abcde"));
         ASSERT_EQ(*res, *expected) << res->toString() << " vs. " << expected->toString();
     }
@@ -161,7 +161,7 @@ TEST_F(RewriteUnaryNotExprVisitorTest, TestRelExpr) {
     // !("bcd" ENDS WITH "abc")  =>  ("bcd" NOT ENDS WITH "abc")
     {
         auto expr = notExpr(endsWithExpr(constantExpr("bcd"), constantExpr("abcde")));
-        auto res = ExpressionUtils::reduceUnaryNotExpr(expr, pool);
+        auto res = ExpressionUtils::reduceUnaryNotExpr(expr);
         auto expected = notEndsWithExpr(constantExpr("bcd"), constantExpr("abcde"));
         ASSERT_EQ(*res, *expected) << res->toString() << " vs. " << expected->toString();
     }
@@ -173,7 +173,7 @@ TEST_F(RewriteUnaryNotExprVisitorTest, TestLogicalExpr) {
         auto expr = notExpr(andExpr(andExpr(neExpr(constantExpr(1), constantExpr(1)),
                                             geExpr(constantExpr(2), constantExpr(3))),
                                     leExpr(constantExpr(30), constantExpr(20))));
-        auto res = ExpressionUtils::reduceUnaryNotExpr(expr, pool);
+        auto res = ExpressionUtils::reduceUnaryNotExpr(expr);
 
         auto expected = LogicalExpression::makeOr(pool);
         expected->addOperand(eqExpr(constantExpr(1), constantExpr(1)));
@@ -187,7 +187,7 @@ TEST_F(RewriteUnaryNotExprVisitorTest, TestLogicalExpr) {
         auto expr = notExpr(orExpr(orExpr(neExpr(constantExpr(1), constantExpr(1)),
                                           geExpr(constantExpr(2), constantExpr(3))),
                                    leExpr(constantExpr(30), constantExpr(20))));
-        auto res = ExpressionUtils::reduceUnaryNotExpr(expr, pool);
+        auto res = ExpressionUtils::reduceUnaryNotExpr(expr);
 
         auto expected = LogicalExpression::makeAnd(pool);
         expected->addOperand(eqExpr(constantExpr(1), constantExpr(1)));
@@ -201,7 +201,7 @@ TEST_F(RewriteUnaryNotExprVisitorTest, TestLogicalExpr) {
         auto expr = notExpr(orExpr(andExpr(neExpr(constantExpr(1), constantExpr(1)),
                                            geExpr(constantExpr(2), constantExpr(3))),
                                    leExpr(constantExpr(30), constantExpr(20))));
-        auto res = ExpressionUtils::reduceUnaryNotExpr(expr, pool);
+        auto res = ExpressionUtils::reduceUnaryNotExpr(expr);
 
         auto expected = andExpr(orExpr(eqExpr(constantExpr(1), constantExpr(1)),
                                        ltExpr(constantExpr(2), constantExpr(3))),


### PR DESCRIPTION
Delete the ObjectPool type parameter in ExpressionUtil functions and fix the inconsistency of the Expression's ObjectPool caused by explicitly specifying the ObjectPool.