### PR TITLE
Support lookup indexScan using IN expression as filter

### DIFF
--- a/src/optimizer/OptimizerUtils.cpp
+++ b/src/optimizer/OptimizerUtils.cpp
@@ -641,7 +641,9 @@ StatusOr<ScoredColumnHint> selectRelExprIndex(const ColumnDef& field,
     }
 
     auto right = expr->right();
-    DCHECK(right->kind() == Expression::Kind::kConstant);
+    expr->kind() == Expression::Kind::kRelIn ? DCHECK(right->isContainerExpr())
+                                             : DCHECK(right->kind() == Expression::Kind::kConstant);
+
     const auto& value = static_cast<const ConstantExpression*>(right)->value();
 
     ScoredColumnHint hint;
@@ -661,6 +663,10 @@ StatusOr<ScoredColumnHint> selectRelExprIndex(const ColumnDef& field,
         }
         case Expression::Kind::kRelNE: {
             hint.score = IndexScore::kNotEqual;
+            break;
+        }
+        case Expression::Kind::kRelIn: {
+            // check the property has an index
             break;
         }
         default: {
@@ -911,6 +917,32 @@ bool OptimizerUtils::findOptimalIndex(const Expression* condition,
     ictx->set_index_id(index.index->get_index_id());
     ictx->set_column_hints(std::move(hints));
     return true;
+}
+
+// Check if the relational expression has a valid index
+// The left operand should either be a kEdgeProperty or kTagProperty expr
+bool OptimizerUtils::relExprHasIndex(
+    const Expression* expr,
+    const std::vector<std::shared_ptr<nebula::meta::cpp2::IndexItem>>& indexItems) {
+    DCHECK(expr->isRelExpr());
+
+    for (auto& index : indexItems) {
+        const auto& fields = index->get_fields();
+        if (fields.empty()) {
+            return false;
+        }
+
+        auto left = static_cast<const RelationalExpression*>(expr)->left();
+        DCHECK(left->kind() == Expression::Kind::kEdgeProperty ||
+               left->kind() == Expression::Kind::kTagProperty);
+
+        auto propExpr = static_cast<const PropertyExpression*>(left);
+        if (propExpr->prop() == fields[0].get_name()) {
+            return true;
+        }
+    }
+
+    return false;
 }
 
 void OptimizerUtils::copyIndexScanData(const nebula::graph::IndexScan* from,

--- a/src/optimizer/OptimizerUtils.h
+++ b/src/optimizer/OptimizerUtils.h
@@ -96,6 +96,10 @@ public:
         bool* isPrefixScan,
         nebula::storage::cpp2::IndexQueryContext* ictx);
 
+    static bool relExprHasIndex(
+        const Expression* expr,
+        const std::vector<std::shared_ptr<nebula::meta::cpp2::IndexItem>>& indexItems);
+
     static void copyIndexScanData(const nebula::graph::IndexScan* from,
                                   nebula::graph::IndexScan* to);
 };

--- a/src/optimizer/rule/UnionAllIndexScanBaseRule.cpp
+++ b/src/optimizer/rule/UnionAllIndexScanBaseRule.cpp
@@ -16,6 +16,7 @@
 #include "planner/plan/PlanNode.h"
 #include "planner/plan/Query.h"
 #include "planner/plan/Scan.h"
+#include "util/ExpressionUtils.h"
 
 using nebula::graph::Filter;
 using nebula::graph::IndexScan;
@@ -24,11 +25,18 @@ using nebula::graph::TagIndexFullScan;
 using nebula::storage::cpp2::IndexQueryContext;
 
 using Kind = nebula::graph::PlanNode::Kind;
+using ExprKind = nebula::Expression::Kind;
 using TransformResult = nebula::opt::OptRule::TransformResult;
 
 namespace nebula {
 namespace opt {
 
+// The matched expression should be either a OR expression or an expression that could be
+// rewrote to a OR expression. There are 3 senarios.
+// 1. OR expr. If OR expr has IN expr operand that has a valid index, expand it to OR expr.
+// 2. AND expr such as A in [a, b] AND B, because it can be transformed to (A==a AND B) OR (A==b
+// AND B)
+// 3. IN expr such as A in [a, b] since it can be transformed to (A==a) OR (A==b)
 bool UnionAllIndexScanBaseRule::match(OptContext* ctx, const MatchedResult& matched) const {
     if (!OptRule::match(ctx, matched)) {
         return false;
@@ -36,13 +44,32 @@ bool UnionAllIndexScanBaseRule::match(OptContext* ctx, const MatchedResult& matc
     auto filter = static_cast<const Filter*>(matched.planNode());
     auto scan = static_cast<const IndexScan*>(matched.planNode({0, 0}));
     auto condition = filter->condition();
-    if (!condition->isLogicalExpr() || condition->kind() != Expression::Kind::kLogicalOr) {
-        return false;
+    auto conditionType = condition->kind();
+
+    if (condition->isLogicalExpr()) {
+        if (conditionType == ExprKind::kLogicalOr) {
+            return true;
+        }
+        if (conditionType == ExprKind::kLogicalAnd &&
+            graph::ExpressionUtils::findAny(static_cast<LogicalExpression*>(condition),
+                                            {ExprKind::kRelIn})) {
+            return true;
+        }
+        // Check logical operands
+        for (auto operand : static_cast<const LogicalExpression*>(condition)->operands()) {
+            if (!operand->isRelExpr() || !operand->isLogicalExpr()) {
+                return false;
+            }
+        }
     }
 
-    for (auto operand : static_cast<const LogicalExpression*>(condition)->operands()) {
-        if (!operand->isRelExpr()) {
-            return false;
+    // If the number of elements is less or equal than 1, the IN expr will be transformed into a
+    // relEQ expr by the OptimizeTagIndexScanByFilterRule.
+    if (condition->isRelExpr()) {
+        auto relExpr = static_cast<const RelationalExpression*>(condition);
+        if (relExpr->kind() == ExprKind::kRelIn && relExpr->right()->isContainerExpr()) {
+            auto operandsVec = graph::ExpressionUtils::getContainerExprOperands(relExpr->right());
+            return operandsVec.size() > 1;
         }
     }
 
@@ -52,9 +79,10 @@ bool UnionAllIndexScanBaseRule::match(OptContext* ctx, const MatchedResult& matc
         }
     }
 
-    return true;
+    return false;
 }
 
+// If the IN expr has only 1 element in its container, it will be converted to an relEQ expr
 StatusOr<TransformResult> UnionAllIndexScanBaseRule::transform(OptContext* ctx,
                                                                const MatchedResult& matched) const {
     auto filter = static_cast<const Filter*>(matched.planNode());
@@ -62,20 +90,73 @@ StatusOr<TransformResult> UnionAllIndexScanBaseRule::transform(OptContext* ctx,
     auto scan = static_cast<const IndexScan*>(node);
 
     auto metaClient = ctx->qctx()->getMetaClient();
-    StatusOr<std::vector<std::shared_ptr<meta::cpp2::IndexItem>>> status;
-    if (node->kind() == graph::PlanNode::Kind::kTagIndexFullScan) {
-        status = metaClient->getTagIndexesFromCache(scan->space());
-    } else {
-        status = metaClient->getEdgeIndexesFromCache(scan->space());
-    }
+    auto status = node->kind() == graph::PlanNode::Kind::kTagIndexFullScan
+                      ? metaClient->getTagIndexesFromCache(scan->space())
+                      : metaClient->getEdgeIndexesFromCache(scan->space());
     NG_RETURN_IF_ERROR(status);
     auto indexItems = std::move(status).value();
 
     OptimizerUtils::eraseInvalidIndexItems(scan->schemaId(), &indexItems);
 
+    // Check whether the prop has index.
+    // Rewrite if the property in the IN expr has a valid index
+    if (indexItems.empty()) {
+        return TransformResult::noTransform();
+    }
+
+    auto condition = filter->condition();
+    auto conditionType = condition->kind();
+    Expression* transformedExpr = condition->clone();
+
+    // Stand alone IN expr
+    if (conditionType == ExprKind::kRelIn) {
+        if (!OptimizerUtils::relExprHasIndex(condition, indexItems)) {
+            return TransformResult::noTransform();
+        }
+        transformedExpr = graph::ExpressionUtils::rewriteInExpr(condition);
+    }
+
+    // AND expr containing IN expr operand
+    if (conditionType == ExprKind::kLogicalAnd) {
+        auto relInExprs = graph::ExpressionUtils::collectAll(transformedExpr, {ExprKind::kRelIn});
+        DCHECK(!relInExprs.empty());
+        bool indexFound = false;
+        // Iterate all operands and expand IN exprs if possible
+        for (auto& expr : static_cast<LogicalExpression*>(transformedExpr)->operands()) {
+            if (expr->kind() == ExprKind::kRelIn) {
+                if (OptimizerUtils::relExprHasIndex(transformedExpr, indexItems)) {
+                    expr = graph::ExpressionUtils::rewriteInExpr(expr);
+                }
+            }
+        }
+        if (!indexFound) {
+            return TransformResult::noTransform();
+        }
+
+        // Reconstruct AND expr using distributive law
+    }
+
+    // OR expr
+    if (conditionType == ExprKind::kLogicalOr) {
+        auto relInExprs = graph::ExpressionUtils::collectAll(transformedExpr, {ExprKind::kRelIn});
+        if (!relInExprs.empty()) {
+            // Iterate all operands and expand IN exprs if possible
+            for (auto& expr : static_cast<LogicalExpression*>(transformedExpr)->operands()) {
+                if (expr->kind() == ExprKind::kRelIn) {
+                    if (OptimizerUtils::relExprHasIndex(expr, indexItems)) {
+                        expr = graph::ExpressionUtils::rewriteInExpr(expr);
+                    }
+                }
+            }
+            // Flatten OR exprs
+            graph::ExpressionUtils::pullOrs(transformedExpr);
+        }
+    }
+
+    DCHECK(transformedExpr->kind() == ExprKind::kLogicalOr);
     std::vector<IndexQueryContext> idxCtxs;
-    auto condition = static_cast<const LogicalExpression*>(filter->condition());
-    for (auto operand : condition->operands()) {
+    auto logicalExpr = static_cast<const LogicalExpression*>(transformedExpr);
+    for (auto operand : logicalExpr->operands()) {
         IndexQueryContext ictx;
         bool isPrefixScan = false;
         if (!OptimizerUtils::findOptimalIndex(operand, indexItems, &isPrefixScan, &ictx)) {

--- a/src/util/ExpressionUtils.cpp
+++ b/src/util/ExpressionUtils.cpp
@@ -171,6 +171,61 @@ Expression *ExpressionUtils::rewriteAgg2VarProp(const Expression *expr) {
     return RewriteVisitor::transform(expr, std::move(matcher), std::move(rewriter));
 }
 
+// Rewrite the IN expr to a relEQ expr if the right operand has only 1 element.
+// Rewrite the IN expr to a OR expr if the right operand has more than 1 element.
+Expression *ExpressionUtils::rewriteInExpr(const Expression *expr) {
+    DCHECK(expr->kind() == Expression::Kind::kRelIn);
+    auto pool = expr->getObjPool();
+    auto inExpr = static_cast<RelationalExpression *>(expr->clone());
+    auto containerOperands = getContainerExprOperands(inExpr->right());
+
+    auto operandSize = containerOperands.size();
+    // container has only 1 element, no need to transform to logical expression
+    if (operandSize == 1) {
+        return RelationalExpression::makeEQ(pool, inExpr->left(), containerOperands[0]);
+    }
+
+    std::vector<Expression *> orExprOperands;
+    orExprOperands.reserve(operandSize);
+    // A in [B, C, D]  =>  (A == B) or (A == C) or (A == D)
+    for (auto *operand : containerOperands) {
+        orExprOperands.emplace_back(RelationalExpression::makeEQ(pool, inExpr->left(), operand));
+    }
+    auto orExpr = LogicalExpression::makeOr(pool);
+    orExpr->setOperands(orExprOperands);
+
+    return orExpr;
+}
+
+std::vector<Expression *> ExpressionUtils::getContainerExprOperands(const Expression *expr) {
+    DCHECK(expr->isContainerExpr());
+    auto pool = expr->getObjPool();
+    auto containerExpr = expr->clone();
+
+    std::vector<Expression *> containerOperands;
+    switch (containerExpr->kind()) {
+        case Expression::Kind::kList:
+            containerOperands = static_cast<ListExpression *>(containerExpr)->get();
+            break;
+        case Expression::Kind::kSet: {
+            containerOperands = static_cast<SetExpression *>(containerExpr)->get();
+            break;
+        }
+        case Expression::Kind::kMap: {
+            auto mapItems = static_cast<MapExpression *>(containerExpr)->get();
+            // iterate map and add key into containerOperands
+            for (auto &item : mapItems) {
+                containerOperands.emplace_back(
+                    ConstantExpression::make(pool, std::move(item.first)));
+            }
+            break;
+        }
+        default:
+            LOG(FATAL) << "Invalid expression type " << containerExpr->kind();
+    }
+    return containerOperands;
+}
+
 StatusOr<Expression *> ExpressionUtils::foldConstantExpr(const Expression *expr) {
     ObjectPool* objPool = expr->getObjPool();
     auto newExpr = expr->clone();

--- a/src/util/ExpressionUtils.h
+++ b/src/util/ExpressionUtils.h
@@ -75,7 +75,14 @@ public:
     // Clone and reduce unaryNot expression
     static Expression* reduceUnaryNotExpr(const Expression* expr);
 
+    // Rewrite IN expression into OR expression
+    // static Expression* rewriteInExpr(const Expression* expr, ObjectPool* pool);
+
     // Transform filter using multiple expression rewrite strategies
+    // 1. rewrite relational expressions containing arithmetic operands so that
+    //    all constants are on the right side of relExpr.
+    // 2. fold constant
+    // 3. reduce unary expression e.g. !(A and B) => !A or !B
     static StatusOr<Expression*> filterTransform(const Expression* expr);
 
     // Negate the given logical expr: (A && B) -> (!A || !B)

--- a/src/util/ExpressionUtils.h
+++ b/src/util/ExpressionUtils.h
@@ -69,6 +69,14 @@ public:
     static Expression* rewriteRelExprHelper(const Expression* expr,
                                             Expression*& relRightOperandExpr);
 
+    // Rewrite IN expression into OR expression or relEQ expression
+    static Expression* rewriteInExpr(const Expression* expr);
+
+    // Return the operands of container expressions
+    // For list and set, return the operands
+    // For map, return the keys
+    static std::vector<Expression*> getContainerExprOperands(const Expression* expr);
+
     // Clone and fold constant expression
     static StatusOr<Expression*> foldConstantExpr(const Expression* expr);
 

--- a/src/util/ExpressionUtils.h
+++ b/src/util/ExpressionUtils.h
@@ -75,9 +75,6 @@ public:
     // Clone and reduce unaryNot expression
     static Expression* reduceUnaryNotExpr(const Expression* expr);
 
-    // Rewrite IN expression into OR expression
-    // static Expression* rewriteInExpr(const Expression* expr, ObjectPool* pool);
-
     // Transform filter using multiple expression rewrite strategies
     // 1. rewrite relational expressions containing arithmetic operands so that
     //    all constants are on the right side of relExpr.

--- a/src/validator/LookupValidator.cpp
+++ b/src/validator/LookupValidator.cpp
@@ -148,7 +148,6 @@ StatusOr<Expression*> LookupValidator::handleLogicalExprOperands(LogicalExpressi
 }
 
 StatusOr<Expression*> LookupValidator::checkFilter(Expression* expr) {
-    // TODO: Support IN expression push down
     if (expr->isRelExpr()) {
         auto relExpr = static_cast<RelationalExpression*>(expr);
         NG_RETURN_IF_ERROR(checkRelExpr(relExpr));

--- a/src/validator/LookupValidator.h
+++ b/src/validator/LookupValidator.h
@@ -42,11 +42,11 @@ private:
     Status checkRelExpr(RelationalExpression* expr);
     StatusOr<std::string> checkTSExpr(Expression* expr);
     StatusOr<Expression*> checkConstExpr(Expression* expr,
-                                         ObjectPool* pool,
                                          const std::string& prop,
                                          const Expression::Kind kind);
 
     StatusOr<Expression*> rewriteRelExpr(RelationalExpression* expr);
+    // Rewrite IN expression into OR expression or relEQ expression
     Expression* rewriteInExpr(const Expression* expr);
     Expression* reverseRelKind(RelationalExpression* expr);
 

--- a/src/validator/LookupValidator.h
+++ b/src/validator/LookupValidator.h
@@ -46,8 +46,6 @@ private:
                                          const Expression::Kind kind);
 
     StatusOr<Expression*> rewriteRelExpr(RelationalExpression* expr);
-    // Rewrite IN expression into OR expression or relEQ expression
-    Expression* rewriteInExpr(const Expression* expr);
     Expression* reverseRelKind(RelationalExpression* expr);
 
     const LookupSentence* sentence() const;

--- a/src/validator/LookupValidator.h
+++ b/src/validator/LookupValidator.h
@@ -39,13 +39,15 @@ private:
     Status prepareFilter();
 
     StatusOr<Expression*> checkFilter(Expression* expr);
-    StatusOr<Expression*> checkRelExpr(RelationalExpression* expr);
+    Status checkRelExpr(RelationalExpression* expr);
     StatusOr<std::string> checkTSExpr(Expression* expr);
-    StatusOr<Value> checkConstExpr(Expression* expr,
-                                   const std::string& prop,
-                                   const Expression::Kind kind);
+    StatusOr<Expression*> checkConstExpr(Expression* expr,
+                                         ObjectPool* pool,
+                                         const std::string& prop,
+                                         const Expression::Kind kind);
 
     StatusOr<Expression*> rewriteRelExpr(RelationalExpression* expr);
+    Expression* rewriteInExpr(const Expression* expr);
     Expression* reverseRelKind(RelationalExpression* expr);
 
     const LookupSentence* sentence() const;

--- a/src/validator/test/LookupValidatorTest.cpp
+++ b/src/validator/test/LookupValidatorTest.cpp
@@ -133,5 +133,6 @@ TEST_F(LookupValidatorTest, InvalidFilterExpression) {
         EXPECT_TRUE(checkResult(query, {}));
     }
 }
+
 }   // namespace graph
 }   // namespace nebula

--- a/src/visitor/FoldConstantExprVisitor.cpp
+++ b/src/visitor/FoldConstantExprVisitor.cpp
@@ -345,6 +345,11 @@ void FoldConstantExprVisitor::visitBinaryExpr(BinaryExpression *expr) {
 }
 
 Expression *FoldConstantExprVisitor::fold(Expression *expr) {
+    // Container expresison shuold remain the same type after being folded
+    if (expr->isContainerExpr()) {
+        return expr;
+    }
+
     QueryExpressionContext ctx;
     auto value = expr->eval(ctx(nullptr));
     if (value.type() == Value::Type::NULLVALUE) {

--- a/src/visitor/VidExtractVisitor.cpp
+++ b/src/visitor/VidExtractVisitor.cpp
@@ -156,10 +156,6 @@ void VidExtractVisitor::visit(RelationalExpression *expr) {
             return;
         }
         auto *listExpr = static_cast<ListExpression *>(expr->right());
-        // if (listExpr->value().type() != Value::Type::LIST) {
-        //     vidPattern_ = VidPattern{};
-        //     return;
-        // }
         QueryExpressionContext ctx;
         vidPattern_ =
             VidPattern{VidPattern::Special::kInUsed,

--- a/src/visitor/test/FoldConstantExprVisitorTest.cpp
+++ b/src/visitor/test/FoldConstantExprVisitorTest.cpp
@@ -108,6 +108,8 @@ TEST_F(FoldConstantExprVisitorTest, TestListExpr) {
     expr->accept(&visitor);
     ASSERT_EQ(*expr, *expected) << expr->toString() << " vs. " << expected->toString();
     ASSERT(visitor.canBeFolded());
+    // type should remain the same after folding
+    ASSERT_EQ(expr->kind(), Expression::Kind::kList);
 }
 
 TEST_F(FoldConstantExprVisitorTest, TestSetExpr) {
@@ -121,6 +123,8 @@ TEST_F(FoldConstantExprVisitorTest, TestSetExpr) {
     expr->accept(&visitor);
     ASSERT_EQ(*expr, *expected) << expr->toString() << " vs. " << expected->toString();
     ASSERT(visitor.canBeFolded());
+    // type should remain the same after folding
+    ASSERT_EQ(expr->kind(), Expression::Kind::kSet);
 }
 
 TEST_F(FoldConstantExprVisitorTest, TestMapExpr) {
@@ -135,6 +139,8 @@ TEST_F(FoldConstantExprVisitorTest, TestMapExpr) {
     expr->accept(&visitor);
     ASSERT_EQ(*expr, *expected) << expr->toString() << " vs. " << expected->toString();
     ASSERT(visitor.canBeFolded());
+    // type should remain the same after folding
+    ASSERT_EQ(expr->kind(), Expression::Kind::kMap);
 }
 
 TEST_F(FoldConstantExprVisitorTest, TestCaseExpr) {

--- a/tests/tck/features/lookup/EdgeIndexFullScan.feature
+++ b/tests/tck/features/lookup/EdgeIndexFullScan.feature
@@ -120,11 +120,10 @@ Feature: Lookup edge index full scan
       | SrcVID | DstVID | Ranking | edge_1.col1_str |
       | "102"  | "103"  | 0       | "Yellow"        |
     And the execution plan should be:
-      | id | name              | dependencies | operator info                                              |
-      | 3  | Project           | 2            |                                                            |
-      | 2  | Filter            | 4            | {"condition": "(edge_1.col1_str IN [\"Red\",\"Yellow\"])"} |
-      | 4  | EdgeIndexFullScan | 0            |                                                            |
-      | 0  | Start             |              |                                                            |
+      | id | name      | dependencies | operator info |
+      | 3  | Project   | 4            |               |
+      | 4  | IndexScan | 0            |               |
+      | 0  | Start     |              |               |
     When executing query:
       """
       LOOKUP ON edge_1 WHERE edge_1.col1_str IN ["non-existed-name"] YIELD edge_1.col1_str
@@ -140,11 +139,10 @@ Feature: Lookup edge index full scan
       | "103"  | "101"  | 0       | 33              |
       | "102"  | "103"  | 0       | 22              |
     And the execution plan should be:
-      | id | name              | dependencies | operator info                                 |
-      | 3  | Project           | 2            |                                               |
-      | 2  | Filter            | 4            | {"condition": "(edge_1.col2_int IN [22,33])"} |
-      | 4  | EdgeIndexFullScan | 0            |                                               |
-      | 0  | Start             |              |                                               |
+      | id | name      | dependencies | operator info |
+      | 3  | Project   | 4            |               |
+      | 4  | IndexScan | 0            |               |
+      | 0  | Start     |              |               |
     When profiling query:
       """
       LOOKUP ON edge_1 WHERE edge_1.col1_str NOT IN ["Blue"] YIELD edge_1.col1_str

--- a/tests/tck/features/lookup/EdgeIndexFullScan.feature
+++ b/tests/tck/features/lookup/EdgeIndexFullScan.feature
@@ -143,6 +143,87 @@ Feature: Lookup edge index full scan
       | 3  | Project   | 4            |               |
       | 4  | IndexScan | 0            |               |
       | 0  | Start     |              |               |
+    # a IN b OR c
+    When profiling query:
+      """
+      LOOKUP ON edge_1
+      WHERE edge_1.col2_int IN [23 - 1 , 66/2] OR edge_1.col2_int==11
+      YIELD edge_1.col2_int
+      """
+    Then the result should be, in any order:
+      | SrcVID | DstVID | Ranking | edge_1.col2_int |
+      | "101"  | "102"  | 0       | 11              |
+      | "102"  | "103"  | 0       | 22              |
+      | "103"  | "101"  | 0       | 33              |
+    And the execution plan should be:
+      | id | name      | dependencies | operator info |
+      | 3  | Project   | 4            |               |
+      | 4  | IndexScan | 0            |               |
+      | 0  | Start     |              |               |
+    # a IN b OR c IN d
+    When profiling query:
+      """
+      LOOKUP ON edge_1
+      WHERE edge_1.col2_int IN [23 - 1 , 66/2] OR edge_1.col1_str IN [toUpper("r")+"ed1"]
+      YIELD edge_1.col1_str, edge_1.col2_int
+      """
+    Then the result should be, in any order:
+      | SrcVID | DstVID | Ranking | edge_1.col1_str | edge_1.col2_int |
+      | "101"  | "102"  | 0       | "Red1"          | 11              |
+      | "102"  | "103"  | 0       | "Yellow"        | 22              |
+      | "103"  | "101"  | 0       | "Blue"          | 33              |
+    And the execution plan should be:
+      | id | name      | dependencies | operator info |
+      | 3  | Project   | 4            |               |
+      | 4  | IndexScan | 0            |               |
+      | 0  | Start     |              |               |
+    # a IN b AND c (EdgeIndexPrefixScan)
+    When profiling query:
+      """
+      LOOKUP ON edge_1
+      WHERE edge_1.col2_int IN [11 , 66/2] AND edge_1.col2_int==11
+      YIELD edge_1.col2_int
+      """
+    Then the result should be, in any order:
+      | SrcVID | DstVID | Ranking | edge_1.col2_int |
+      | "101"  | "102"  | 0       | 11              |
+    And the execution plan should be:
+      | id | name                | dependencies | operator info |
+      | 3  | Project             | 4            |               |
+      | 4  | EdgeIndexPrefixScan | 0            |               |
+      | 0  | Start               |              |               |
+    # a IN b AND c IN d
+    # List has only 1 element, so prefixScan is applied
+    When profiling query:
+      """
+      LOOKUP ON edge_1
+      WHERE edge_1.col2_int IN [11 , 66/2] AND edge_1.col1_str IN [toUpper("r")+"ed1"]
+      YIELD edge_1.col1_str, edge_1.col2_int
+      """
+    Then the result should be, in any order:
+      | SrcVID | DstVID | Ranking | edge_1.col1_str | edge_1.col2_int |
+      | "101"  | "102"  | 0       | "Red1"          | 11              |
+    And the execution plan should be:
+      | id | name                | dependencies | operator info |
+      | 3  | Project             | 4            |               |
+      | 4  | EdgeIndexPrefixScan | 0            |               |
+      | 0  | Start               |              |               |
+    # a IN b AND c IN d (EdgeIndexFullScan)
+    When profiling query:
+      """
+      LOOKUP ON edge_1
+      WHERE edge_1.col2_int IN [11 , 66/2] AND edge_1.col1_str IN [toUpper("r")+"ed1", "ABC"]
+      YIELD edge_1.col1_str, edge_1.col2_int
+      """
+    Then the result should be, in any order:
+      | SrcVID | DstVID | Ranking | edge_1.col1_str | edge_1.col2_int |
+      | "101"  | "102"  | 0       | "Red1"          | 11              |
+    And the execution plan should be:
+      | id | name              | dependencies | operator info                                                                                                                       |
+      | 3  | Project           | 2            |                                                                                                                                     |
+      | 2  | Filter            | 4            | {"condition": "(((edge_1.col2_int==11) OR (edge_1.col2_int==33)) AND ((edge_1.col1_str==\"Red1\") OR (edge_1.col1_str==\"ABC\")))"} |
+      | 4  | EdgeIndexFullScan | 0            |                                                                                                                                     |
+      | 0  | Start             |              |                                                                                                                                     |
     When profiling query:
       """
       LOOKUP ON edge_1 WHERE edge_1.col1_str NOT IN ["Blue"] YIELD edge_1.col1_str

--- a/tests/tck/features/lookup/LookUp.feature
+++ b/tests/tck/features/lookup/LookUp.feature
@@ -77,7 +77,6 @@ Feature: LookUpTest_Vid_String
       """
     Then a SemanticError should be raised at runtime:
     Then drop the used space
-
   Scenario: LookupTest VertexConditionScan
     Given having executed:
       """

--- a/tests/tck/features/lookup/TagIndexFullScan.feature
+++ b/tests/tck/features/lookup/TagIndexFullScan.feature
@@ -93,6 +93,7 @@ Feature: Lookup tag index full scan
       | 4  | TagIndexFullScan | 0            |                                           |
       | 0  | Start            |              |                                           |
 
+  # TODO: Support compare operator info that has multiple column hints
   Scenario: Tag with relational IN/NOT IN filter
     When profiling query:
       """
@@ -103,11 +104,10 @@ Feature: Lookup tag index full scan
       | "Jazz"    |
       | "Hornets" |
     And the execution plan should be:
-      | id | name             | dependencies | operator info                                          |
-      | 3  | Project          | 2            |                                                        |
-      | 2  | Filter           | 4            | {"condition": "(team.name IN [\"Hornets\",\"Jazz\"])"} |
-      | 4  | TagIndexFullScan | 0            |                                                        |
-      | 0  | Start            |              |                                                        |
+      | id | name      | dependencies | operator info |
+      | 3  | Project   | 4            |               |
+      | 4  | IndexScan | 0            |               |
+      | 0  | Start     |              |               |
     When executing query:
       """
       LOOKUP ON team WHERE team.name IN ["non-existed-name"]
@@ -125,11 +125,10 @@ Feature: Lookup tag index full scan
       | "Tony Parker"       | 36         |
       | "Boris Diaw"        | 36         |
     And the execution plan should be:
-      | id | name             | dependencies | operator info                            |
-      | 3  | Project          | 2            |                                          |
-      | 2  | Filter           | 4            | {"condition": "(player.age IN [39,36])"} |
-      | 4  | TagIndexFullScan | 0            |                                          |
-      | 0  | Start            |              |                                          |
+      | id | name      | dependencies | operator info |
+      | 3  | Project   | 4            |               |
+      | 4  | IndexScan | 0            |               |
+      | 0  | Start     |              |               |
     When profiling query:
       """
       LOOKUP ON team WHERE team.name NOT IN ["Hornets", "Jazz"]


### PR DESCRIPTION
1. Fix constant fold for container expressions
2. Convert `IN` expression to `OR` expression in `LOOKUP` if the property in the`IN` expression has a valid index:
    - Stand alone `IN` expr: `A in [B, C, D]  =>  (A == B) or (A == C) or (A == D)`
    - With `AND` expr : `A in [a, b] AND B  =>  (A==a AND B) OR (A==b AND B)`
    - With `OR` expr: `A in [a, b] OR B  =>   A==a OR A==b OR B`
3. If the container has only one element, the `IN` expression will be transformed to a `relEQ` expression. e.g.  `A in [B]  =>  A==B`
