### PR TITLE
small change for RewriteVisitor

### DIFF
--- a/src/validator/GroupByValidator.cpp
+++ b/src/validator/GroupByValidator.cpp
@@ -50,7 +50,7 @@ Status GroupByValidator::validateYield(const YieldClause* yieldClause) {
                 needGenProject_ = true;
             }
             if (!aggs.empty()) {
-                auto* colRewrited = ExpressionUtils::rewriteAgg2VarProp(colExpr);
+                auto* colRewrited = ExpressionUtils::rewriteAgg2VarProp(colExpr->clone());
                 projCols_->addColumn(new YieldColumn(colRewrited, colOldName));
                 continue;
             }

--- a/src/validator/MatchValidator.cpp
+++ b/src/validator/MatchValidator.cpp
@@ -712,7 +712,7 @@ Status MatchValidator::validateGroup(YieldClauseContext &yieldCtx) const {
                 yieldCtx.aggOutputColumnNames_.emplace_back(agg->toString());
             }
             if (!aggs.empty()) {
-                auto *rewritedExpr = ExpressionUtils::rewriteAgg2VarProp(colExpr);
+                auto *rewritedExpr = ExpressionUtils::rewriteAgg2VarProp(colExpr->clone());
                 yieldCtx.projCols_->addColumn(new YieldColumn(rewritedExpr, colOldName));
                 yieldCtx.projOutputColumnNames_.emplace_back(colOldName);
                 continue;

--- a/src/visitor/RewriteVisitor.cpp
+++ b/src/visitor/RewriteVisitor.cpp
@@ -325,9 +325,10 @@ Expression *RewriteVisitor::transform(const Expression *expr, Matcher matcher, R
         return rewriter(expr);
     } else {
         RewriteVisitor visitor(std::move(matcher), std::move(rewriter));
-        auto exprCopy = expr->clone();
-        exprCopy->accept(&visitor);
-        return exprCopy;
+        // rewrite expr in-place
+        auto* e = const_cast<Expression*>(expr);
+        e->accept(&visitor);
+        return e;
     }
 }
 
@@ -341,9 +342,10 @@ Expression *RewriteVisitor::transform(
     } else {
         RewriteVisitor visitor(
             std::move(matcher), std::move(rewriter), std::move(needVisitedTypes));
-        auto exprCopy = expr->clone();
-        exprCopy->accept(&visitor);
-        return exprCopy;
+        // rewrite expr in-place
+        auto* e = const_cast<Expression*>(expr);
+        e->accept(&visitor);
+        return e;
     }
 }
 }   // namespace graph


### PR DESCRIPTION
Rewrite expressions in-place to support matching of rewritten expressions of type `Expression*`.
