### PR TITLE
fix ci crash

### DIFF
--- a/src/planner/match/MatchPlanner.cpp
+++ b/src/planner/match/MatchPlanner.cpp
@@ -67,15 +67,17 @@ StatusOr<SubPlan> MatchPlanner::transform(AstContext* astCtx) {
         }
     }
 
-    auto finalPlan = connectSegments(subplans, matchCtx->clauses);
+    auto finalPlan = connectSegments(astCtx, subplans, matchCtx->clauses);
     NG_RETURN_IF_ERROR(finalPlan);
     return std::move(finalPlan).value();
 }
 
 StatusOr<SubPlan> MatchPlanner::connectSegments(
+    AstContext* astCtx,
     std::vector<SubPlan>& subplans,
     std::vector<std::unique_ptr<CypherClauseContextBase>>& clauses) {
     DCHECK(!subplans.empty());
+    subplans.front().tail->setInputVar(astCtx->qctx->vctx()->anonVarGen()->getVar());
     if (subplans.size() == 1) {
         return subplans.front();
     }

--- a/src/planner/match/MatchPlanner.h
+++ b/src/planner/match/MatchPlanner.h
@@ -24,6 +24,7 @@ public:
 
 private:
     StatusOr<SubPlan> connectSegments(
+        AstContext* astCtx,
         std::vector<SubPlan>& subplans,
         std::vector<std::unique_ptr<CypherClauseContextBase>>& clauses);
 };


### PR DESCRIPTION

The CI crash is caused by the empty inputVar on the plan, which is triggered by `CollapseProjectRule`.

This pr fixes inputVar of the first plan node.
